### PR TITLE
go sdk: initial structure

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -1,0 +1,25 @@
+package tunnels
+
+import (
+	"context"
+	"io"
+	"net"
+)
+
+type Client struct{}
+
+func Connect(ctx context.Context, tunnel *Tunnel, hostID string) (*Client, error) {
+	return nil, nil
+}
+
+func (s *Client) ForwardPort(ctx context.Context, port int, conn io.ReadWriteCloser) error {
+	return nil
+}
+
+func (s *Client) ForwardPortToListener(ctx context.Context, port int, listener net.Listener) error {
+	return nil
+}
+
+func (s *Client) WaitForForwardedPort(ctx context.Context, port int) error {
+	return nil
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/microsoft/tunnels/go
+
+go 1.17

--- a/go/host.go
+++ b/go/host.go
@@ -1,0 +1,15 @@
+package tunnels
+
+import "context"
+
+type Host struct {
+	manager *Manager
+}
+
+func NewHost(manager *Manager) *Host {
+	return &Host{}
+}
+
+func (h *Host) StartServer(ctx context.Context, tunnel *Tunnel, hostPublicKeys []string) error {
+	return nil
+}

--- a/go/manager.go
+++ b/go/manager.go
@@ -1,0 +1,88 @@
+package tunnels
+
+import "context"
+
+type Manager struct{}
+
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+type TunnelRequestOptions struct {
+	AccessToken       string
+	AdditionalHeaders map[string]string
+	FollowRedirects   bool
+	IncludePorts      bool
+	Scopes            []string
+	TokenScopes       []string
+}
+
+func (m *Manager) ListTunnels(
+	ctx context.Context, clusterID string, options *TunnelRequestOptions,
+) ([]*Tunnel, error) {
+	return nil, nil
+}
+
+func (m *Manager) SearchTunnels(
+	ctx context.Context, tags []string, requireAllTags bool, clusterID string, options *TunnelRequestOptions,
+) ([]*TunnelPort, error) {
+	return nil, nil
+}
+
+func (m *Manager) GetTunnel(ctx context.Context, tunnel *Tunnel, options *TunnelRequestOptions) (*Tunnel, error) {
+	return nil, nil
+}
+
+func (m *Manager) CreateTunnel(ctx context.Context, tunnel *Tunnel, options *TunnelRequestOptions) (*Tunnel, error) {
+	return nil, nil
+}
+
+func (m *Manager) UpdateTunnel(ctx context.Context, tunnel *Tunnel, options *TunnelRequestOptions) (*Tunnel, error) {
+	return nil, nil
+}
+
+func (m *Manager) DeleteTunnel(ctx context.Context, tunnel *Tunnel, options *TunnelRequestOptions) error {
+	return nil
+}
+
+func (m *Manager) UpdateTunnelEndpoint(
+	ctx context.Context, tunnel *Tunnel, endpoint *TunnelEndpoint, options *TunnelRequestOptions,
+) (*TunnelEndpoint, error) {
+	return nil, nil
+}
+
+func (m *Manager) DeleteTunnelEndpoints(
+	ctx context.Context, tunnel *Tunnel, hostID string, connectionMode TunnelConnectionMode, options *TunnelRequestOptions,
+) error {
+	return nil
+}
+
+func (m *Manager) ListTunnelPorts(
+	ctx context.Context, tunnel *Tunnel, options *TunnelRequestOptions,
+) ([]*TunnelPort, error) {
+	return nil, nil
+}
+
+func (m *Manager) GetTunnelPort(
+	ctx context.Context, tunnel *Tunnel, port int, options *TunnelRequestOptions,
+) (*TunnelPort, error) {
+	return nil, nil
+}
+
+func (m *Manager) CreateTunnelPort(
+	ctx context.Context, tunnel *Tunnel, port *TunnelPort, options *TunnelRequestOptions,
+) (*TunnelPort, error) {
+	return nil, nil
+}
+
+func (m *Manager) UpdateTunnelPort(
+	ctx context.Context, tunnel *Tunnel, port *TunnelPort, options *TunnelRequestOptions,
+) (*TunnelPort, error) {
+	return nil, nil
+}
+
+func (m *Manager) DeleteTunnelPort(
+	ctx context.Context, tunnel *Tunnel, port int, options *TunnelRequestOptions,
+) error {
+	return nil
+}

--- a/go/tunnels.go
+++ b/go/tunnels.go
@@ -1,0 +1,81 @@
+package tunnels
+
+import "time"
+
+type Tunnel struct {
+	ClusterID     string
+	TunnelID      string
+	Name          string
+	Description   string
+	Tags          []string
+	Domain        string
+	AccessTokens  map[string]string
+	AccessControl *TunnelAccessControl
+	Options       *TunnelOptions
+	Status        *TunnelStatus
+	Endpoints     []*TunnelEndpoint
+	Ports         []*TunnelPort
+}
+
+type TunnelAccessControl struct {
+	Entries []*TunnelAccessControlEntry
+}
+
+type TunnelAccessControlEntry struct {
+	Type         TunnelAccessControlEntryType
+	IsInherited  bool
+	IsDeny       bool
+	Subjects     []string
+	Scopes       []string
+	Provider     string
+	Organization string
+}
+
+type TunnelAccessControlEntryType string
+
+const (
+	TunnelAccessControlEntryTypeNone            TunnelAccessControlEntryType = "none"
+	TunnelAccessControlEntryTypeAnonymous       TunnelAccessControlEntryType = "anonymous"
+	TunnelAccessControlEntryTypeUsers           TunnelAccessControlEntryType = "users"
+	TunnelAccessControlEntryTypeGroups          TunnelAccessControlEntryType = "groups"
+	TunnelAccessControlEntryTypeOrganizations   TunnelAccessControlEntryType = "organizations"
+	TunnelAccessControlEntryTypeRepositories    TunnelAccessControlEntryType = "repositories"
+	TunnelAccessControlEntryTypePublicKeys      TunnelAccessControlEntryType = "publickeys"
+	TunnelAccessControlEntryTypeIPAddressRanges TunnelAccessControlEntryType = "ipaddressranges"
+)
+
+type TunnelOptions struct {
+	ConnectionModes []TunnelConnectionMode
+}
+
+type TunnelConnectionMode string
+
+const (
+	TunnelConnectionModeLocalNetwork   TunnelConnectionMode = "LocalNetwork"
+	TunnelConnectionModeTunnelRelay    TunnelConnectionMode = "TunnelRelay"
+	TunnelConnectionModeLiveShareRelay TunnelConnectionMode = "LiveShareRelay"
+)
+
+type TunnelStatus struct {
+	HostConectionCount       int
+	LastHostConnectionTime   time.Time
+	ClientConnectionCount    int
+	LastClientConnectionTime time.Time
+}
+
+type TunnelEndpoint struct {
+	ConnectionMode TunnelConnectionMode
+	HostID         string
+	PortURIFormat  string
+}
+
+type TunnelPort struct {
+	ClusterID     string
+	TunnelID      string
+	PortNumber    int
+	Protocol      string
+	AccessTokens  map[string]string
+	AccessControl *TunnelAccessControl
+	Options       *TunnelOptions
+	Status        *TunnelStatus
+}


### PR DESCRIPTION
This PR introduces a skeleton file structure and types for the Basis Go SDK. It models three different entities within the SDK
- Manager
- Client
- Host

The design is derived from the existing Typescript and C# SDKs