### PR TITLE
Add msbuild target to generate C# API docs

### DIFF
--- a/cs/.gitignore
+++ b/cs/.gitignore
@@ -2,3 +2,4 @@ bin
 .vs
 .store
 nbgv.exe
+docs

--- a/cs/Directory.Build.props
+++ b/cs/Directory.Build.props
@@ -38,4 +38,10 @@
     </Content>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(GenerateDocs)'=='true'">
+    <!-- This causes all dependency assemblies to be copied to the output directory,
+         which is required by the doc generator tool. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
 </Project>

--- a/cs/Directory.Build.targets
+++ b/cs/Directory.Build.targets
@@ -1,0 +1,23 @@
+<Project>
+
+    <!-- Generates markdown documentation files from XML documentation and compiled assemblies. -->
+    <Target
+        Name="GenerateDocumentation"
+        AfterTargets="Build"
+        Condition="'$(GenerateDocs)'=='true' AND '$(TargetFramework)' == 'netcoreapp3.1'"
+    >
+        <!-- This target only runs for the .NET 3.1 target; xmldocmd tool currently does not work on .NET 6. -->
+        <!-- It requires the `xmldocmd` tool: dotnet tool install -g xmldocmd -->
+        <!-- Invoke this target with: dotnet build -c Release src/TunnelsSDK.sln -p:GenerateDocs=true -->
+
+        <PropertyGroup>
+            <!-- Enable doc links between the different assemblies in the SDK. -->
+            <DocumentationReferenceAssemblies Condition="! $(TargetName.EndsWith('.Contracts'))">$(DocumentationReferenceAssemblies) --external Microsoft.VsSaaS.TunnelService.Contracts</DocumentationReferenceAssemblies>
+            <DocumentationReferenceAssemblies Condition="$(TargetName.EndsWith('.Connections'))">$(DocumentationReferenceAssemblies) --external Microsoft.VsSaaS.TunnelService.Management</DocumentationReferenceAssemblies>
+        </PropertyGroup>
+
+        <Message Importance="High" Text="Generating documentation for $(TargetName)..." />
+        <Exec Command="xmldocmd $(TargetPath) docs $(DocumentationReferenceAssemblies) --skip-unbrowsable" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+    </Target>
+
+</Project>


### PR DESCRIPTION
Related: microsoft/basis-planning#114