### PR TITLE
Fix loop variable bug in Go SDK

### DIFF
--- a/go/host.go
+++ b/go/host.go
@@ -119,8 +119,9 @@ func (h *Host) StartServer(ctx context.Context, tunnel *Tunnel, hostPublicKeys [
 
 	g, ctx := errgroup.WithContext(ctx)
 	for _, channelType := range supportedChannelTypes {
+		chanType := channelType
 		g.Go(func() error {
-			ch := h.ssh.OpenChannelNotifier(channelType)
+			ch := h.ssh.OpenChannelNotifier(chanType)
 			return h.handleOpenChannel(ctx, ch)
 		})
 	}
@@ -155,8 +156,9 @@ func (h *Host) handleOpenChannel(ctx context.Context, incomingChannels <-chan ss
 			// TODO(josebalius): are these requests really discarded?
 			go ssh.DiscardRequests(requests)
 
+			innerChannel := channel
 			go func() {
-				h.logger.Println(fmt.Sprintf("accepted channel: %s", channel.ChannelType()))
+				h.logger.Println(fmt.Sprintf("accepted channel: %s", innerChannel.ChannelType()))
 				if err := h.connectAndRunClientSession(ctx, channelSession); err != nil {
 					sendError(errc, fmt.Errorf("failed to handle channel session: %w", err))
 				}


### PR DESCRIPTION
This fixes a bug where loop variables are directly passed to functions in goroutines. 


What happens is that the loop variable is passed to goroutine by reference. Then when the loop moves on to the next iteration, the variable will be updated and when the goroutine reads it the variable will have the new value. This can be prevented by coping the loop variable into a new variable before passing to a goroutine