### PR TITLE
Send both user agents in one header

### DIFF
--- a/go/manager.go
+++ b/go/manager.go
@@ -440,8 +440,7 @@ func (m *Manager) sendTunnelRequest(
 	if token := m.getAccessToken(tunnel, tunnelRequestOptions, accessTokenScopes); token != "" {
 		request.Header.Add("Authorization", token)
 	}
-	request.Header.Add("User-Agent", m.userAgent)
-	request.Header.Add("User-Agent", goUserAgent)
+	request.Header.Add("User-Agent", fmt.Sprintf("%s %s", goUserAgent, m.userAgent))
 	request.Header.Add("Content-Type", "application/json;charset=UTF-8")
 
 	// Add additional headers


### PR DESCRIPTION
This changes how the Go SDK sends its userAgent header so that it now sends both user agents in a string separated by a space.  This allows both userAgents to be read by the control plane