### PR TITLE
Check for version.json in new location for cs build.

### DIFF
--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -104,7 +104,7 @@
       </ItemGroup>
       <ItemGroup Condition="false">
         <!-- All projects need to be rebuilt if the version changes. -->
-        <Content Include="$(MSBuildThisFileDirectory)..\version.json" Link="version.json">
+        <Content Include="$(MSBuildThisFileDirectory)\..\..\version.json" Link="version.json">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
           <Visible>false</Visible> <!-- Hide from VS solution explorer -->
           <Pack>false</Pack> <!--Exclude from NuGet Packages -->

--- a/cs/src/Directory.Build.props
+++ b/cs/src/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <!-- All projects need to be rebuilt if the version changes. -->
-    <Content Include="$(MSBuildThisFileDirectory)..\version.json" Link="version.json">
+    <Content Include="$(MSBuildThisFileDirectory)\..\..\version.json" Link="version.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible><!-- Hide from VS solution explorer -->
       <Pack>false</Pack> <!--Exclude from NuGet Packages -->


### PR DESCRIPTION
* https://github.com/microsoft/tunnels/pull/31 neglected to update the version location for the Csharp build. This fixes that.