### PR TITLE
Add test for updating tunnel multiple times

### DIFF
--- a/go/manager_test.go
+++ b/go/manager_test.go
@@ -195,6 +195,7 @@ func TestTunnelCreateUpdateTwiceDelete(t *testing.T) {
 		updatedTunnel.table().Print()
 	}
 
+	// In the second update we want to update the description without updating the name
 	createdTunnel.Name = ""
 	createdTunnel.Description = "test description"
 	updatedTunnel, err = managementClient.UpdateTunnel(ctx, createdTunnel, options)


### PR DESCRIPTION
This adds a test where a tunnel is given a name and updated. Then the update command is run again with the name set to the default value and the description set. This checks that the name was not updated and the description was updated in the recent call.