### PR TITLE
Report request ID in service request exceptions

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VsSaaS.TunnelService
         private const string EndpointsApiSubPath = "/endpoints";
         private const string PortsApiSubPath = "/ports";
         private const string TunnelAuthenticationScheme = "Tunnel";
+        private const string RequestIdHeaderName = "VsSaaS-Request-Id";
 
         private static readonly string[] ManageAccessTokenScope =
             new[] { TunnelAccessScopes.Manage };
@@ -327,6 +328,11 @@ namespace Microsoft.VsSaaS.TunnelService
             }
 
             errorMessage ??= "Tunnel service response status code: " + response.StatusCode;
+
+            if (response.Headers.TryGetValues(RequestIdHeaderName, out var requestId))
+            {
+                errorMessage += $"\nRequest ID: {requestId.First()}";
+            }
 
             try
             {

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -360,6 +360,11 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             }
         }
 
+        const requestIdHeaderName = 'VsSaaS-Request-Id';
+        if (error.response?.headers && error.response.headers[requestIdHeaderName]) {
+            errorMessage += `\nRequest ID: ${error.response.headers[requestIdHeaderName]}`;
+        }
+
         return errorMessage;
     }
 

--- a/ts/test/tunnels-test/package.json
+++ b/ts/test/tunnels-test/package.json
@@ -5,8 +5,8 @@
 		"Tunnels"
 	],
 	"scripts": {
-		"compile": "npm run -C ../../.. compile",
-		"watch": "npm run -C ../../.. watch .",
-		"test": "npm run -C ../../.. test"
+		"compile": "npm run -C ../.. compile",
+		"watch": "npm run -C ../.. watch .",
+		"test": "npm run -C ../.. test"
 	}
 }


### PR DESCRIPTION
Include the `VsSaaS-Request-Id` response header value in error messages of exceptions thrown from `TunnelManagementClient` requests. The CLI also displays these messages. This will make it easier for us to investigate service telemetry for errors reported by users.