### PR TITLE
update default public key algorithm to ecdsa-sha2-nistp384

### DIFF
--- a/cs/src/Connections/TunnelHostBase.cs
+++ b/cs/src/Connections/TunnelHostBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <summary>
         /// Private key used for connections.
         /// </summary>
-        protected IKeyPair HostPrivateKey { get; } = SshAlgorithms.PublicKey.RsaWithSha512.GenerateKeyPair();
+        protected IKeyPair HostPrivateKey { get; } = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
 
         /// <summary>
         /// Management client used for connections

--- a/ts/src/connections/tunnelHostBase.ts
+++ b/ts/src/connections/tunnelHostBase.ts
@@ -52,7 +52,7 @@ export abstract class TunnelHostBase implements TunnelHost {
 
     constructor(managementClient: TunnelManagementClient) {
         this.managementClient = managementClient;
-        const publicKey = SshAlgorithms.publicKey.rsaWithSha512!;
+        const publicKey = SshAlgorithms.publicKey.ecdsaSha2Nistp384!;
         if (publicKey) {
             this.hostPrivateKeyPromise = publicKey.generateKeyPair();
         }


### PR DESCRIPTION
The ssh library (mina-sshd) being used for the Java SDK has trouble parsing the preferred rsa public key algorithm. We had intended to make this change at some point anyway as ecdsa is more performant than rsa while being just as secure, if not moreso.

* Changes the preferred public key algorithm from `rsa-sha2-512` to `ecdsa-sha2-nistp384`.

~~There will need to be another PR to the vs-ssh library to udpate the docs and test defaults.~~