### PR TITLE
Pin es5-ext to 0.10.53

### DIFF
--- a/ts/src/connections/package.json
+++ b/ts/src/connections/package.json
@@ -23,6 +23,7 @@
 		"hyco-websocket": "1.0.5",
 		"uuid": "^3.3.3",
 		"await-semaphore": "^0.1.3",
-		"websocket": "^1.0.28"
+		"websocket": "^1.0.28",
+		"es5-ext": "0.10.53"
 	}
 }


### PR DESCRIPTION
Our package is being flagged by component governance for the dependency `es5-ext` which contains anti-war protest messages. See https://github.com/medikoo/es5-ext/issues/116. There is no newer package which can be used at this time.

Since `es5-ext` is an indirect dependency, adding a pinned version as a direct dependency should cause the upstream packages to choose that version (`0.10.53`) which does not contain the flagged commit.