### PR TITLE
Resolve common-io and sshd-mina warnings

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,25 +18,22 @@
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-shared-utils</artifactId>
       <version>3.3.4</version>
     </dependency>
 
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.7</version>
+    </dependency>
 
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.9.0</version>
-    </dependency>
-
-
-    <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-mina</artifactId>
-      <version>2.8.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
* pins the common-io dependency to `2.7` as `2.6` and lower contain a vulnerability: https://mvnrepository.com/artifact/commons-io/commons-io. This is a transitive dependency of `maven-shared-utils`.
* Removes the `sshd-mina` dependency which has a vulnerability related to HTTP requests. In the PR to add the TunnelClient we use [sshd-netty](https://github.com/microsoft/tunnels/pull/55/files#diff-d8225ebcfc11b480a6e4f54e183b67c3ead51635a167c106d928c2abf1f9ef66R23) instead.