### PR TITLE
Ignore inherited ACL when updating tunnel

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -946,13 +946,6 @@ namespace Microsoft.VsSaaS.TunnelService
         /// </summary>
         private Tunnel ConvertTunnelForRequest(Tunnel tunnel)
         {
-            if (tunnel.AccessControl?.Any((ace) => ace.IsInherited) == true)
-            {
-                throw new ArgumentException(
-                    "Tunnel access control cannot include inherited entries.",
-                    nameof(tunnel.AccessControl));
-            }
-
             return new Tunnel
             {
                 Name = tunnel.Name,

--- a/go/tunnels.go
+++ b/go/tunnels.go
@@ -9,14 +9,6 @@ import (
 const PackageVersion = "0.0.1"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
-	if tunnel.AccessControl != nil && tunnel.AccessControl.Entries != nil {
-		for _, access := range tunnel.AccessControl.Entries {
-			if access.IsInherited {
-				return nil, fmt.Errorf("tunnel access control cannot include inherited entries")
-			}
-		}
-	}
-
 	convertedTunnel := &Tunnel{
 		Name:        tunnel.Name,
 		Domain:      tunnel.Domain,


### PR DESCRIPTION
With the introduction of policies, tunnels can have access-control entries that are inherited from policies. (Previously only ports could have inherited ACEs from tunnels.) When updating tunnels using the SDK management APIs, it will be common for the tunnel to have inherited ACEs, therefore the management API should not throw an exception in that case.

This change removes the check and throw for inherited ACEs, in C# and Go SDKs. TypeScript and Java SDKs already did not have that code. All languages already filtered inherited ACEs from the tunnel JSON payload that gets sent to the service. 