### PR TITLE
Fix TS request options query param formatting

### DIFF
--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -581,7 +581,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             }
 
             queryItems.push(
-                Object.keys(queryOptions).map((key) => {
+                ...Object.keys(queryOptions).map((key) => {
                     const value = queryOptions[key];
                     return `${key}=${encodeURI(value)}`;
                 }),

--- a/ts/test/tunnels-test/tunnelManagementTests.ts
+++ b/ts/test/tunnels-test/tunnelManagementTests.ts
@@ -54,4 +54,13 @@ export class TunnelManagementTests {
         assert(this.lastRequest.uri.startsWith('http://global.'));
         assert(this.lastRequest.uri.includes('global=true'));
     }
+
+    @test
+    public async listTunnelsIncludePorts() {
+        this.nextResponse = [];
+        await this.managementClient.listTunnels(undefined, { includePorts: true, scopes: [ 'connect' ] });
+        assert(this.lastRequest && this.lastRequest.uri);
+        assert(this.lastRequest.uri.startsWith('http://global.'));
+        assert(this.lastRequest.uri.includes('includePorts=true&scopes=connect&global=true'));
+    }
 }


### PR DESCRIPTION
A missing `...` caused the request options to be concatenated with `,` instead of `&`.