### PR TITLE
Use git tags for java SDK release versioning.

### DIFF
--- a/.github/workflows/java-sdk-release.yml
+++ b/.github/workflows/java-sdk-release.yml
@@ -20,7 +20,9 @@ jobs:
         with:
           java-version: "11"
           distribution: "adopt"
+      - name: Set java release version env variable
+        run: echo "JAVA_RELEASE_VERSION=$(echo ${{github.ref_name}} | cut -c 7-)" >> $GITHUB_ENV
       - name: Publish package
-        run: mvn --batch-mode deploy --file pom.xml
+        run: mvn --batch-mode deploy --file pom.xml -Drevision=$JAVA_RELEASE_VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.microsoft.tunnels</groupId>
   <artifactId>tunnels-java-sdk</artifactId>
-  <version>0.1.0</version>
+  <version>${revision}</version>
 
   <name>tunnels-java-sdk</name>
   <url>https://github.com/microsoft/tunnels</url>
@@ -15,6 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <revision>0.1.0</revision>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The maven release plugin wants to pollute our commit history by committing an update to `pom.xml` every time we want to publish a new package. This is not great considering this repo manages multiple language SDKs.

Instead, this change uses the tag set at time of release in the format `java-vX.Y.Z` to specify the version of the java SDK to publish, getting the `X.Y.Z` part of the tag to store as a environment variable to use in the following deploy step.

This commit was used to publish version 0.1.1 (up from 0.1.0)
https://github.com/microsoft/tunnels/packages/1375564?version=0.1.1

Ideally we would have more sophisticated git versioning that runs on every commit (the github package release is a manual process), but that solution has not yet presented itself.