### PR TITLE
Fix ResourceStatus serialization

### DIFF
--- a/cs/src/Contracts/TunnelContracts.cs
+++ b/cs/src/Contracts/TunnelContracts.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VsSaaS.TunnelService.Contracts
             options.Converters.Add(new JsonStringEnumConverter());
             options.Converters.Add(new TunnelEndpoint.Converter());
             options.Converters.Add(new TunnelAccessControl.Converter());
+            options.Converters.Add(new ResourceStatus.Converter());
             options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
             return options;
         }

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -410,6 +410,7 @@ namespace Microsoft.VsSaaS.TunnelService
 
                     case HttpStatusCode.NotFound:
                     case HttpStatusCode.Conflict:
+                    case HttpStatusCode.TooManyRequests:
                         throw new InvalidOperationException(errorMessage, hrex);
 
                     case HttpStatusCode.Redirect:
@@ -420,6 +421,7 @@ namespace Microsoft.VsSaaS.TunnelService
                         // when client auto redirection is disabled.
                         hrex.Data["Location"] = response.Headers.Location;
                         throw;
+
                     default: throw;
                 }
             }

--- a/cs/tools/TunnelsSDK.Generator/JavaContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/JavaContractWriter.cs
@@ -79,7 +79,6 @@ internal class JavaContractWriter : ContractWriter
         {
             WriteEnumContract(s, indent, type);
             imports.Add(SerializedNameType);
-            imports.Add(GsonExposeType);
         }
         else
         {

--- a/cs/tools/TunnelsSDK.Generator/TSContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/TSContractWriter.cs
@@ -376,6 +376,11 @@ internal class TSContractWriter : ContractWriter
             {
                 imports.Add(tsType);
             }
+
+            if (tsType == "ResourceStatus")
+            {
+                tsType = "number | ResourceStatus";
+            }
         }
         else
         {

--- a/go/tunnels/manager_test.go
+++ b/go/tunnels/manager_test.go
@@ -5,6 +5,7 @@ package tunnels
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -712,5 +713,30 @@ func TestTunnelEndpoints(t *testing.T) {
 		t.Errorf("tunnel was not successfully deleted")
 	} else {
 		logger.Printf("Deleted tunnel with id %s", getTunnel.TunnelID)
+	}
+}
+
+
+func TestResourceStatusUnmarshal(t *testing.T) {
+	var test1 = []byte("{ \"current\": 3, \"limit\": 10 }")
+	var result1 ResourceStatus
+	var err = json.Unmarshal(test1, &result1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if (result1.Limit == 0) {
+		t.Errorf("Limit was not deserialized")
+	}
+
+	var result2 ResourceStatus
+	var test2 = []byte("3")
+	err = json.Unmarshal(test2, &result2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if result1.Current != result2.Current {
+		t.Errorf("%d != %d", result1.Current, result2.Current)
 	}
 }

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -4,6 +4,7 @@
 package tunnels
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/rodaine/table"
@@ -143,4 +144,19 @@ func (tunnelPort *TunnelPort) requestObject(tunnel *Tunnel) (*TunnelPort, error)
 	}
 
 	return convertedPort, nil
+}
+
+func (rs *ResourceStatus) UnmarshalJSON(data []byte) (err error) {
+	// First attempt to un-marshal as a ResourceStatus object.
+	var obj map[string]uint64
+	err = json.Unmarshal(data, &obj)
+	if (err == nil) {
+		rs.Current = obj["current"]
+		rs.Limit = obj["limit"]
+	} else {
+		// It's not an object - unmarshal as a simple number.
+		err = json.Unmarshal(data, &rs.Current)
+		rs.Limit = 0
+	}
+	return err
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlEntryType.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlEntryType.java
@@ -4,7 +4,6 @@
 
 package com.microsoft.tunnels.contracts;
 
-import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 /**

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConnectionMode.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConnectionMode.java
@@ -4,7 +4,6 @@
 
 package com.microsoft.tunnels.contracts;
 
-import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 /**

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelContracts.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelContracts.java
@@ -1,0 +1,79 @@
+package com.microsoft.tunnels.contracts;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+public class TunnelContracts {
+  private TunnelContracts() {}
+
+  private static Gson gson = createConfiguredGson();
+
+  public static Gson getGson() {
+    return gson;
+  }
+
+  private static Gson createConfiguredGson() {
+    // TODO - serializeNulls?
+    var builder = new GsonBuilder()
+        .excludeFieldsWithoutExposeAnnotation()
+        .registerTypeAdapter(ResourceStatus.class, new ResourceStatusDeserializer())
+        .registerTypeAdapter(TunnelEndpoint.class, new TunnelEndpointDeserializer());
+    return builder.create();
+  }
+
+  private static class TunnelEndpointDeserializer implements JsonDeserializer<TunnelEndpoint> {
+    private Gson gson;
+
+    TunnelEndpointDeserializer() {
+      this.gson = new Gson();
+    }
+
+    @Override
+    public TunnelEndpoint deserialize(
+        JsonElement json,
+        Type typeOfT,
+        JsonDeserializationContext context)
+        throws JsonParseException {
+      var endpointObject = json.getAsJsonObject();
+      var connectionMode = endpointObject.get("connectionMode").getAsString();
+      if (connectionMode.equals("TunnelRelay")) {
+        return gson.fromJson(endpointObject, TunnelRelayTunnelEndpoint.class);
+      } else if (connectionMode.equals("LiveShareRelay")) {
+        return gson.fromJson(endpointObject, LiveShareRelayTunnelEndpoint.class);
+      } else if (connectionMode.equals("LocalNetwork")) {
+        return gson.fromJson(endpointObject, LocalNetworkTunnelEndpoint.class);
+      } else {
+        throw new JsonParseException("Unable to parse TunnelEnpoint: " + endpointObject);
+      }
+    }
+  }
+
+  private static class ResourceStatusDeserializer implements JsonDeserializer<ResourceStatus> {
+    private Gson gson;
+
+    ResourceStatusDeserializer() {
+      this.gson = new Gson();
+    }
+
+    @Override
+    public ResourceStatus deserialize(
+        JsonElement json,
+        Type typeOfT,
+        JsonDeserializationContext context)
+        throws JsonParseException {
+      if (json.isJsonObject()) {
+        return gson.fromJson(json, ResourceStatus.class);
+      } else {
+        var status = new ResourceStatus();
+        status.current = json.getAsLong();
+        return status;
+      }
+    }
+  }
+}

--- a/java/src/test/java/com/microsoft/tunnels/TunnelContractsTests.java
+++ b/java/src/test/java/com/microsoft/tunnels/TunnelContractsTests.java
@@ -3,13 +3,17 @@
 
 package com.microsoft.tunnels;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import com.microsoft.tunnels.contracts.ResourceStatus;
 import com.microsoft.tunnels.contracts.TunnelAccessControl;
 import com.microsoft.tunnels.contracts.TunnelConstraints;
+import com.microsoft.tunnels.contracts.TunnelContracts;
 import com.microsoft.tunnels.contracts.TunnelEndpoint;
 import com.microsoft.tunnels.contracts.TunnelServiceProperties;
 
@@ -80,5 +84,15 @@ public class TunnelContractsTests {
       TunnelAccessControl.validateScopes(invalidScopes, validScopes);
     });
     assertTrue(exception.getMessage().equals("Invalid tunnel access scope: invalid"));
+  }
+
+  @Test
+  public void resourceStatus() {
+    var gson = TunnelContracts.getGson();
+    var result1 = gson.fromJson("{\"current\": 3, \"limit\": 10 }", ResourceStatus.class);
+    assertNotEquals(0, result1.current);
+    assertNotEquals(0, result1.limit);
+    var result2 = gson.fromJson("3", ResourceStatus.class);
+    assertEquals(result1.current, result2.current);
   }
 }

--- a/ts/src/contracts/tunnelPortStatus.ts
+++ b/ts/src/contracts/tunnelPortStatus.ts
@@ -20,7 +20,7 @@ export interface TunnelPortStatus {
      * unless they are upgraded to websockets. HTTP connections are counted per-request
      * rather than per-connection: see {@link TunnelPortStatus.httpRequestRate}.
      */
-    clientConnectionCount?: ResourceStatus;
+    clientConnectionCount?: number | ResourceStatus;
 
     /**
      * Gets or sets the UTC date time when a client was last connected to the port, or

--- a/ts/src/contracts/tunnelStatus.ts
+++ b/ts/src/contracts/tunnelStatus.ts
@@ -13,7 +13,7 @@ export interface TunnelStatus {
     /**
      * Gets or sets the current value and limit for the number of ports on the tunnel.
      */
-    portCount?: ResourceStatus;
+    portCount?: number | ResourceStatus;
 
     /**
      * Gets or sets the current value and limit for the number of hosts currently
@@ -22,7 +22,7 @@ export interface TunnelStatus {
      * This is typically 0 or 1, but may be more than 1 if the tunnel options allow
      * multiple hosts.
      */
-    hostConnectionCount?: ResourceStatus;
+    hostConnectionCount?: number | ResourceStatus;
 
     /**
      * Gets or sets the UTC time when a host was last accepting connections to the tunnel,
@@ -37,7 +37,7 @@ export interface TunnelStatus {
      * This counts non-port-specific client connections, which is SDK and SSH clients. See
      * {@link TunnelPortStatus} for status of per-port client connections.
      */
-    clientConnectionCount?: ResourceStatus;
+    clientConnectionCount?: number | ResourceStatus;
 
     /**
      * Gets or sets the UTC time when a client last connected to the tunnel, or null if a


### PR DESCRIPTION
Instead of renaming the `hostConnectionCount` and `clientConnectionCount` status properties, this change makes `ResourceStatus` serialization backward-compatible by supporting both the simple number and object (current + limit) format, using custom serializers for C#, Go, and Java, and a union type for TS.

Also, Java JSON serialization config code is refactored into a `TunnelContracts` static class, to match how it was done in C#.