### PR TITLE
Fix casing for generated TS & Go enum values

### DIFF
--- a/cs/tools/TunnelsSDK.Generator/GoContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/GoContractWriter.cs
@@ -208,8 +208,7 @@ internal class GoContractWriter : ContractWriter
             s.AppendLine();
             s.Append(FormatDocComment(field.GetDocumentationCommentXml(), "\t"));
             var alignment = new string(' ', maxFieldNameLength - field.Name.Length);
-            var value = type.BaseType?.Name == "Enum" ?
-                TSContractWriter.ToCamelCase(field.Name) : field.ConstantValue;
+            var value = type.BaseType?.Name == "Enum" ? field.Name : field.ConstantValue;
             s.AppendLine($"\t{typeName}{field.Name}{alignment} {typeName} = \"{value}\"");
         }
 

--- a/cs/tools/TunnelsSDK.Generator/TSContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/TSContractWriter.cs
@@ -180,8 +180,7 @@ internal class TSContractWriter : ContractWriter
             s.AppendLine();
             s.Append(FormatDocComment(field.GetDocumentationCommentXml(), indent + "    "));
 
-            var value = type.BaseType?.Name == "Enum" ?
-                ToCamelCase(field.Name) : field.ConstantValue;
+            var value = type.BaseType?.Name == "Enum" ? field.Name : field.ConstantValue;
             s.AppendLine($"{indent}    {field.Name} = '{value}',");
         }
 

--- a/go/tunnels/tunnel_access_control_entry_type.go
+++ b/go/tunnels/tunnel_access_control_entry_type.go
@@ -9,33 +9,33 @@ type TunnelAccessControlEntryType string
 
 const (
 	// Uninitialized access control entry type.
-	TunnelAccessControlEntryTypeNone            TunnelAccessControlEntryType = "none"
+	TunnelAccessControlEntryTypeNone            TunnelAccessControlEntryType = "None"
 
 	// The access control entry refers to all anonymous users.
-	TunnelAccessControlEntryTypeAnonymous       TunnelAccessControlEntryType = "anonymous"
+	TunnelAccessControlEntryTypeAnonymous       TunnelAccessControlEntryType = "Anonymous"
 
 	// The access control entry is a list of user IDs that are allowed (or denied) access.
-	TunnelAccessControlEntryTypeUsers           TunnelAccessControlEntryType = "users"
+	TunnelAccessControlEntryTypeUsers           TunnelAccessControlEntryType = "Users"
 
 	// The access control entry is a list of groups IDs that are allowed (or denied) access.
-	TunnelAccessControlEntryTypeGroups          TunnelAccessControlEntryType = "groups"
+	TunnelAccessControlEntryTypeGroups          TunnelAccessControlEntryType = "Groups"
 
 	// The access control entry is a list of organization IDs that are allowed (or denied)
 	// access.
 	//
 	// All users in the organizations are allowed (or denied) access, unless overridden by
 	// following group or user rules.
-	TunnelAccessControlEntryTypeOrganizations   TunnelAccessControlEntryType = "organizations"
+	TunnelAccessControlEntryTypeOrganizations   TunnelAccessControlEntryType = "Organizations"
 
 	// The access control entry is a list of repositories. Users are allowed access to the
 	// tunnel if they have access to the repo.
-	TunnelAccessControlEntryTypeRepositories    TunnelAccessControlEntryType = "repositories"
+	TunnelAccessControlEntryTypeRepositories    TunnelAccessControlEntryType = "Repositories"
 
 	// The access control entry is a list of public keys. Users are allowed access if they
 	// can authenticate using a private key corresponding to one of the public keys.
-	TunnelAccessControlEntryTypePublicKeys      TunnelAccessControlEntryType = "publicKeys"
+	TunnelAccessControlEntryTypePublicKeys      TunnelAccessControlEntryType = "PublicKeys"
 
 	// The access control entry is a list of IP address ranges that are allowed (or denied)
 	// access to the tunnel.
-	TunnelAccessControlEntryTypeIPAddressRanges TunnelAccessControlEntryType = "iPAddressRanges"
+	TunnelAccessControlEntryTypeIPAddressRanges TunnelAccessControlEntryType = "IPAddressRanges"
 )

--- a/go/tunnels/tunnel_connection_mode.go
+++ b/go/tunnels/tunnel_connection_mode.go
@@ -15,11 +15,11 @@ const (
 	//
 	// While it's technically not "tunneling", this mode may be combined with others to
 	// enable choosing the most efficient connection mode available.
-	TunnelConnectionModeLocalNetwork   TunnelConnectionMode = "localNetwork"
+	TunnelConnectionModeLocalNetwork   TunnelConnectionMode = "LocalNetwork"
 
 	// Use the tunnel service's integrated relay function.
-	TunnelConnectionModeTunnelRelay    TunnelConnectionMode = "tunnelRelay"
+	TunnelConnectionModeTunnelRelay    TunnelConnectionMode = "TunnelRelay"
 
 	// Connect via a Live Share workspace's Azure Relay endpoint.
-	TunnelConnectionModeLiveShareRelay TunnelConnectionMode = "liveShareRelay"
+	TunnelConnectionModeLiveShareRelay TunnelConnectionMode = "LiveShareRelay"
 )

--- a/ts/src/contracts/tunnelAccessControlEntryType.ts
+++ b/ts/src/contracts/tunnelAccessControlEntryType.ts
@@ -10,23 +10,23 @@ export enum TunnelAccessControlEntryType {
     /**
      * Uninitialized access control entry type.
      */
-    None = 'none',
+    None = 'None',
 
     /**
      * The access control entry refers to all anonymous users.
      */
-    Anonymous = 'anonymous',
+    Anonymous = 'Anonymous',
 
     /**
      * The access control entry is a list of user IDs that are allowed (or denied) access.
      */
-    Users = 'users',
+    Users = 'Users',
 
     /**
      * The access control entry is a list of groups IDs that are allowed (or denied)
      * access.
      */
-    Groups = 'groups',
+    Groups = 'Groups',
 
     /**
      * The access control entry is a list of organization IDs that are allowed (or denied)
@@ -35,23 +35,23 @@ export enum TunnelAccessControlEntryType {
      * All users in the organizations are allowed (or denied) access, unless overridden by
      * following group or user rules.
      */
-    Organizations = 'organizations',
+    Organizations = 'Organizations',
 
     /**
      * The access control entry is a list of repositories. Users are allowed access to the
      * tunnel if they have access to the repo.
      */
-    Repositories = 'repositories',
+    Repositories = 'Repositories',
 
     /**
      * The access control entry is a list of public keys. Users are allowed access if they
      * can authenticate using a private key corresponding to one of the public keys.
      */
-    PublicKeys = 'publicKeys',
+    PublicKeys = 'PublicKeys',
 
     /**
      * The access control entry is a list of IP address ranges that are allowed (or
      * denied) access to the tunnel.
      */
-    IPAddressRanges = 'iPAddressRanges',
+    IPAddressRanges = 'IPAddressRanges',
 }

--- a/ts/src/contracts/tunnelConnectionMode.ts
+++ b/ts/src/contracts/tunnelConnectionMode.ts
@@ -16,15 +16,15 @@ export enum TunnelConnectionMode {
      * While it's technically not "tunneling", this mode may be combined with others to
      * enable choosing the most efficient connection mode available.
      */
-    LocalNetwork = 'localNetwork',
+    LocalNetwork = 'LocalNetwork',
 
     /**
      * Use the tunnel service's integrated relay function.
      */
-    TunnelRelay = 'tunnelRelay',
+    TunnelRelay = 'TunnelRelay',
 
     /**
      * Connect via a Live Share workspace's Azure Relay endpoint.
      */
-    LiveShareRelay = 'liveShareRelay',
+    LiveShareRelay = 'LiveShareRelay',
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/basis-planning/issues/351

C# and (generated) Java code use PascalCase for enum values, while the generated TS & Go code used camelCase. This inconsistency could cause problems when directly comparing enum values in TS & Go with values returned by the service (which are PascalCase).