### PR TITLE
Include auth params in unauthorized exception

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -403,7 +403,8 @@ namespace Microsoft.VsSaaS.TunnelService
                         if (response.Headers.WwwAuthenticate?.Count > 0)
                         {
                             ex.SetAuthenticationSchemes(
-                                response.Headers.WwwAuthenticate.Select((v) => v.Scheme).ToArray());
+                                response.Headers.WwwAuthenticate.Select(
+                                    (v) => v.ToString()).ToArray());
                         }
 
                         throw ex;

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -402,9 +402,7 @@ namespace Microsoft.VsSaaS.TunnelService
 
                         if (response.Headers.WwwAuthenticate?.Count > 0)
                         {
-                            ex.SetAuthenticationSchemes(
-                                response.Headers.WwwAuthenticate.Select(
-                                    (v) => v.ToString()).ToArray());
+                            ex.SetAuthenticationSchemes(response.Headers.WwwAuthenticate);
                         }
 
                         throw ex;


### PR DESCRIPTION
Fix the C# tunnel management client to propagate additional parameters related to custom auth in case of an unauthorized error. (Other language SDKs don't currently have any special handling of the WWW-Authenticate response header.)