### PR TITLE
Fix handling of multiple WWW-Authenticate header values

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -400,11 +400,10 @@ namespace Microsoft.VsSaaS.TunnelService
                     case HttpStatusCode.Forbidden:
                         var ex = new UnauthorizedAccessException(errorMessage, hrex);
 
-                        if (response.Headers.WwwAuthenticate?.Count > 0)
-                        {
-                            ex.SetAuthenticationSchemes(response.Headers.WwwAuthenticate);
-                        }
-
+                        // The HttpResponseHeaders.WwwAuthenticate property does not correctly
+                        // handle multiple values! Get the values by name instead.
+                        var authHeaderValues = response.Headers.GetValues("WWW-Authenticate");
+                        ex.SetAuthenticationSchemes(authHeaderValues);
                         throw ex;
 
                     case HttpStatusCode.NotFound:

--- a/cs/src/Management/UnauthorizedAccessExceptionExtensions.cs
+++ b/cs/src/Management/UnauthorizedAccessExceptionExtensions.cs
@@ -44,12 +44,18 @@ public static class UnauthorizedAccessExceptionExtensions
         this UnauthorizedAccessException ex,
         IEnumerable<AuthenticationHeaderValue>? authenticationSchemes)
     {
+        SetAuthenticationSchemes(ex, authenticationSchemes?
+            .Select((s) => s?.ToString()!)
+            .Where((s) => s != null));
+    }
+
+    internal static void SetAuthenticationSchemes(
+        this UnauthorizedAccessException ex,
+        IEnumerable<string>? authenticationSchemes)
+    {
         lock (ex.Data)
         {
-            ex.Data[AuthenticationSchemesKey] = authenticationSchemes?
-                .Select((s) => s?.ToString() !)
-                .Where((s) => s != null)
-                .ToArray();
+            ex.Data[AuthenticationSchemesKey] = authenticationSchemes?.ToArray();
         }
     }
 }


### PR DESCRIPTION
The tunnel service can potentially return multiple values for the `WWW-Authenticate` header. The multiple values were not getting propagated as expected by the SDK client due to a bug or limitation in .NET's `HttpResponseHeaders` class.