### PR TITLE
Fix WWW-Authenticate header bug

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -402,8 +402,12 @@ namespace Microsoft.VsSaaS.TunnelService
 
                         // The HttpResponseHeaders.WwwAuthenticate property does not correctly
                         // handle multiple values! Get the values by name instead.
-                        var authHeaderValues = response.Headers.GetValues("WWW-Authenticate");
-                        ex.SetAuthenticationSchemes(authHeaderValues);
+                        if (response.Headers.TryGetValues(
+                            "WWW-Authenticate", out var authHeaderValues))
+                        {
+                            ex.SetAuthenticationSchemes(authHeaderValues);
+                        }
+
                         throw ex;
 
                     case HttpStatusCode.NotFound:


### PR DESCRIPTION
This fixes a bug in my [previous PR](https://github.com/microsoft/dev-tunnels/pull/89): it threw an exception when the service returned 403 without any `WWW-Authenticate` header.