### PR TITLE
Add name, description, & tags props to TunnelPort

### DIFF
--- a/cs/src/Contracts/TunnelPort.cs
+++ b/cs/src/Contracts/TunnelPort.cs
@@ -38,6 +38,27 @@ namespace Microsoft.VsSaaS.TunnelService.Contracts
         public ushort PortNumber { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional short name of the port.
+        /// </summary>
+        /// <remarks>
+        /// The name must be unique among named ports of the same tunnel.
+        /// </remarks>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional description of the port.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tags of the port.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? Tags { get; set; }
+
+        /// <summary>
         /// Gets or sets the protocol of the tunnel port.
         /// </summary>
         /// <remarks>

--- a/go/tunnels/tunnel_port.go
+++ b/go/tunnels/tunnel_port.go
@@ -15,6 +15,17 @@ type TunnelPort struct {
 	// Gets or sets the IP port number of the tunnel port.
 	PortNumber    uint16 `json:"portNumber"`
 
+	// Gets or sets the optional short name of the port.
+	//
+	// The name must be unique among named ports of the same tunnel.
+	Name          string `json:"name,omitempty"`
+
+	// Gets or sets the optional description of the port.
+	Description   string `json:"description,omitempty"`
+
+	// Gets or sets the tags of the port.
+	Tags          []string `json:"tags,omitempty"`
+
 	// Gets or sets the protocol of the tunnel port.
 	//
 	// Should be one of the string constants from `TunnelProtocol`.

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelPort.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelPort.java
@@ -30,6 +30,26 @@ public class TunnelPort {
     public int portNumber;
 
     /**
+     * Gets or sets the optional short name of the port.
+     *
+     * The name must be unique among named ports of the same tunnel.
+     */
+    @Expose
+    public String name;
+
+    /**
+     * Gets or sets the optional description of the port.
+     */
+    @Expose
+    public String description;
+
+    /**
+     * Gets or sets the tags of the port.
+     */
+    @Expose
+    public String[] tags;
+
+    /**
      * Gets or sets the protocol of the tunnel port.
      *
      * Should be one of the string constants from {@link TunnelProtocol}.

--- a/rs/src/contracts/tunnel_access_control_entry.rs
+++ b/rs/src/contracts/tunnel_access_control_entry.rs
@@ -26,8 +26,9 @@ pub struct TunnelAccessControlEntry {
     // the user/group/org IDs. It may be one of the well-known provider names in
     // `TunnelAccessControlEntry.Providers`, or (in the future) a custom identity
     // provider.  For public key ACEs, this value is the type of public key, e.g. "ssh".
-    // For IP address range ACEs, this value is the IP addrss version, e.g. "ipv4" or
-    // "ipv6".  For anonymous ACEs, this value is null.
+    // For IP address range ACEs, this value is the IP address version, "ipv4" or "ipv6",
+    // or "service-tag" if the range is defined by an Azure service tag.  For anonymous
+    // ACEs, this value is null.
     pub provider: Option<String>,
 
     // Gets or sets a value indicating whether this is an access control entry on a tunnel
@@ -94,3 +95,6 @@ pub const PROVIDERS_IPV4: &str = "ipv4";
 
 // IPv6 addresses.
 pub const PROVIDERS_IPV6: &str = "ipv6";
+
+// Service tags.
+pub const PROVIDERS_SERVICE_TAG: &str = "service-tag";

--- a/rs/src/contracts/tunnel_access_control_entry_type.rs
+++ b/rs/src/contracts/tunnel_access_control_entry_type.rs
@@ -37,7 +37,7 @@ pub enum TunnelAccessControlEntryType {
     PublicKeys,
 
     // The access control entry is a list of IP address ranges that are allowed (or
-    // denied) access to the tunnel.
+    // denied) access to the tunnel. Ranges can be IPv4, IPv6, or Azure service tags.
     IPAddressRanges,
 }
 

--- a/rs/src/contracts/tunnel_port.rs
+++ b/rs/src/contracts/tunnel_port.rs
@@ -21,6 +21,18 @@ pub struct TunnelPort {
     // Gets or sets the IP port number of the tunnel port.
     pub port_number: u16,
 
+    // Gets or sets the optional short name of the port.
+    //
+    // The name must be unique among named ports of the same tunnel.
+    pub name: Option<String>,
+
+    // Gets or sets the optional description of the port.
+    pub description: Option<String>,
+
+    // Gets or sets the tags of the port.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tags: Vec<String>,
+
     // Gets or sets the protocol of the tunnel port.
     //
     // Should be one of the string constants from `TunnelProtocol`.

--- a/ts/src/contracts/tunnelPort.ts
+++ b/ts/src/contracts/tunnelPort.ts
@@ -27,6 +27,23 @@ export interface TunnelPort {
     portNumber: number;
 
     /**
+     * Gets or sets the optional short name of the port.
+     *
+     * The name must be unique among named ports of the same tunnel.
+     */
+    name?: string;
+
+    /**
+     * Gets or sets the optional description of the port.
+     */
+    description?: string;
+
+    /**
+     * Gets or sets the tags of the port.
+     */
+    tags?: string[];
+
+    /**
      * Gets or sets the protocol of the tunnel port.
      *
      * Should be one of the string constants from {@link TunnelProtocol}.


### PR DESCRIPTION
This change adds `name`, `description`, and `tags` properties to the `TunnelPort` contract. These properties will give applications more options for working with multiple ports of a tunnel. They're currently ignored by the tunnel service, but will be implemented later.