### PR TITLE
Move search tags to request options

### DIFF
--- a/cs/src/Management/ITunnelManagementClient.cs
+++ b/cs/src/Management/ITunnelManagementClient.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VsSaaS.TunnelService
     public interface ITunnelManagementClient : IDisposable
     {
         /// <summary>
-        /// Lists all tunnels that are owned by the caller.
+        /// Lists tunnels that are owned by the caller.
         /// </summary>
         /// <param name="clusterId">A tunnel cluster ID, or null to list tunnels globally.</param>
         /// <param name="domain">Tunnel domain, or null for the default domain.</param>
@@ -27,6 +27,11 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <returns>Array of tunnel objects.</returns>
         /// <exception cref="UnauthorizedAccessException">The client access token was missing,
         /// invalid, or unauthorized.</exception>
+        /// <remarks>
+        /// The list can be filtered by setting <see cref="TunnelRequestOptions.Tags"/>.
+        /// Ports will not be included in the returned tunnels unless
+        /// <see cref="TunnelRequestOptions.IncludePorts"/> is set to true.
+        /// </remarks>
         Task<Tunnel[]> ListTunnelsAsync(
             string? clusterId = null,
             string? domain = null,
@@ -45,6 +50,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <returns>Array of tunnel objects.</returns>
         /// <exception cref="UnauthorizedAccessException">The client access token was missing,
         /// invalid, or unauthorized.</exception>
+        [Obsolete("Use ListTunnelsAsync() method with TunnelRequestOptions.Tags instead.")]
         Task<Tunnel[]> SearchTunnelsAsync(
             string[] tags,
             bool requireAllTags,
@@ -63,6 +69,10 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <returns>The requested tunnel object, or null if the ID or name was not found.</returns>
         /// <exception cref="UnauthorizedAccessException">The client access token was missing,
         /// invalid, or unauthorized.</exception>
+        /// <remarks>
+        /// Ports will not be included in the returned tunnel unless
+        /// <see cref="TunnelRequestOptions.IncludePorts"/> is set to true.
+        /// </remarks>
         Task<Tunnel?> GetTunnelAsync(
             Tunnel tunnel,
             TunnelRequestOptions? options = null,
@@ -180,7 +190,7 @@ namespace Microsoft.VsSaaS.TunnelService
             CancellationToken cancellation = default);
 
         /// <summary>
-        /// Lists all ports on a tunnel.
+        /// Lists ports on a tunnel.
         /// </summary>
         /// <param name="tunnel">Tunnel object including at least either a tunnel name
         /// (globally unique, if configured) or tunnel ID and cluster ID.</param>
@@ -191,6 +201,9 @@ namespace Microsoft.VsSaaS.TunnelService
         /// invalid, or unauthorized.</exception>
         /// <exception cref="InvalidOperationException">The tunnel ID or name was not found.
         /// </exception>
+        /// <remarks>
+        /// The list can be filtered by setting <see cref="TunnelRequestOptions.Tags"/>.
+        /// </remarks>
         Task<TunnelPort[]> ListTunnelPortsAsync(
             Tunnel tunnel,
             TunnelRequestOptions? options = null,

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -599,6 +599,7 @@ namespace Microsoft.VsSaaS.TunnelService
         }
 
         /// <inheritdoc />
+        [Obsolete("Use ListTunnelsAsync() method with TunnelRequestOptions.Tags instead.")]
         public async Task<Tunnel[]> SearchTunnelsAsync(
             string[] tags,
             bool requireAllTags,

--- a/cs/src/Management/TunnelRequestOptions.cs
+++ b/cs/src/Management/TunnelRequestOptions.cs
@@ -68,7 +68,9 @@ namespace Microsoft.VsSaaS.TunnelService
         /// Requested tags are compared to the <see cref="Tunnel.Tags"/> or
         /// <see cref="TunnelPort.Tags"/> when calling
         /// <see cref="ITunnelManagementClient.ListTunnelsAsync"/> or
-        /// <see cref="ITunnelManagementClient.ListTunnelPortsAsync"/> respectively.
+        /// <see cref="ITunnelManagementClient.ListTunnelPortsAsync"/> respectively. By default, an
+        /// item is included if ANY tag matches; set <see cref="RequireAllTags" /> to match ALL
+        /// tags instead.
         /// </remarks>
         public string[]? Tags { get; set; }
 

--- a/cs/src/Management/TunnelRequestOptions.cs
+++ b/cs/src/Management/TunnelRequestOptions.cs
@@ -22,6 +22,8 @@ namespace Microsoft.VsSaaS.TunnelService
     /// </remarks>
     public class TunnelRequestOptions
     {
+        private static readonly string[] TrueOption = new[] { "true" };
+
         /// <summary>
         /// Gets or sets a tunnel access token for the request.
         /// </summary>
@@ -55,9 +57,26 @@ namespace Microsoft.VsSaaS.TunnelService
         public bool FollowRedirects { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a flag that requests tunnel ports when retrieving a tunnel object.
+        /// Gets or sets a flag that requests tunnel ports when retrieving tunnels.
         /// </summary>
         public bool IncludePorts { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional list of tags to filter the requested tunnels or ports.
+        /// </summary>
+        /// <remarks>
+        /// Requested tags are compared to the <see cref="Tunnel.Tags"/> or
+        /// <see cref="TunnelPort.Tags"/> when calling
+        /// <see cref="ITunnelManagementClient.ListTunnelsAsync"/> or
+        /// <see cref="ITunnelManagementClient.ListTunnelPortsAsync"/> respectively.
+        /// </remarks>
+        public string[]? Tags { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag that indicates whether listed items must match all tags
+        /// specified in <see cref="Tags"/>. If false, an item is included if any tag matches.
+        /// </summary>
+        public bool RequireAllTags { get; set; }
 
         /// <summary>
         /// Gets or sets an optional list of scopes that should be authorized when retrieving a
@@ -89,32 +108,42 @@ namespace Microsoft.VsSaaS.TunnelService
         /// </summary>
         protected internal virtual string ToQueryString()
         {
-            var queryOptions = new Dictionary<string, string>();
+            var queryOptions = new Dictionary<string, string[]>();
 
             if (IncludePorts)
             {
-                queryOptions["includePorts"] = "true";
+                queryOptions["includePorts"] = TrueOption;
             }
 
             if (Scopes != null)
             {
                 TunnelAccessControl.ValidateScopes(Scopes);
-                queryOptions["scopes"] = string.Join(",", Scopes);
+                queryOptions["scopes"] = Scopes;
             }
 
             if (TokenScopes != null)
             {
                 TunnelAccessControl.ValidateScopes(TokenScopes);
-                queryOptions["tokenScopes"] = string.Join(",", TokenScopes);
+                queryOptions["tokenScopes"] = TokenScopes;
             }
 
             if (ForceRename)
             {
-                queryOptions["forceRename"] = "true";
+                queryOptions["forceRename"] = TrueOption;
             }
 
+            if (Tags != null && Tags.Length > 0)
+            {
+                queryOptions["tags"] = Tags;
+                if (RequireAllTags)
+                {
+                    queryOptions["allTags"] = TrueOption;
+                }
+            }
+
+            // Note the comma separator for multi-valued options is NOT URL-encoded.
             return string.Join('&', queryOptions.Select(
-                (o) => $"{o.Key}={HttpUtility.UrlEncode(o.Value)}"));
+                (o) => $"{o.Key}={string.Join(",", o.Value.Select(HttpUtility.UrlEncode))}"));
         }
     }
 }

--- a/go/tunnels/manager.go
+++ b/go/tunnels/manager.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"strconv"
 	"strings"
 )
 
@@ -112,7 +111,7 @@ func NewManager(userAgents []UserAgent, tp tokenProviderfn, tunnelServiceUrl *ur
 	return &Manager{tokenProvider: tp, httpClient: client, uri: tunnelServiceUrl, userAgents: userAgents}, nil
 }
 
-// Lists all tunnels owned by the authenticated user.
+// Lists tunnels owned by the authenticated user.
 // Returns a list of tunnels or an error if the search fails.
 func (m *Manager) ListTunnels(
 	ctx context.Context, clusterID string, domain string, options *TunnelRequestOptions,
@@ -128,37 +127,6 @@ func (m *Manager) ListTunnels(
 	response, err := m.sendTunnelRequest(ctx, nil, options, http.MethodGet, url, nil, nil, readAccessTokenScope, false)
 	if err != nil {
 		return nil, fmt.Errorf("error sending list tunnel request: %w", err)
-	}
-
-	err = json.Unmarshal(response, &ts)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing response json to tunnel: %w", err)
-	}
-
-	return ts, nil
-}
-
-// Search tunnels that the authenticated user has access to based on tags.
-// If requireAllTags is true then tunnels returned must contain all tags in the tags slice.
-// Returns a slice of the found tunnels or an error if the search fails.
-func (m *Manager) SearchTunnels(
-	ctx context.Context, tags []string, requireAllTags bool, clusterID string, domain string, options *TunnelRequestOptions,
-) (ts []*Tunnel, err error) {
-	queryParams := url.Values{}
-	if clusterID == "" {
-		queryParams.Add("global", "true")
-	}
-	if domain != "" {
-		queryParams.Add("domain", domain)
-	}
-	queryParams.Add("allTags", strconv.FormatBool(requireAllTags))
-	tagString := strings.Join(tags, ",")
-	queryParams.Add("tags", tagString)
-
-	url := m.buildUri(clusterID, tunnelsApiPath, options, queryParams.Encode())
-	response, err := m.sendTunnelRequest(ctx, nil, options, http.MethodGet, url, nil, nil, readAccessTokenScope, false)
-	if err != nil {
-		return nil, fmt.Errorf("error sending search tunnel request: %w", err)
 	}
 
 	err = json.Unmarshal(response, &ts)
@@ -338,7 +306,7 @@ func (m *Manager) DeleteTunnelEndpoints(
 	return err
 }
 
-// Lists all ports on the tunnel.
+// Lists ports on the tunnel.
 func (m *Manager) ListTunnelPorts(
 	ctx context.Context, tunnel *Tunnel, options *TunnelRequestOptions,
 ) (tp []*TunnelPort, err error) {

--- a/go/tunnels/request_options.go
+++ b/go/tunnels/request_options.go
@@ -21,6 +21,13 @@ type TunnelRequestOptions struct {
 	// Flag that requests tunnel ports when retrieving a tunnel object.
 	IncludePorts bool
 
+	// Optional list of tags to filter the requested tunnels or ports.
+	Tags []string
+
+	// Flag that indicates whether listed items must match all tags specified in `tags`.
+	// If false, an item is included if any tag matches.
+	RequireAllTags bool
+
 	// List of scopes that are needed for the current request.
 	Scopes TunnelAccessScopes
 
@@ -53,6 +60,15 @@ func (options *TunnelRequestOptions) queryString() string {
 	}
 	if options.ForceRename {
 		queryOptions.Set("forceRename", "true")
+	}
+	if options.Tags != nil {
+		for _, tag := range options.Tags {
+			queryOptions.Add("tags", string(tag))
+		}
+
+		if options.RequireAllTags {
+			queryOptions.Set("allTags", "true")
+		}
 	}
 
 	return queryOptions.Encode()

--- a/go/tunnels/request_options.go
+++ b/go/tunnels/request_options.go
@@ -22,6 +22,8 @@ type TunnelRequestOptions struct {
 	IncludePorts bool
 
 	// Optional list of tags to filter the requested tunnels or ports.
+	// By default, an item is included if ANY tag matches; set `requireAllTags` to match
+	// ALL tags instead.
 	Tags []string
 
 	// Flag that indicates whether listed items must match all tags specified in `tags`.

--- a/java/src/main/java/com/microsoft/tunnels/management/ITunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/ITunnelManagementClient.java
@@ -17,29 +17,14 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface ITunnelManagementClient {
   /**
-   * Lists all tunnels that are owned by the caller.
+   * Lists tunnels that are owned by the caller.
    *
    * @param clusterId A tunnel cluster ID, or null to list tunnels globally.
+   * @param domain    Tunnel domain, or null for the default domain.
    * @param options   Request options.
    * @return Array of tunnel objects.
    */
   public CompletableFuture<Collection<Tunnel>> listTunnelsAsync(
-      String clusterId,
-      TunnelRequestOptions options);
-
-  /**
-   * Search for all tunnels with matching tags.
-   *
-   * @param tags           The tags to search for.
-   * @param requireAllTags requires a tunnel to have all specified tags.
-   * @param clusterId      A tunnel cluster ID, or null to list tunnels globally.
-   * @param domain         Tunnel domain, or null for the default domain.
-   * @param options        Request options.
-   * @return Array of tunnel objects.
-   */
-  public CompletableFuture<Collection<Tunnel>> searchTunnelsAsync(
-      String[] tags,
-      boolean requireAllTags,
       String clusterId,
       String domain,
       TunnelRequestOptions options);

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -6,7 +6,6 @@ package com.microsoft.tunnels.management;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.microsoft.tunnels.contracts.Tunnel;
-import com.microsoft.tunnels.contracts.TunnelAccessControl;
 import com.microsoft.tunnels.contracts.TunnelAccessControlEntry;
 import com.microsoft.tunnels.contracts.TunnelAccessScopes;
 import com.microsoft.tunnels.contracts.TunnelConnectionMode;
@@ -14,11 +13,9 @@ import com.microsoft.tunnels.contracts.TunnelContracts;
 import com.microsoft.tunnels.contracts.TunnelEndpoint;
 import com.microsoft.tunnels.contracts.TunnelPort;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -242,7 +239,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
 
     String queryString = "";
     if (options != null) {
-      queryString = toQueryString(options);
+      queryString = options.toQueryString();
     }
     if (query != null) {
       queryString += StringUtils.isBlank(queryString) ? query : "&" + query;
@@ -263,38 +260,10 @@ public class TunnelManagementClient implements ITunnelManagementClient {
     }
   }
 
-  private String toQueryString(TunnelRequestOptions options) {
-    final String encoding = "UTF-8";
-    var queryOptions = new ArrayList<String>();
-    if (options.includePorts) {
-      queryOptions.add("includePorts=true");
-    }
-
-    if (options.scopes != null) {
-      TunnelAccessControl.validateScopes(options.scopes, null);
-      try {
-        queryOptions.add("scopes=" + URLEncoder.encode(String.join(",", options.scopes), encoding));
-      } catch (UnsupportedEncodingException e) {
-        throw new IllegalArgumentException("Bad encoding: " + encoding);
-      }
-    }
-
-    if (options.tokenScopes != null) {
-      TunnelAccessControl.validateScopes(options.tokenScopes, null);
-      try {
-        queryOptions.add(
-            "tokenScopes=" + URLEncoder.encode(String.join(",", options.tokenScopes), encoding));
-      } catch (UnsupportedEncodingException e) {
-        throw new IllegalArgumentException("Bad encoding: " + encoding);
-      }
-    }
-    return String.join("&", queryOptions);
-  }
-
   public CompletableFuture<Collection<Tunnel>> listTunnelsAsync(
       String clusterId,
+      String domain,
       TunnelRequestOptions options) {
-    // TODO - add domain parameter
     var query = StringUtils.isBlank(clusterId) ? "global=true" : null;
     var requestUri = this.buildUri(clusterId, tunnelsApiPath, options, query);
     final Type responseType = new TypeToken<Collection<Tunnel>>() {
@@ -307,17 +276,6 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         ReadAccessTokenScopes,
         null /* requestObject */,
         responseType);
-  }
-
-  @Override
-  public CompletableFuture<Collection<Tunnel>> searchTunnelsAsync(
-      String[] tags,
-      boolean requireAllTags,
-      String clusterId,
-      String domain,
-      TunnelRequestOptions options) {
-    // TODO Auto-generated method stub
-    return null;
   }
 
   @Override

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
@@ -3,8 +3,15 @@
 
 package com.microsoft.tunnels.management;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.microsoft.tunnels.contracts.TunnelAccessControl;
 
 /**
  * TunnelRequestOptions.
@@ -16,9 +23,8 @@ public class TunnelRequestOptions {
    * </p>
    *
    * <p>
-   * Note this should not be a _user_ access token (such as AAD or GitHub); use
-   * the
-   * callback parameter to the `TunnelManagementHttpClient` constructor to
+   * Note this should not be a _user_ access token (such as AAD or GitHub); use the
+   * callback parameter to the `TunnelManagementClient` constructor to
    * supply user access tokens.
    * </p>
    */
@@ -56,6 +62,20 @@ public class TunnelRequestOptions {
   public boolean includePorts;
 
   /**
+   * Gets or sets an optional list of tags to filter the requested tunnels or ports.
+   *
+   * Requested tags are compared to the `Tunnel.tags` or `TunnelPort.tags` when calling
+   * `TunnelManagementClient.listTunnels` or `TunnelManagementClient.listTunnelPorts` respectively.
+   */
+  public Collection<String> tags;
+
+  /*
+   * Gets or sets a flag that indicates whether listed items must match all tags
+   * specified in `tags`. If false, an item is included if any tag matches.
+   */
+  public boolean requireAllTags;
+
+  /**
    * Gets or sets an optional list of scopes that should be authorized when
    * retrieving a tunnel or tunnel port object.
    */
@@ -66,4 +86,57 @@ public class TunnelRequestOptions {
    * are requested when retrieving a tunnel or tunnel port object.
    */
   public Collection<String> tokenScopes;
+
+  /**
+   * If true on a create or update request then upon a name conflict, attempt to rename the
+   * existing tunnel to null and give the name to the tunnel from the request.
+   */
+  public boolean forceRename;
+
+
+  /**
+   * Converts tunnel request options to a query string for HTTP requests to the
+   * tunnel management API.
+   */
+  public String toQueryString() {
+    var queryOptions = new HashMap<String, Collection<String>>();
+
+    if (this.includePorts) {
+      queryOptions.put("includePorts", Arrays.asList("true"));
+    }
+
+    if (this.scopes != null) {
+      TunnelAccessControl.validateScopes(this.scopes, null);
+      queryOptions.put("scopes", this.scopes);
+    }
+
+    if (this.tokenScopes != null) {
+      TunnelAccessControl.validateScopes(this.tokenScopes, null);
+      queryOptions.put("tokenScopes", this.tokenScopes);
+    }
+
+    if (this.forceRename) {
+      queryOptions.put("forceRename", Arrays.asList("true"));
+    }
+
+    if (this.tags != null) {
+      queryOptions.put("tags", this.tags);
+      if (this.requireAllTags) {
+        queryOptions.put("allTags", Arrays.asList("true"));
+      }
+    }
+
+    Stream<String> encodedParameters = queryOptions.entrySet().stream().map(o -> {
+      Stream<String> encodedValues = o.getValue().stream().map(v -> {
+        final String encoding = "UTF-8";
+        try {
+          return URLEncoder.encode(v, encoding);
+        } catch (UnsupportedEncodingException e) {
+          throw new IllegalArgumentException("Bad encoding: " + encoding);
+        }
+      });
+      return o.getKey() + "=" + encodedValues.collect(Collectors.joining("&"));
+    });
+    return encodedParameters.collect(Collectors.joining("&"));
+  }
 }

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
@@ -66,6 +66,8 @@ public class TunnelRequestOptions {
    *
    * Requested tags are compared to the `Tunnel.tags` or `TunnelPort.tags` when calling
    * `TunnelManagementClient.listTunnels` or `TunnelManagementClient.listTunnelPorts` respectively.
+   * By default, an item is included if ANY tag matches; set `requireAllTags` to match
+     * ALL tags instead.
    */
   public Collection<String> tags;
 

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
@@ -67,7 +67,7 @@ public class TunnelRequestOptions {
    * Requested tags are compared to the `Tunnel.tags` or `TunnelPort.tags` when calling
    * `TunnelManagementClient.listTunnels` or `TunnelManagementClient.listTunnelPorts` respectively.
    * By default, an item is included if ANY tag matches; set `requireAllTags` to match
-     * ALL tags instead.
+   * ALL tags instead.
    */
   public Collection<String> tags;
 

--- a/rs/src/management/tunnel_request_options.rs
+++ b/rs/src/management/tunnel_request_options.rs
@@ -18,6 +18,11 @@ pub struct TunnelRequestOptions {
     pub include_ports: bool,
 
     /// Gets or sets an optional list of tags to filter the requested tunnels or ports.
+    ///
+    /// Requested tags are compared to the `Tunnel.tags` or `TunnelPort.tags` when calling
+    /// `TunnelManagementClient.list_all_tunnels` or `TunnelManagementClient.list_tunnel_ports`
+    /// respectively. By default, an item is included if ANY tag matches; set `require_all_tags`
+    /// to match ALL tags instead.
     pub tags: Vec<String>,
 
     /// Gets or sets a flag that indicates whether listed items must match all tags

--- a/rs/src/management/tunnel_request_options.rs
+++ b/rs/src/management/tunnel_request_options.rs
@@ -7,7 +7,7 @@ pub struct TunnelRequestOptions {
     /// Gets or sets authorization for the request.
     ///
     /// Note this should not be a _user_ access token (such as AAD or GitHub); use the
-    /// callback parameter to the `TunnelManagementHttpClient` constructor to
+    /// callback parameter to the `TunnelManagementClient` constructor to
     /// supply user access tokens.
     pub authorization: Option<Authorization>,
 
@@ -17,6 +17,13 @@ pub struct TunnelRequestOptions {
     /// Gets or sets a flag that requests tunnel ports when retrieving a tunnel object.
     pub include_ports: bool,
 
+    /// Gets or sets an optional list of tags to filter the requested tunnels or ports.
+    pub tags: Vec<String>,
+
+    /// Gets or sets a flag that indicates whether listed items must match all tags
+    /// specified in `tags`. If false, an item is included if any tag matches.
+    pub require_all_tags: bool,
+
     /// Gets or sets an optional list of token scopes that
     /// are requested when retrieving a tunnel or tunnel port object.
     pub token_scopes: Vec<String>,
@@ -24,12 +31,19 @@ pub struct TunnelRequestOptions {
     /// Gets or sets an optional list of scopes that should be authorized when
     /// retrieving a tunnel or tunnel port object.
     pub scopes: Vec<String>,
+
+    /// If true on a create or update request then upon a name conflict, attempt to rename the
+    /// existing tunnel to null and give the name to the tunnel from the request.
+    pub force_rename: bool,
 }
 
 pub const NO_REQUEST_OPTIONS: &TunnelRequestOptions = &TunnelRequestOptions {
     authorization: None,
     headers: Vec::new(),
     include_ports: false,
+    tags: Vec::new(),
+    require_all_tags: false,
     token_scopes: Vec::new(),
     scopes: Vec::new(),
+    force_rename: false,
 };

--- a/ts/src/management/tunnelManagementClient.ts
+++ b/ts/src/management/tunnelManagementClient.ts
@@ -16,30 +16,30 @@ export interface TunnelManagementClient {
     httpsAgent?: https.Agent;
 
     /**
-     * Lists all tunnels that are owned by the caller.
-     * @param clusterId
-     * @param options
+     * Lists tunnels that are owned by the caller.
+     *
+     * The list can be filtered by setting `TunnelRequestOptions.tags`. Ports will not be
+     * included in the returned tunnels unless `TunnelRequestOptions.includePorts` is set to true.
+     *
+     * @param clusterId A tunnel cluster ID, or null to list tunnels globally.
+     * @param domain Tunnel domain, or null for the default domain.
+     * @param options Request options.
      */
-    listTunnels(clusterId?: string, options?: TunnelRequestOptions): Promise<Tunnel[]>;
-
-    /**
-     * Search for all tunnels with matching tags.
-     * @param tags
-     * @param requireAllTags
-     * @param clusterId
-     * @param options
-     */
-    searchTunnels(
-        tags: string[],
-        requireAllTags: boolean,
+    listTunnels(
         clusterId?: string,
+        domain?: string,
         options?: TunnelRequestOptions,
     ): Promise<Tunnel[]>;
 
     /**
      * Gets one tunnel by ID or name.
-     * @param tunnel
-     * @param options
+     *
+     * Ports will not be included in the returned tunnel unless `TunnelRequestOptions.includePorts`
+     * is set to true.
+     *
+     * @param tunnel Tunnel object including at least either a tunnel name (globally unique,
+     * if configured) or tunnel ID and cluster ID.
+     * @param options Request options.
      */
     getTunnel(tunnel: Tunnel, options?: TunnelRequestOptions): Promise<Tunnel | null>;
 
@@ -91,9 +91,13 @@ export interface TunnelManagementClient {
     ): Promise<boolean>;
 
     /**
-     * Lists all ports on a tunnel.
-     * @param tunnel
-     * @param options
+     * Lists ports on a tunnel.
+     *
+     * The list can be filtered by setting `TunnelRequestOptions.tags`.
+     *
+     * @param tunnel Tunnel object including at least either a tunnel name (globally unique,
+     * if configured) or tunnel ID and cluster ID.
+     * @param options Request options.
      */
     listTunnelPorts(tunnel: Tunnel, options?: TunnelRequestOptions): Promise<TunnelPort[]>;
 

--- a/ts/src/management/tunnelRequestOptions.ts
+++ b/ts/src/management/tunnelRequestOptions.ts
@@ -37,6 +37,20 @@ export interface TunnelRequestOptions {
     includePorts?: boolean;
 
     /**
+     * Gets or sets an optional list of tags to filter the requested tunnels or ports.
+     *
+     * Requested tags are compared to the `Tunnel.tags` or `TunnelPort.tags` when calling
+     * `TunnelManagementClient.listTunnels` or `TunnelManagementClient.listTunnelPorts` respectively.
+     */
+    tags?: string[];
+
+    /*
+     * Gets or sets a flag that indicates whether listed items must match all tags
+     * specified in `tags`. If false, an item is included if any tag matches.
+     */
+    requireAllTags?: boolean;
+
+    /**
      * Gets or sets an optional list of scopes that should be authorized when
      * retrieving a tunnel or tunnel port object.
      */
@@ -47,4 +61,10 @@ export interface TunnelRequestOptions {
      * are requested when retrieving a tunnel or tunnel port object.
      */
     tokenScopes?: string[];
+
+    /**
+     * If true on a create or update request then upon a name conflict, attempt to rename the
+     * existing tunnel to null and give the name to the tunnel from the request.
+     */
+    forceRename?: boolean;
 }

--- a/ts/src/management/tunnelRequestOptions.ts
+++ b/ts/src/management/tunnelRequestOptions.ts
@@ -40,7 +40,9 @@ export interface TunnelRequestOptions {
      * Gets or sets an optional list of tags to filter the requested tunnels or ports.
      *
      * Requested tags are compared to the `Tunnel.tags` or `TunnelPort.tags` when calling
-     * `TunnelManagementClient.listTunnels` or `TunnelManagementClient.listTunnelPorts` respectively.
+     * `TunnelManagementClient.listTunnels` or `TunnelManagementClient.listTunnelPorts`
+     * respectively. By default, an item is included if ANY tag matches; set `requireAllTags`
+     * to match ALL tags instead.
      */
     tags?: string[];
 

--- a/ts/test/tunnels-test/mocks/mockTunnelManagementClient.ts
+++ b/ts/test/tunnels-test/mocks/mockTunnelManagementClient.ts
@@ -16,25 +16,23 @@ export class MockTunnelManagementClient implements TunnelManagementClient {
     public hostRelayUri?: string;
     public clientRelayUri?: string;
 
-    listTunnels(clusterId?: string, options?: TunnelRequestOptions): Promise<Tunnel[]> {
-        return Promise.resolve(this.tunnels);
-    }
-
-    searchTunnels(
-        tags: string[],
-        requireAllTags: boolean,
+    listTunnels(
         clusterId?: string,
+        domain?: string,
         options?: TunnelRequestOptions,
     ): Promise<Tunnel[]> {
-        let tunnels: Tunnel[];
-        if (!requireAllTags) {
-            tunnels = this.tunnels.filter(
-                (tunnel) => tunnel.tags && tags.some((t) => tunnel!.tags!.includes(t)),
-            );
-        } else {
-            tunnels = this.tunnels.filter(
-                (tunnel) => tunnel.tags && tags.every((t) => tunnel!.tags!.includes(t)),
-            );
+        let tunnels = this.tunnels;
+
+        if (options?.tags) {
+            if (!options.requireAllTags) {
+                tunnels = this.tunnels.filter(
+                    (tunnel) => tunnel.tags && options.tags!.some((t) => tunnel.tags!.includes(t)),
+                );
+            } else {
+                tunnels = this.tunnels.filter(
+                    (tunnel) => tunnel.tags && options.tags!.every((t) => tunnel.tags!.includes(t)),
+                );
+            }
         }
 
         return Promise.resolve(tunnels);

--- a/ts/test/tunnels-test/tunnelManagementTests.ts
+++ b/ts/test/tunnels-test/tunnelManagementTests.ts
@@ -60,7 +60,8 @@ export class TunnelManagementTests {
     @test
     public async listTunnelsIncludePorts() {
         this.nextResponse = [];
-        await this.managementClient.listTunnels(undefined, { includePorts: true, scopes: [ 'connect' ] });
+        await this.managementClient.listTunnels(
+            undefined, undefined, { includePorts: true, scopes: [ 'connect' ] });
         assert(this.lastRequest && this.lastRequest.uri);
         assert(this.lastRequest.uri.startsWith('http://global.'));
         assert(this.lastRequest.uri.includes('includePorts=true&scopes=connect&global=true'));


### PR DESCRIPTION
The "search" API was originally designed to search tunnels by tags across all users, returning any matching tunnels that the caller had some access to. But that kind of search is too expensive, and not useful in any known scenarios. This update replaces that function with a more limited option to include tags as a filter to the "list" API that only covers tunnels owned by the caller. And since ports will also soon support tags, and tags are just one of many query options, I'm moving the tags option to the general request options class.

 - Mark the `SearchTunnelsAsync()` API as `[Obsolete]` in C#; remove it in the other 4 languages. We'll remove it from C# in the future.
 - Add `Tags` and `RequireAllTags` to `TunnelRequestOptions`, and update `ToQueryString()` to include those parameters (all 5 languages).
 - Add `ForceRename` request option where it was missing in TS, Java, and Rust.