### PR TITLE
Make SDK cs client reconnect SSH host and client sessions

### DIFF
--- a/cs/src/Connections/ConnectionStatus.cs
+++ b/cs/src/Connections/ConnectionStatus.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ConnectionStatus.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Tunnel client or host connection status.
+/// </summary>
+public enum ConnectionStatus
+{
+    /// <summary>
+    /// The connection has not started yet. This is the initial status.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Connecting (if changed from None) or reconnecting (if changed from Connected) to the service.
+    /// </summary>
+    Connecting,
+
+    /// <summary>
+    /// Connecting and refreshing the tunnel access token to connect with.
+    /// </summary>
+    RefreshingTunnelAccessToken,
+
+    /// <summary>
+    /// Connected to the service.
+    /// </summary>
+    Connected,
+
+    /// <summary>
+    /// Disconnected from the service and could not reconnect either due to disposal, service down, tunnel deleted, or token expiration. This is the final status.
+    /// </summary>
+    Disconnected,
+}

--- a/cs/src/Connections/ConnectionStatusChangedEventArgs.cs
+++ b/cs/src/Connections/ConnectionStatusChangedEventArgs.cs
@@ -21,6 +21,7 @@ public class ConnectionStatusChangedEventArgs : EventArgs
     {
         PreviousStatus = previousStatus;
         Status = status;
+        DisconnectException = disconnectException;
     }
 
     /// <summary>

--- a/cs/src/Connections/ConnectionStatusChangedEventArgs.cs
+++ b/cs/src/Connections/ConnectionStatusChangedEventArgs.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="ConnectionStatusChangedEventArgs.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Connection status change event args.
+/// </summary>
+public class ConnectionStatusChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Create a new instance of <see cref="ConnectionStatusChangedEventArgs"/>.
+    /// </summary>
+    public ConnectionStatusChangedEventArgs(ConnectionStatus previousStatus, ConnectionStatus status, Exception? disconnectException)
+    {
+        PreviousStatus = previousStatus;
+        Status = status;
+    }
+
+    /// <summary>
+    /// Get the previous connection status.
+    /// </summary>
+    public ConnectionStatus PreviousStatus { get; }
+
+    /// <summary>
+    /// Get the current connection status.
+    /// </summary>
+    public ConnectionStatus Status { get; }
+
+    /// <summary>
+    /// Get the exception that caused disconnect if <see cref="Status"/> is <see cref="ConnectionStatus.Disconnected"/>.
+    /// </summary>
+    public Exception? DisconnectException { get; }
+}

--- a/cs/src/Connections/IRelayClient.cs
+++ b/cs/src/Connections/IRelayClient.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="IRelayClient.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Ssh;
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Relay service client.
+/// </summary>
+internal interface IRelayClient
+{
+    /// <summary>
+    /// Get tunnel access scope for this tunnel client or host.
+    /// </summary>
+    string TunnelAccessScope { get; }
+
+    /// <summary>
+    /// Gets the trace source.
+    /// </summary>
+    TraceSource Trace { get; }
+
+    /// <summary>
+    /// Create stream to the tunnel.
+    /// </summary>
+    Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation);
+
+    /// <summary>
+    /// Configures tunnel SSH session with the given stream.
+    /// </summary>
+    Task ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation);
+
+    /// <summary>
+    /// Closes tunnel SSH session due to an error or exception.
+    /// </summary>
+    Task CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception);
+
+    /// <summary>
+    /// Refresh tunnel access token. This may be useful when the Relay service responds with 401 Unauthorized.
+    /// </summary>
+    Task<bool> RefreshTunnelAccessTokenAsync(CancellationToken cancellation);
+}

--- a/cs/src/Connections/ITunnelClient.cs
+++ b/cs/src/Connections/ITunnelClient.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// Event handler for refreshing the tunnel access token.
         /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
         /// </summary>
-        EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken { get; set; }
+        event EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken;
 
         /// <summary>
         /// Connection status changed event.

--- a/cs/src/Connections/ITunnelClient.cs
+++ b/cs/src/Connections/ITunnelClient.cs
@@ -36,6 +36,17 @@ namespace Microsoft.VsSaaS.TunnelService
         bool AcceptLocalConnectionsForForwardedPorts { get; set; }
 
         /// <summary>
+        /// Gets the connection status.
+        /// </summary>
+        ConnectionStatus ConnectionStatus { get; }
+
+        /// <summary>
+        /// Gets the exception that caused disconnection.
+        /// Null if not yet connected or disconnection was caused by disposing of this object.
+        /// </summary>
+        Exception? DisconnectException { get; }
+
+        /// <summary>
         /// Connects to a tunnel.
         /// </summary>
         /// <param name="tunnel">Tunnel to connect to.</param>
@@ -94,5 +105,16 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <returns>A <see cref="Task{Stream}"/> representing the result of the asynchronous operation.</returns>
         /// <exception cref="InvalidOperationException">If the tunnel is not yet connected and hasn't started connecting.</exception>
         Task<Stream?> ConnectToForwardedPortAsync(int forwardedPort, CancellationToken cancellation);
+
+        /// <summary>
+        /// Event handler for refreshing the tunnel access token.
+        /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
+        /// </summary>
+        EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken { get; set; }
+
+        /// <summary>
+        /// Connection status changed event.
+        /// </summary>
+        event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
     }
 }

--- a/cs/src/Connections/ITunnelConnector.cs
+++ b/cs/src/Connections/ITunnelConnector.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="ITunnelRelayConnector.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Tunnel connector.
+/// </summary>
+public interface ITunnelConnector
+{
+    /// <summary>
+    /// Connect or reconnect tunnel SSH session.
+    /// </summary>
+    Task ConnectSessionAsync(bool isReconnect, CancellationToken cancellation);
+}

--- a/cs/src/Connections/ITunnelHost.cs
+++ b/cs/src/Connections/ITunnelHost.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// Event handler for refreshing the tunnel access token.
         /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
         /// </summary>
-        EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken { get; set; }
+        event EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken;
 
         /// <summary>
         /// Connection status changed event.

--- a/cs/src/Connections/ITunnelHost.cs
+++ b/cs/src/Connections/ITunnelHost.cs
@@ -17,6 +17,17 @@ namespace Microsoft.VsSaaS.TunnelService
     public interface ITunnelHost : IAsyncDisposable
     {
         /// <summary>
+        /// Gets the connection status.
+        /// </summary>
+        ConnectionStatus ConnectionStatus { get; }
+
+        /// <summary>
+        /// Gets the exception that caused disconnection.
+        /// Null if not yet connected or disconnection was caused by disposing of this object.
+        /// </summary>
+        Exception? DisconnectException { get; }
+
+        /// <summary>
         /// Connects to a tunnel as a host and starts accepting incoming connections
         /// to local ports as defined on the tunnel.
         /// </summary>
@@ -78,6 +89,15 @@ namespace Microsoft.VsSaaS.TunnelService
             TunnelPort updatedPort,
             CancellationToken cancellation);
 
-        // TODO: Events about tunnel port and connection activity?
+        /// <summary>
+        /// Event handler for refreshing the tunnel access token.
+        /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
+        /// </summary>
+        EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken { get; set; }
+
+        /// <summary>
+        /// Connection status changed event.
+        /// </summary>
+        event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
     }
 }

--- a/cs/src/Connections/RefreshingTunnelAccessTokenEventArgs.cs
+++ b/cs/src/Connections/RefreshingTunnelAccessTokenEventArgs.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="RefreshingTunnelAccessTokenEventArgs.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Event args for tunnel access token refresh event.
+/// </summary>
+public class RefreshingTunnelAccessTokenEventArgs : EventArgs
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="RefreshingTunnelAccessTokenEventArgs"/> class.
+    /// </summary>
+    public RefreshingTunnelAccessTokenEventArgs(string tunnelAccessScope)
+    {
+        TunnelAccessScope = Requires.NotNull(tunnelAccessScope, nameof(tunnelAccessScope));
+    }
+
+    /// <summary>
+    /// Tunnel access scope to get the token for.
+    /// </summary>
+    public string TunnelAccessScope { get; }
+
+    /// <summary>
+    /// Optional token provider function the event handler may set to asynchnronously fetch the token.
+    /// The arguments are: tunnel access scope and cancellation token.
+    /// The result is the task that returns the new tunnel access token or null if it couldn't fetch the token.
+    /// </summary>
+    public Func<string, CancellationToken, Task<string?>>? TunnelAccessTokenProvider { get; set; }
+
+    /// <summary>
+    /// Tunnel access token that the event handler may set synchronously.
+    /// </summary>
+    public string? TunnelAccessToken { get; set; }
+}

--- a/cs/src/Connections/RefreshingTunnelAccessTokenEventArgs.cs
+++ b/cs/src/Connections/RefreshingTunnelAccessTokenEventArgs.cs
@@ -17,9 +17,10 @@ public class RefreshingTunnelAccessTokenEventArgs : EventArgs
     /// <summary>
     /// Creates a new instance of <see cref="RefreshingTunnelAccessTokenEventArgs"/> class.
     /// </summary>
-    public RefreshingTunnelAccessTokenEventArgs(string tunnelAccessScope)
+    public RefreshingTunnelAccessTokenEventArgs(string tunnelAccessScope, CancellationToken cancellation)
     {
         TunnelAccessScope = Requires.NotNull(tunnelAccessScope, nameof(tunnelAccessScope));
+        Cancellation = cancellation;
     }
 
     /// <summary>
@@ -28,14 +29,13 @@ public class RefreshingTunnelAccessTokenEventArgs : EventArgs
     public string TunnelAccessScope { get; }
 
     /// <summary>
-    /// Optional token provider function the event handler may set to asynchnronously fetch the token.
-    /// The arguments are: tunnel access scope and cancellation token.
-    /// The result is the task that returns the new tunnel access token or null if it couldn't fetch the token.
+    /// Cancellation token that event handler may observe when it asynchronously fetches the tunnel access token.
     /// </summary>
-    public Func<string, CancellationToken, Task<string?>>? TunnelAccessTokenProvider { get; set; }
+    public CancellationToken Cancellation { get; }
 
     /// <summary>
-    /// Tunnel access token that the event handler may set synchronously.
+    /// Token task the event handler may set to asynchnronously fetch the token.
+    /// The result of the task may be a new tunnel access token or null if it couldn't get the token.
     /// </summary>
-    public string? TunnelAccessToken { get; set; }
+    public Task<string?>? TunnelAccessTokenTask { get; set; }
 }

--- a/cs/src/Connections/RelayTunnelConnector.cs
+++ b/cs/src/Connections/RelayTunnelConnector.cs
@@ -1,0 +1,198 @@
+﻿// <copyright file="RelayTunnelConnector.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Ssh;
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Tunnel connector that connects to Tunnel Relay service.
+/// </summary>
+internal sealed class RelayTunnelConnector : ITunnelConnector
+{
+    private const int ReconnectAttemptsDoublingDelay = 7; // After the 6th attemt, each next attempt will happen after a delay of 2^7 * 100ms = 12.8s
+    private const int ReconnectInitialDelayMs = 100;
+
+    private readonly IRelayClient relayClient;
+
+    public RelayTunnelConnector(IRelayClient relayClient)
+    {
+        this.relayClient = Requires.NotNull(relayClient, nameof(relayClient));
+        Requires.NotNull(relayClient.Trace, nameof(IRelayClient.Trace));
+    }
+
+    private TraceSource Trace => this.relayClient.Trace;
+
+    /// <inheritdoc/>
+    public async Task ConnectSessionAsync(bool isReconnect, CancellationToken cancellation)
+    {
+        int attempDelayMs = ReconnectInitialDelayMs;
+        bool isDelayNeeded;
+
+        object? errorDescription;
+        var disconnectReason = SshDisconnectReason.ConnectionLost;
+        Exception? exception = null;
+        int attempt = 0;
+        bool isTunnelAccessTokenRefreshed = false;
+        string message;
+
+        while (true)
+        {
+            cancellation.ThrowIfCancellationRequested();
+            attempt++;
+            isDelayNeeded = true;
+            Stream? stream = null;
+            errorDescription = null;
+            try
+            {
+                // TODO: check tunnel access token expiration and try refresh it if it's expired.
+                stream = await this.relayClient.CreateSessionStreamAsync(cancellation);
+                await this.relayClient.ConfigureSessionAsync(stream, isReconnect, cancellation);
+
+                stream = null;
+                disconnectReason = SshDisconnectReason.None;
+                return;
+            }
+            catch (SshReconnectException srex)
+            {
+                errorDescription = srex.Message;
+                disconnectReason = SshDisconnectReason.ProtocolError;
+                exception = srex;
+                isDelayNeeded = false;
+                isReconnect = false;
+            }
+            catch (SshConnectionException scex) when (scex.DisconnectReason == SshDisconnectReason.ConnectionLost)
+            {
+                // Recoverable
+                errorDescription = scex.Message;
+            }
+            catch (SshConnectionException scex)
+            {
+                // All other SSH connection exceptions are not recoverable.
+                disconnectReason = scex.DisconnectReason != SshDisconnectReason.None ? scex.DisconnectReason : SshDisconnectReason.ByApplication;
+                exception = scex;
+                throw new TunnelConnectionException($"Failed to start tunnel SSH session: {scex.Message}", scex);
+            }
+            catch (WebSocketException wse)
+            {
+                if (wse.WebSocketErrorCode == WebSocketError.UnsupportedProtocol)
+                {
+                    throw new InvalidOperationException("Unsupported web socket sub-protocol.", wse);
+                }
+
+                if (wse.WebSocketErrorCode == WebSocketError.NotAWebSocket)
+                {
+                    int? statusCode = wse.Data.Contains("HttpStatusCode") ? (int)wse.Data["HttpStatusCode"]! : null;
+                    switch (statusCode)
+                    {
+                        case 401:
+                            // Unauthorized error may happen when the tunnel access token is no longer valid, e.g. expired.
+                            // Try refreshing it.
+                            if (!isTunnelAccessTokenRefreshed)
+                            {
+                                try
+                                {
+                                    isTunnelAccessTokenRefreshed = await this.relayClient.RefreshTunnelAccessTokenAsync(cancellation);
+                                }
+                                catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+                                {
+                                    throw;
+                                }
+                                catch (Exception ex)
+                                {
+                                    throw new UnauthorizedAccessException(
+                                        $"Not authorized (401). Refreshing tunnel access token also failed with error {ex.Message}",
+                                        ex);
+                                }
+
+                                if (isTunnelAccessTokenRefreshed)
+                                {
+                                    isDelayNeeded = false;
+                                    errorDescription = "The tunnel access token expired and just has been refreshed.";
+                                    break;
+                                }
+                            }
+
+                            message = "Not authorized (401). " +
+                                (isTunnelAccessTokenRefreshed ? 
+                                "Refreshed tunnel access token also doesn't work." : 
+                                $"Provide a fresh tunnel access token with '{this.relayClient.TunnelAccessScope}' scope.");
+
+                            throw new UnauthorizedAccessException(message, wse);
+
+                        case 403:
+                            message = $"Forbidden (403). Provide a fresh tunnel access token with '{this.relayClient.TunnelAccessScope}' scope.";
+                            throw new UnauthorizedAccessException(message, wse);
+
+                        case 404:
+                            throw new TunnelConnectionException($"The tunnel or port is not found (404).", wse);
+
+                        case 429:
+                            errorDescription = "Rate limit exceeded (429). Too many requests in a given amount of time.";
+                            break;
+
+                        default:
+                            // For any other status code we assume the error is not recoverable.
+                            throw new TunnelConnectionException(wse.Message, wse);
+                    }
+                }
+
+                // Other web socket errors may be recoverable
+                errorDescription ??= wse.Message;
+                exception = wse;
+            }
+            catch (OperationCanceledException)
+            {
+                disconnectReason = SshDisconnectReason.ByApplication;
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // These exceptions are not recoverable
+                if (ex is InvalidOperationException ||
+                    ex is ObjectDisposedException ||
+                    ex is NullReferenceException ||
+                    ex is ArgumentNullException ||
+                    ex is ArgumentException)
+                {
+                    throw;
+                }
+
+                errorDescription = ex;
+                exception = ex;
+            }
+            finally
+            {
+                if (disconnectReason != SshDisconnectReason.None)
+                {
+                    await this.relayClient.CloseSessionAsync(disconnectReason, exception);
+                }
+
+                if (stream != null)
+                {
+                    await stream.DisposeAsync();
+                }
+            }
+
+            var retryTiming = isDelayNeeded ? $" in {(attempDelayMs < 1000 ? $"0.{attempDelayMs / 100}s" : $"{attempDelayMs / 1000}s")}" : string.Empty;
+            Trace.Verbose($"Error connecting to tunnel SSH session, retrying{retryTiming}{(errorDescription != null ? $": {errorDescription}" : string.Empty)}");
+
+            if (isDelayNeeded)
+            {
+                await Task.Delay(attempDelayMs, cancellation);
+                if (attempt < ReconnectAttemptsDoublingDelay)
+                {
+                    attempDelayMs <<= 1;
+                }
+            }
+        }
+    }
+}

--- a/cs/src/Connections/TunnelBase.cs
+++ b/cs/src/Connections/TunnelBase.cs
@@ -1,0 +1,291 @@
+﻿// <copyright file="TunnelBase.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VsSaaS.TunnelService.Contracts;
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Base class for tunnel client and host.
+/// </summary>
+public abstract class TunnelBase : IAsyncDisposable
+{
+    private readonly object reconnectLock = new();
+    private readonly CancellationTokenSource disposeCts = new();
+    private Task? reconnectTask;
+    private ConnectionStatus connectionStatus;
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="TunnelBase"/> class.
+    /// </summary>
+    public TunnelBase(ITunnelManagementClient? managementClient, TraceSource trace)
+    {
+        ManagementClient = managementClient;
+        Trace = Requires.NotNull(trace, nameof(trace));
+    }
+
+    /// <summary>
+    /// Gets the connection status.
+    /// </summary>
+    public ConnectionStatus ConnectionStatus 
+    {
+        get => this.connectionStatus;
+        protected set
+        {
+            lock (this.reconnectLock)
+            {
+                if (this.disposeCts.IsCancellationRequested)
+                {
+                    value = ConnectionStatus.Disconnected;
+                }
+
+                var previousConnectionStatus = this.connectionStatus;
+                this.connectionStatus = value;
+                if (value != previousConnectionStatus)
+                {
+                    OnConnectionStatusChanged(previousConnectionStatus, value);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get the exception that caused disconnection.
+    /// Null if not yet connected or disconnection was caused by disposing of this object.
+    /// </summary>
+    public Exception? DisconnectException { get; protected set; }
+
+    /// <summary>
+    /// Get the tunnel that is being hosted or connected to.
+    /// May be null if the tunnel client used relay service URL and tunnel access token directly.
+    /// </summary>
+    public Tunnel? Tunnel { get; private set; }
+
+    /// <summary>
+    /// Trace to write output to console.
+    /// </summary>
+    protected TraceSource Trace { get; }
+
+    /// <summary>
+    /// Management client used for connections.
+    /// Not null for the tunnel host. Maybe null for the tunnel client.
+    /// </summary>
+    protected ITunnelManagementClient? ManagementClient { get; }
+
+    /// <summary>
+    /// Tunnel connector.
+    /// </summary>
+    protected ITunnelConnector? connector;
+
+    /// <summary>
+    /// Tunnel access token.
+    /// </summary>
+    protected string? accessToken;
+
+    /// <summary>
+    /// Create tunnel connector for <see cref="Tunnel"/>.
+    /// </summary>
+    protected abstract Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation);
+
+    /// <summary>
+    /// Get tunnel access scope for this tunnel client or host.
+    /// </summary>
+    protected abstract string TunnelAccessScope { get; }
+
+    /// <summary>
+    /// Event handler for refreshing the tunnel access token.
+    /// The tunnel client or host fires this event when it is not able to use the access token it got from the tunnel.
+    /// </summary>
+    public EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken { get; set; }
+
+    /// <summary>
+    /// Connection status changed event.
+    /// </summary>
+    public event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
+
+    /// <summary>
+    /// Assign the tunnel and connect to it.
+    /// </summary>
+    protected Task ConnectTunnelSessionAsync(Tunnel tunnel, CancellationToken cancellation)
+    {
+        Requires.NotNull(tunnel, nameof(tunnel));
+        return ConnectTunnelSessionAsync(async (cancellation) =>
+        {
+            var isReconnect = Tunnel != null;
+            Tunnel = tunnel;
+            this.connector ??= await CreateTunnelConnectorAsync(cancellation);
+            await this.connector.ConnectSessionAsync(isReconnect, cancellation);
+        },
+        cancellation);
+    }
+
+    /// <summary>
+    /// Connect to tunnel session by running <paramref name="connectAction"/>.
+    /// </summary>
+    protected async Task ConnectTunnelSessionAsync(Func<CancellationToken, Task> connectAction, CancellationToken cancellation)
+    {
+        Requires.NotNull(connectAction, nameof(connectAction));
+        ConnectionStatus = ConnectionStatus.Connecting;
+        try
+        {
+            await connectAction(cancellation);
+            ConnectionStatus = ConnectionStatus.Connected;
+        }
+        catch (OperationCanceledException)
+        {
+            ConnectionStatus = ConnectionStatus.Disconnected;
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Trace.Error(
+                "Error connecting {0} tunnel session: {1}",
+                TunnelAccessScope == TunnelAccessScopes.Connect ? "client" : "host",
+                ex is UnauthorizedAccessException || ex is TunnelConnectionException ? ex.Message : ex);
+
+            DisconnectException = ex;
+            ConnectionStatus = ConnectionStatus.Disconnected;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Gets the fresh tunnel access token when Relay service returns 401.
+    /// </summary>
+    protected async Task<bool> RefreshTunnelAccessTokenAsync(CancellationToken cancellation)
+    {
+        var previousStatus = ConnectionStatus;
+        ConnectionStatus = ConnectionStatus.RefreshingTunnelAccessToken;
+        try
+        {
+            var newTunnelAccessToken = await GetFreshTunnelAccessTokenAsync(cancellation);
+            if (!string.IsNullOrEmpty(newTunnelAccessToken) &&
+                newTunnelAccessToken != this.accessToken)
+            {
+                this.accessToken = newTunnelAccessToken;
+                return true;
+            }
+
+            return false;
+        }
+        finally
+        {
+            ConnectionStatus = previousStatus;
+        }
+    }
+
+    /// <summary>
+    /// Gets the fresh tunnel access token or null if it cannot.
+    /// </summary>
+    /// <remarks>
+    /// If <see cref="Tunnel"/>, <see cref="ManagementClient"/> are not null and <see cref="RefreshingTunnelAccessToken"/> is null,
+    /// gets the tunnel with <see cref="ITunnelManagementClient.GetTunnelAsync(Tunnel, TunnelRequestOptions?, CancellationToken)"/> and gets the token 
+    /// off it based on <see cref="TunnelAccessScope"/>.
+    /// Otherwise, invokes <see cref="RefreshingTunnelAccessToken"/> event.
+    /// </remarks>
+    protected virtual async Task<string?> GetFreshTunnelAccessTokenAsync(CancellationToken cancellation)
+    {
+        if (Tunnel != null &&
+            ManagementClient != null &&
+            RefreshingTunnelAccessToken == null)
+        {
+            var options = new TunnelRequestOptions
+            {
+                TokenScopes = new[] { TunnelAccessScope },
+            };
+
+            Tunnel = await ManagementClient.GetTunnelAsync(Tunnel!, options, cancellation);
+            return Tunnel!.AccessTokens?.TryGetValue(TunnelAccessScope, out var result) == true ? result : null;
+        }
+
+        var eventArgs = new RefreshingTunnelAccessTokenEventArgs(TunnelAccessScope);
+        RefreshingTunnelAccessToken?.Invoke(this, eventArgs);
+
+        return eventArgs.TunnelAccessToken ??
+            (eventArgs.TunnelAccessTokenProvider != null ?
+            await eventArgs.TunnelAccessTokenProvider(TunnelAccessScope, cancellation).ConfigureAwait(false) :
+            null);
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask DisposeAsync()
+    {
+        Task? reconnectTask;
+        lock (this.reconnectLock)
+        {
+            this.disposeCts.Cancel();
+            reconnectTask = this.reconnectTask;
+        }
+
+        if (reconnectTask != null)
+        {
+            await reconnectTask;
+        }
+
+        ConnectionStatus = ConnectionStatus.Disconnected;
+    }
+
+    /// <summary>
+    /// Event fired when the connection status has changed.
+    /// </summary>
+    protected virtual void OnConnectionStatusChanged(ConnectionStatus previousConnectionStatus, ConnectionStatus connectionStatus)
+    {
+        var handler = ConnectionStatusChanged;
+        if (handler != null)
+        {
+            var args = new ConnectionStatusChangedEventArgs(
+                previousConnectionStatus, 
+                connectionStatus, 
+                connectionStatus == ConnectionStatus.Disconnected ? DisconnectException : null);
+
+            handler(this, args);
+        }
+    }
+
+    /// <summary>
+    /// Start reconnect task if the object is not yet disposed.
+    /// </summary>
+    protected void StartReconnectTaskIfNotDisposed()
+    {
+        lock (this.reconnectLock)
+        {
+            if (!this.disposeCts.IsCancellationRequested && 
+                this.reconnectTask == null &&
+                this.connector != null) // The connector may be null if the tunnel client/host was created directly from a stream.
+            {
+                var task = ReconnectAsync(this.disposeCts.Token);
+                this.reconnectTask = !task.IsCompleted ? task : null;
+            }
+        }
+    }
+
+    private async Task ReconnectAsync(CancellationToken cancellation)
+    {
+        Requires.NotNull(this.connector!, nameof(this.connector));
+
+        try
+        {
+            await ConnectTunnelSessionAsync(
+                (cancellation) => this.connector.ConnectSessionAsync(isReconnect: true, cancellation),
+                cancellation);
+        }
+        catch
+        {
+            // Tracing of the exception has already been done by ConnectToTunnelSessionAsync.
+            // As reconnection is an async process, there is nobody watching it throw.
+            // The exception, if it was not cancellation, is stored in DisconnectException property.
+            // There might have been ConnectionStatusChanged event fired as well.
+        }
+
+        lock (this.reconnectLock)
+        {
+            this.reconnectTask = null;
+        }
+    }
+}

--- a/cs/src/Connections/TunnelClientBase.cs
+++ b/cs/src/Connections/TunnelClientBase.cs
@@ -229,6 +229,7 @@ public abstract class TunnelClientBase : TunnelBase, ITunnelClient
         if (this.SshSession != null)
         {
             await this.SshSession.CloseAsync(SshDisconnectReason.ByApplication);
+            this.SshSession.Dispose();
         }
 
         SshSessionClosed = null;

--- a/cs/src/Connections/TunnelClientBase.cs
+++ b/cs/src/Connections/TunnelClientBase.cs
@@ -125,10 +125,11 @@ public abstract class TunnelClientBase : TunnelBase, ITunnelClient
         throw new InvalidOperationException("Port forwarding has not been started. Ensure that the client has connected by calling ConnectAsync.");
 
     /// <summary>
-    /// Start Ssh session on the <paramref name="stream"/>.
+    /// Start SSH session on the <paramref name="stream"/>.
     /// </summary>
     /// <remarks>
     /// Overwrites <see cref="SshSession"/> property.
+    /// SSH session reconnect is enabled only if <see cref="TunnelBase.connector"/> is not null.
     /// </remarks>
     protected async Task StartSshSessionAsync(Stream stream, CancellationToken cancellation)
     {
@@ -142,7 +143,8 @@ public abstract class TunnelClientBase : TunnelBase, ITunnelClient
             this.SshSession.Request -= OnRequest;
         }
 
-        var clientConfig = new SshSessionConfiguration(enableReconnect: true);
+        // Enable reconnect only if connector is set as reconnect depends on it.
+        var clientConfig = new SshSessionConfiguration(enableReconnect: this.connector != null);
 
         // Enable port-forwarding via the SSH protocol.
         clientConfig.AddService(typeof(PortForwardingService));

--- a/cs/src/Connections/TunnelHostBase.cs
+++ b/cs/src/Connections/TunnelHostBase.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Ssh;
@@ -22,26 +21,33 @@ namespace Microsoft.VsSaaS.TunnelService
     /// <summary>
     /// Base class for Hosts that host one tunnel
     /// </summary>
-    public abstract class TunnelHostBase : ITunnelHost
+    public abstract class TunnelHostBase : TunnelBase, ITunnelHost
     {
+        /// <summary>
+        /// Sessions created between this host and clients. Lock on this hash set to be thread-safe.
+        /// </summary>
+        protected HashSet<SshServerSession> sshSessions = new();
+
         /// <summary>
         /// Creates a new instance of the <see cref="TunnelHostBase" /> class.
         /// </summary>
-        public TunnelHostBase(ITunnelManagementClient managementClient, TraceSource trace)
+        public TunnelHostBase(ITunnelManagementClient managementClient, TraceSource trace) : base(managementClient, trace)
         {
-            ManagementClient = Requires.NotNull(managementClient, nameof(managementClient));
-            Trace = Requires.NotNull(trace, nameof(trace));
         }
 
         /// <summary>
-        /// Sessions created between this host and clients
+        /// Enumeration of sessions created between this host and clients. Thread safe.
         /// </summary>
-        protected ConcurrentBag<SshServerSession> SshSessions { get; } = new ConcurrentBag<SshServerSession>();
-
-        /// <summary>
-        /// Get the tunnel that is being hosted.
-        /// </summary>
-        public Tunnel? Tunnel { get; protected set; }
+        protected IEnumerable<SshServerSession> SshSessions 
+        { 
+            get 
+            {
+                lock (this.sshSessions)
+                {
+                    return this.sshSessions.ToArray();
+                }
+            }
+        }
 
         /// <summary>
         /// Port Forwarders between host and clients
@@ -53,23 +59,8 @@ namespace Microsoft.VsSaaS.TunnelService
         /// </summary>
         protected IKeyPair HostPrivateKey { get; } = SshAlgorithms.PublicKey.ECDsaSha2Nistp384.GenerateKeyPair();
 
-        /// <summary>
-        /// Management client used for connections
-        /// </summary>
-        protected ITunnelManagementClient ManagementClient { get; }
-
-        /// <summary>
-        /// Trace used for writing output
-        /// </summary>
-        protected TraceSource Trace { get; }
-
         /// <inheritdoc />
-        public abstract ValueTask DisposeAsync();
-
-        /// <summary>
-        /// Do start work specific to the type of host.
-        /// </summary>
-        protected abstract Task StartAsync(Tunnel tunnel, string[]? hostPublicKeys, CancellationToken cancellation);
+        protected override string TunnelAccessScope => TunnelAccessScopes.Host;
 
         /// <inheritdoc />
         public async Task StartAsync(Tunnel tunnel, CancellationToken cancellation)
@@ -83,12 +74,7 @@ namespace Microsoft.VsSaaS.TunnelService
             }
 
             Requires.NotNull(tunnel.Ports!, nameof(tunnel.Ports));
-            var hostPublicKeys = new[]
-            {
-                HostPrivateKey.GetPublicKeyBytes(HostPrivateKey.KeyAlgorithmName).ToBase64(),
-            };
-
-            await StartAsync(tunnel, hostPublicKeys, cancellation);
+            await ConnectTunnelSessionAsync(tunnel, cancellation);
         }
 
         /// <inheritdoc />
@@ -101,13 +87,14 @@ namespace Microsoft.VsSaaS.TunnelService
                 throw new InvalidOperationException("Tunnel must be running");
             }
 
-            var port = await ManagementClient.CreateTunnelPortAsync(Tunnel, portToAdd, null, cancellation);
+            var port = await ManagementClient!.CreateTunnelPortAsync(Tunnel, portToAdd, null, cancellation);
             await Task.WhenAll(SshSessions.Select(sshSession => Task.Run(async () =>
             {
-                if (sshSession.Principal == null)
+                if (sshSession.Principal == null || !sshSession.IsConnected)
                 {
-                    // The session is not yet authenticated; all ports will be forwarded after
-                    // the session is authenticated.
+                    // Two possible cases:
+                    // - The session is not yet authenticated; all ports will be forwarded after the session is authenticated.
+                    // - The session is currently disconnected and will reconnect; all ports will be re-forwarded after the session is reconnected.
                     return;
                 }
 
@@ -134,12 +121,12 @@ namespace Microsoft.VsSaaS.TunnelService
                 throw new InvalidOperationException("Tunnel must be running and have ports to delete");
             }
 
-            var portDeleted = await ManagementClient.DeleteTunnelPortAsync(Tunnel, portNumberToRemove, null, cancellation);
+            var portDeleted = await ManagementClient!.DeleteTunnelPortAsync(Tunnel, portNumberToRemove, null, cancellation);
 
             Parallel.ForEach(SshSessions, sshSession =>
             {
                 var sessionId = sshSession.SessionId;
-                if (sessionId != null)
+                if (sessionId != null && sshSession.IsConnected)
                 {
                     foreach (KeyValuePair<SessionPortKey, RemotePortForwarder> entry in RemoteForwarders)
                     {
@@ -170,35 +157,70 @@ namespace Microsoft.VsSaaS.TunnelService
                 throw new InvalidOperationException("Tunnel must be running and have ports to update");
             }
 
-            var port = await ManagementClient.UpdateTunnelPortAsync(Tunnel, updatedPort, null, cancellation);
+            var port = await ManagementClient!.UpdateTunnelPortAsync(Tunnel, updatedPort, null, cancellation);
             return port;
         }
 
-        internal async Task<bool> ForwardPortAsync(
+        internal async Task ForwardPortAsync(
             PortForwardingService pfs,
             TunnelPort port,
             CancellationToken cancellation)
         {
             var sessionId = Requires.NotNull(pfs.Session.SessionId!, nameof(pfs.Session.SessionId));
 
+            var portNumber = (int)port.PortNumber;
+
+            if (pfs.LocalForwardedPorts.Any((p) => p.LocalPort == portNumber))
+            {
+                // The port is already forwarded. This may happen if we try to add the same port twice after reconnection.
+                return;
+            }
+
             // When forwarding from a Remote port we assume that the RemotePortNumber
             // and requested LocalPortNumber are the same.
             var forwarder = await pfs.ForwardFromRemotePortAsync(
                 IPAddress.Loopback,
-                (int)port.PortNumber,
+                portNumber,
                 IPAddress.Loopback.ToString(),
-                (int)port.PortNumber,
+                portNumber,
                 cancellation);
+
             if (forwarder == null)
             {
                 // The forwarding request was rejected by the client.
-                return false;
+                return;
             }
 
             RemoteForwarders.TryAdd(
                 new SessionPortKey(sessionId, (ushort)forwarder.RemotePort),
                 forwarder);
-            return true;
+            return;
+        }
+
+        /// <summary>
+        /// Add client SSH session. Duplicates are ignored.
+        /// Thread-safe.
+        /// </summary>
+        protected void AddClientSshSession(SshServerSession session)
+        {
+            Requires.NotNull(session, nameof(session));
+            lock (this.sshSessions)
+            {
+                this.sshSessions.Add(session);
+            }
+        }
+
+        /// <summary>
+        /// Remove client SSH session. Noop if the session is not added.
+        /// Thread-safe.
+        /// </summary>
+        protected void RemoveClientSshSession(SshServerSession session)
+        {
+            Requires.NotNull(session, nameof(session));
+            lock (this.sshSessions)
+            {
+                this.sshSessions.Remove(session);
+            }
         }
     }
 }

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -167,6 +167,11 @@ namespace Microsoft.VsSaaS.TunnelService
                 {
                     await SshSession.CloseAsync(disconnectReason);
                 }
+
+                // Closing the SSH session does nothing if the session is in disconnected state,
+                // which may happen for a reconnectable session when the connection drops.
+                // Disposing of the session forces closing and frees up the resources.
+                SshSession.Dispose();
             }
         }
 

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -6,9 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Ssh;
 using Microsoft.VsSaaS.TunnelService.Contracts;
 
 namespace Microsoft.VsSaaS.TunnelService
@@ -16,17 +18,26 @@ namespace Microsoft.VsSaaS.TunnelService
     /// <summary>
     /// Tunnel client implementation that connects via a tunnel relay.
     /// </summary>
-    public class TunnelRelayTunnelClient : TunnelClientBase
+    public class TunnelRelayTunnelClient : TunnelClientBase, IRelayClient
     {
         /// <summary>
         /// Web socket sub-protocol to connect to the tunnel relay endpoint.
         /// </summary>
         public const string WebSocketSubProtocol = "tunnel-relay-client";
 
+        private Uri? relayUri;
+
         /// <summary>
         /// Creates a new instance of a client that connects to a tunnel via a tunnel relay.
         /// </summary>
-        public TunnelRelayTunnelClient(TraceSource trace) : base(trace) { }
+        public TunnelRelayTunnelClient(TraceSource trace) : this(managementClient: null, trace)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a client that connects to a tunnel via a tunnel relay.
+        /// </summary>
+        public TunnelRelayTunnelClient(ITunnelManagementClient? managementClient, TraceSource trace) : base(managementClient, trace) { }
 
         /// <summary>
         /// Gets or sets a factory for creating relay streams.
@@ -43,11 +54,29 @@ namespace Microsoft.VsSaaS.TunnelService
              => new[] { TunnelConnectionMode.TunnelRelay };
 
         /// <inheritdoc />
-        protected override async Task ConnectAsync(
-            Tunnel tunnel,
-            IEnumerable<TunnelEndpoint> endpoints,
-            CancellationToken cancellation)
+        protected override Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
         {
+            Requires.NotNull(Tunnel!, nameof(Tunnel));
+            Requires.NotNull(Tunnel.Endpoints!, nameof(Tunnel.Endpoints));
+
+            var endpointGroups = Tunnel.Endpoints.GroupBy((ep) => ep.HostId).ToArray();
+            IGrouping<string?, TunnelEndpoint> endpoints;
+            if (HostId != null)
+            {
+                endpoints = endpointGroups.SingleOrDefault((g) => g.Key == HostId) ??
+                    throw new InvalidOperationException(
+                        "The specified host is not currently accepting connections to the tunnel.");
+            }
+            else if (endpointGroups.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    "There are multiple hosts for the tunnel. Specify a host ID to connect to.");
+            }
+            else
+            {
+                endpoints = endpointGroups.Single();
+            }
+
             var endpoint = endpoints
                 .OfType<TunnelRelayTunnelEndpoint>()
                 .SingleOrDefault() ??
@@ -56,46 +85,98 @@ namespace Microsoft.VsSaaS.TunnelService
 
             Requires.Argument(
                 !string.IsNullOrEmpty(endpoint?.ClientRelayUri),
-                nameof(tunnel),
+                nameof(Tunnel),
                 $"The tunnel client relay endpoint URI is missing.");
 
-            var clientRelayUri = endpoint.ClientRelayUri;
-
             // The access token might be null if connecting to a tunnel that allows anonymous access.
-            string? accessToken = null!;
-            tunnel.AccessTokens?.TryGetValue(TunnelAccessScopes.Connect, out accessToken);
+            Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken);
+            this.relayUri = new Uri(endpoint.ClientRelayUri, UriKind.Absolute);
 
-            await ConnectAsync(clientRelayUri, accessToken, cancellation);
+            ITunnelConnector result = new RelayTunnelConnector(this);
+            return Task.FromResult(result);
         }
 
         /// <summary>
-        /// Connect to the <paramref name="clientRelayUri"/> using <paramref name="accessToken"/>.
+        /// Connect to the clientRelayUri using accessToken.
         /// </summary>
-        protected async Task ConnectAsync(string clientRelayUri, string? accessToken, CancellationToken cancellation)
+        protected Task ConnectAsync(string clientRelayUri, string? accessToken, CancellationToken cancellation)
         {
-            Requires.NotNullOrEmpty(clientRelayUri, nameof(clientRelayUri));            
-            Trace.TraceInformation("Connecting to client tunnel relay {0}", clientRelayUri);
-            try
+            Requires.NotNull(clientRelayUri, nameof(clientRelayUri));
+            return ConnectTunnelSessionAsync(
+                (cancellation) =>
+                {
+                    this.relayUri = new Uri(clientRelayUri, UriKind.Absolute);
+                    this.accessToken = accessToken;
+                    this.connector = new RelayTunnelConnector(this);
+                    return this.connector.ConnectSessionAsync(isReconnect: false, cancellation);
+                },
+                cancellation);
+        }
+
+        /// <summary>
+        /// Create stream to the tunnel.
+        /// </summary>
+        protected virtual Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
+        {
+            Trace.TraceInformation("Connecting to client tunnel relay {0}", this.relayUri!.AbsoluteUri);
+            return this.StreamFactory.CreateRelayStreamAsync(
+                this.relayUri!,
+                this.accessToken,
+                WebSocketSubProtocol,
+                cancellation);
+        }
+
+        /// <summary>
+        /// Configures tunnel SSH session with the given stream.
+        /// </summary>
+        protected virtual async Task ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
+        {
+            if (isReconnect && SshSession != null && !SshSession.IsClosed)
             {
-                var stream = await StreamFactory.CreateRelayStreamAsync(
-                    new Uri(clientRelayUri, UriKind.Absolute),
-                    accessToken,
-                    WebSocketSubProtocol,
-                    cancellation);
-                try
-                {
-                    await StartSshSessionAsync(stream, cancellation);
-                }
-                catch
-                {
-                    stream.Dispose();
-                    throw;
-                }
+                await SshSession.ReconnectAsync(stream, cancellation);
             }
-            catch (Exception exception)
+            else
             {
-                throw new TunnelConnectionException("Failed to connect to tunnel relay.", exception);
+                await StartSshSessionAsync(stream, cancellation);
             }
         }
+
+        #region IRelayClient
+
+        /// <inheritdoc />
+        string IRelayClient.TunnelAccessScope => TunnelAccessScope;
+
+        /// <inheritdoc />
+        TraceSource IRelayClient.Trace => Trace;
+
+        /// <inheritdoc />
+        Task<Stream> IRelayClient.CreateSessionStreamAsync(CancellationToken cancellation) => 
+            CreateSessionStreamAsync(cancellation);
+
+        /// <inheritdoc />
+        async Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception)
+        {
+            if (SshSession != null && !SshSession.IsClosed && disconnectReason != SshDisconnectReason.None)
+            {
+                if (exception != null)
+                {
+                    await SshSession.CloseAsync(disconnectReason, exception);
+                }
+                else
+                {
+                    await SshSession.CloseAsync(disconnectReason);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        Task IRelayClient.ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation) =>
+            ConfigureSessionAsync(stream, isReconnect, cancellation);
+
+        /// <inheritdoc />
+        Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>
+            RefreshTunnelAccessTokenAsync(cancellation);
+
+        #endregion IRelayClient
     }
 }

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -155,25 +155,8 @@ namespace Microsoft.VsSaaS.TunnelService
             CreateSessionStreamAsync(cancellation);
 
         /// <inheritdoc />
-        async Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception)
-        {
-            if (SshSession != null && !SshSession.IsClosed && disconnectReason != SshDisconnectReason.None)
-            {
-                if (exception != null)
-                {
-                    await SshSession.CloseAsync(disconnectReason, exception);
-                }
-                else
-                {
-                    await SshSession.CloseAsync(disconnectReason);
-                }
-
-                // Closing the SSH session does nothing if the session is in disconnected state,
-                // which may happen for a reconnectable session when the connection drops.
-                // Disposing of the session forces closing and frees up the resources.
-                SshSession.Dispose();
-            }
-        }
+        Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception) =>
+            CloseSessionAsync(disconnectReason, exception);
 
         /// <inheritdoc />
         Task IRelayClient.ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation) =>

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -118,6 +118,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// </summary>
         protected virtual Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
         {
+            ValidateAccessToken();
             Trace.TraceInformation("Connecting to client tunnel relay {0}", this.relayUri!.AbsoluteUri);
             return this.StreamFactory.CreateRelayStreamAsync(
                 this.relayUri!,

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -254,6 +254,8 @@ namespace Microsoft.VsSaaS.TunnelService
             var tcs = new TaskCompletionSource<object?>();
             try
             {
+                // Always enable reconnect on client SSH server.
+                // When a client reconnects, relay service just opens another SSH channel of client-ssh-session-stream type for it.
                 var serverConfig = new SshSessionConfiguration(enableReconnect: true);
 
                 // Enable port-forwarding via the SSH protocol.

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -135,6 +135,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// </summary>
         protected virtual Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
         {
+            ValidateAccessToken();
             Trace.TraceInformation("Connecting to host tunnel relay {0}", this.relayUri!.AbsoluteUri);
             return this.StreamFactory.CreateRelayStreamAsync(
                 this.relayUri!,

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -71,6 +71,7 @@ namespace Microsoft.VsSaaS.TunnelService
             {
                 this.hostSession = null;
                 await hostSession.CloseAsync();
+                hostSession.Dispose();
             }
 
             List<Task> tasks;
@@ -167,9 +168,11 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <inheritdoc />
         async Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception)
         {
-            if (this.hostSession != null)
+            var hostSession = this.hostSession;
+            if (hostSession != null)
             {
-                await this.hostSession.CloseAsync();
+                await hostSession.CloseAsync();
+                hostSession.Dispose();
             }
         }
 

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +23,7 @@ namespace Microsoft.VsSaaS.TunnelService
     /// Tunnel host implementation that uses data-plane relay
     /// to accept client connections.
     /// </summary>
-    public class TunnelRelayTunnelHost : TunnelHostBase
+    public class TunnelRelayTunnelHost : TunnelHostBase, IRelayClient
     {
         /// <summary>
         /// Web socket sub-protocol to connect to the tunnel relay endpoint.
@@ -39,9 +38,11 @@ namespace Microsoft.VsSaaS.TunnelService
         private readonly CancellationTokenSource disposeCts = new CancellationTokenSource();
         private readonly IList<Task> clientSessionTasks = new List<Task>();
         private readonly string hostId;
+        private readonly ICollection<SshServerSession> reconnectableSessions = new List<SshServerSession>();
 
         private MultiChannelStream? hostSession;
-
+        private Uri? relayUri;
+        
         /// <summary>
         /// Creates a new instance of a host that connects to a tunnel via a tunnel relay.
         /// </summary>
@@ -64,7 +65,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <inheritdoc />
         public override async ValueTask DisposeAsync()
         {
-            this.disposeCts.Cancel();
+            await base.DisposeAsync();
 
             var hostSession = this.hostSession;
             if (hostSession != null)
@@ -82,7 +83,7 @@ namespace Microsoft.VsSaaS.TunnelService
 
             if (Tunnel != null)
             {
-                tasks.Add(ManagementClient.DeleteTunnelEndpointsAsync(Tunnel, this.hostId, TunnelConnectionMode.TunnelRelay));
+                tasks.Add(ManagementClient!.DeleteTunnelEndpointsAsync(Tunnel, this.hostId, TunnelConnectionMode.TunnelRelay));
             }
 
             foreach (RemotePortForwarder forwarder in RemoteForwarders.Values)
@@ -90,24 +91,22 @@ namespace Microsoft.VsSaaS.TunnelService
                 forwarder.Dispose();
             }
 
-            while (this.SshSessions.TryTake(out var sshSession))
-            {
-                tasks.Add(sshSession.CloseAsync(SshDisconnectReason.ByApplication));
-            }
-
             await Task.WhenAll(tasks);
-            this.clientSessionTasks.Clear();
         }
 
         /// <inheritdoc />
-        protected override async Task StartAsync(Tunnel tunnel, string[]? hostPublicKeys, CancellationToken cancellation)
+        protected override async Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
         {
-            string? accessToken = null;
-            tunnel.AccessTokens?.TryGetValue(TunnelAccessScopes.Host, out accessToken);
-            Requires.Argument(
-                accessToken != null,
-                nameof(tunnel),
-                $"There is no access token for {nameof(TunnelAccessScopes.Host)} scope on the tunnel.");
+            Requires.NotNull(Tunnel!, nameof(Tunnel));
+
+            this.accessToken = null!;
+            Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken!);
+            Requires.Argument(this.accessToken != null, nameof(Tunnel), $"There is no access token for {TunnelAccessScope} scope on the tunnel.");
+
+            var hostPublicKeys = new[]
+            {
+                HostPrivateKey.GetPublicKeyBytes(HostPrivateKey.KeyAlgorithmName).ToBase64(),
+            };
 
             var endpoint = new TunnelRelayTunnelEndpoint
             {
@@ -115,48 +114,70 @@ namespace Microsoft.VsSaaS.TunnelService
                 HostPublicKeys = hostPublicKeys,
             };
 
-            endpoint = (TunnelRelayTunnelEndpoint)await ManagementClient.UpdateTunnelEndpointAsync(
-                tunnel,
+            endpoint = (TunnelRelayTunnelEndpoint)await ManagementClient!.UpdateTunnelEndpointAsync(
+                Tunnel,
                 endpoint,
                 options: null,
                 cancellation);
 
-            Tunnel = tunnel;
-
             Requires.Argument(
                 !string.IsNullOrEmpty(endpoint?.HostRelayUri),
-                nameof(tunnel),
+                nameof(Tunnel),
                 $"The tunnel host relay endpoint URI is missing.");
 
-            var hostRelayUri = endpoint.HostRelayUri;
-            Trace.TraceInformation("Connecting to host tunnel relay {0}", hostRelayUri);
+            this.relayUri = new Uri(endpoint.HostRelayUri, UriKind.Absolute);
 
-            try
-            {
-                var stream = await StreamFactory.CreateRelayStreamAsync(
-                    new Uri(hostRelayUri, UriKind.Absolute),
-                    accessToken,
-                    WebSocketSubProtocol,
-                    cancellation);
+            return new RelayTunnelConnector(this);
+        }
 
-                this.hostSession = new MultiChannelStream(stream, Trace.WithName("HostSSH"));
-                this.hostSession.ChannelOpening += HostSession_ChannelOpening;
-                this.hostSession.Closed += HostSession_Closed;
-                try
-                {
-                    await this.hostSession.ConnectAsync(cancellation);
-                }
-                catch
-                {
-                    await this.hostSession.CloseAsync();
-                    throw;
-                }
-            }
-            catch (Exception exception)
+        /// <summary>
+        /// Create stream to the tunnel.
+        /// </summary>
+        protected virtual Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
+        {
+            Trace.TraceInformation("Connecting to host tunnel relay {0}", this.relayUri!.AbsoluteUri);
+            return this.StreamFactory.CreateRelayStreamAsync(
+                this.relayUri!,
+                this.accessToken,
+                WebSocketSubProtocol,
+                cancellation);
+        }
+
+        #region IRelayClient
+
+        /// <inheritdoc />
+        string IRelayClient.TunnelAccessScope => TunnelAccessScope;
+
+        /// <inheritdoc />
+        TraceSource IRelayClient.Trace => Trace;
+
+        /// <inheritdoc />
+        Task<Stream> IRelayClient.CreateSessionStreamAsync(CancellationToken cancellation) =>
+            CreateSessionStreamAsync(cancellation);
+
+        /// <inheritdoc />
+        async Task IRelayClient.ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
+        {
+            this.hostSession = new MultiChannelStream(stream, Trace.WithName("HostSSH"));
+            this.hostSession.ChannelOpening += HostSession_ChannelOpening;
+            this.hostSession.Closed += HostSession_Closed;
+            await this.hostSession.ConnectAsync(cancellation);
+        }
+
+        /// <inheritdoc />
+        async Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception)
+        {
+            if (this.hostSession != null)
             {
-                throw new TunnelConnectionException("Failed to connect to tunnel relay.", exception);
+                await this.hostSession.CloseAsync();
             }
         }
+
+        /// <inheritdoc />
+        Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>
+            RefreshTunnelAccessTokenAsync(cancellation);
+
+        #endregion IRelayClient
 
         private void HostSession_Closed(object? sender, SshSessionClosedEventArgs e)
         {
@@ -164,7 +185,11 @@ namespace Microsoft.VsSaaS.TunnelService
             session.Closed -= HostSession_Closed;
             session.ChannelOpening -= HostSession_ChannelOpening;
             this.hostSession = null;
-            Trace.TraceInformation("Connection to host tunnel relay closed.");
+            Trace.TraceInformation(
+                "Connection to host tunnel relay closed.{0}",
+                this.disposeCts.IsCancellationRequested ? string.Empty : " Reconnecting.");
+
+            StartReconnectTaskIfNotDisposed();
         }
 
         private void HostSession_ChannelOpening(object? sender, SshChannelOpeningEventArgs e)
@@ -211,7 +236,7 @@ namespace Microsoft.VsSaaS.TunnelService
         {
             try
             {
-                using var stream = await hostSession.AcceptStreamAsync(ClientStreamChannelType, cancellation);
+                var stream = await hostSession.AcceptStreamAsync(ClientStreamChannelType, cancellation);
                 await ConnectAndRunClientSessionAsync(stream, cancellation);
             }
             catch (OperationCanceledException)
@@ -225,52 +250,75 @@ namespace Microsoft.VsSaaS.TunnelService
 
         private async Task ConnectAndRunClientSessionAsync(Stream stream, CancellationToken cancellation)
         {
-            var serverConfig = new SshSessionConfiguration();
-
-            // Enable port-forwarding via the SSH protocol.
-            serverConfig.AddService(typeof(PortForwardingService));
-
-            var session = new SshServerSession(serverConfig, Trace.WithName("ClientSSH"));
-            session.Credentials = new SshServerCredentials(this.HostPrivateKey);
-
+            var sshSessionOwnsStream = false;
             var tcs = new TaskCompletionSource<object?>();
-            using var tokenRegistration = cancellation.CanBeCanceled ?
-                cancellation.Register(() => tcs.TrySetCanceled(cancellation)) : default;
-
-            session.Authenticating += OnSshClientAuthenticating;
-            session.ClientAuthenticated += OnSshClientAuthenticated;
-            session.ChannelOpening += OnSshChannelOpening;
-            session.Closed += Session_Closed;
-
             try
             {
-                var portForwardingService = session.ActivateService<PortForwardingService>();
+                var serverConfig = new SshSessionConfiguration(enableReconnect: true);
 
-                // All tunnel hosts and clients should disable this because they do not use it (for now) and leaving it enabled is a potential security issue.
-                portForwardingService.AcceptRemoteConnectionsForNonForwardedPorts = false;
+                // Enable port-forwarding via the SSH protocol.
+                serverConfig.AddService(typeof(PortForwardingService));
 
-                await session.ConnectAsync(stream, cancellation);
-                this.SshSessions.Add(session);
-                await tcs.Task;
+                var session = new SshServerSession(serverConfig, this.reconnectableSessions, Trace.WithName("ClientSSH"));
+                session.Credentials = new SshServerCredentials(this.HostPrivateKey);
+
+                using var tokenRegistration = cancellation.CanBeCanceled ?
+                    cancellation.Register(() => tcs.TrySetCanceled(cancellation)) : default;
+
+                session.Authenticating += OnSshClientAuthenticating;
+                session.ClientAuthenticated += OnSshClientAuthenticated;
+                session.Reconnected += OnSshClientReconnected;
+                session.ChannelOpening += OnSshChannelOpening;
+                session.Closed += Session_Closed;
+
+                try
+                {
+                    var portForwardingService = session.ActivateService<PortForwardingService>();
+
+                    // All tunnel hosts and clients should disable this because they do not use it (for now) and leaving it enabled is a potential security issue.
+                    portForwardingService.AcceptRemoteConnectionsForNonForwardedPorts = false;
+
+                    await session.ConnectAsync(stream, cancellation);
+                    sshSessionOwnsStream = true;
+
+                    AddClientSshSession(session);
+
+                    await tcs.Task;
+                }
+                finally
+                {
+                    if (!session.IsClosed)
+                    {
+                        await session.CloseAsync(SshDisconnectReason.ByApplication);
+                    }
+
+                    session.Authenticating -= OnSshClientAuthenticating;
+                    session.ClientAuthenticated -= OnSshClientAuthenticated;
+                    session.Reconnected -= OnSshClientReconnected;
+                    session.ChannelOpening -= OnSshChannelOpening;
+                    session.Closed -= Session_Closed;
+
+                    RemoveClientSshSession(session);
+                }
             }
-            finally
+            catch when (!sshSessionOwnsStream)
             {
-                session.Authenticating -= OnSshClientAuthenticating;
-                session.ChannelOpening -= OnSshChannelOpening;
-                session.Closed -= Session_Closed;
+                stream.Close();
+                throw;
             }
 
             void Session_Closed(object? sender, SshSessionClosedEventArgs e)
             {
-                if (e.Reason == SshDisconnectReason.ByApplication)
-                {
-                    Trace.TraceInformation("Client ssh session closed.");
-                }
-                else if (cancellation.IsCancellationRequested)
+                // Reconnecting client session may cause the new session close with 'None' reason and null exception.
+                if (cancellation.IsCancellationRequested)
                 {
                     Trace.TraceInformation("Client ssh session cancelled.");
                 }
-                else
+                else if (e.Reason == SshDisconnectReason.ByApplication)
+                {
+                    Trace.TraceInformation("Client ssh session closed.");
+                }
+                else if (e.Reason != SshDisconnectReason.None || e.Exception != null)
                 {
                     Trace.TraceEvent(
                         TraceEventType.Error,
@@ -300,13 +348,17 @@ namespace Microsoft.VsSaaS.TunnelService
             }
         }
 
-        private async void OnSshClientAuthenticated(object? sender, EventArgs e)
-        {
-            // After the client session authenicated, automatically start forwarding existing ports.
-            var session = (SshServerSession)sender!;
-            var pfs = session.ActivateService<PortForwardingService>();
+        private async void OnSshClientAuthenticated(object? sender, EventArgs e) =>
+            await StartForwardingExistingPortsAsync((SshServerSession)sender!);
 
-            foreach (TunnelPort port in Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>())
+        private async void OnSshClientReconnected(object? sender, EventArgs e) =>
+            await StartForwardingExistingPortsAsync((SshServerSession)sender!, removeUnusedPorts: true);
+
+        private async Task StartForwardingExistingPortsAsync(SshServerSession session, bool removeUnusedPorts = false)
+        {
+            var tunnelPorts = Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>();
+            var pfs = session.ActivateService<PortForwardingService>();
+            foreach (TunnelPort port in tunnelPorts)
             {
                 try
                 {
@@ -320,6 +372,33 @@ namespace Microsoft.VsSaaS.TunnelService
                         "Error forwarding port {0} to client: {1}",
                         port.PortNumber,
                         exception.Message);
+                }
+            }
+
+            // If a tunnel client reconnects, its SSH session Port Forwarding service may
+            // have remote port forwarders for the ports no longer forwarded.
+            // Remove such forwarders.
+            if (removeUnusedPorts && session.SessionId != null)
+            {
+                tunnelPorts = Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>();
+                var unusedlocalPorts = new HashSet<int>(
+                    pfs.LocalForwardedPorts
+                        .Select(p => p.LocalPort)
+                        .Where(localPort => localPort.HasValue && !tunnelPorts.Any(tp => tp.PortNumber == localPort))
+                        .Select(localPort => localPort!.Value));
+
+                var remoteForwardersToDispose = RemoteForwarders
+                    .Where((kvp) =>
+                        Enumerable.SequenceEqual(kvp.Key.SessionId, session.SessionId) &&
+                        unusedlocalPorts.Contains(kvp.Value.LocalPort))
+                    .Select(kvp => kvp.Key);
+
+                foreach (SessionPortKey key in remoteForwardersToDispose)
+                {
+                    if (RemoteForwarders.TryRemove(key, out var remoteForwarder))
+                    {
+                        remoteForwarder?.Dispose();
+                    }
                 }
             }
         }

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -144,6 +144,18 @@ namespace Microsoft.VsSaaS.TunnelService
                 cancellation);
         }
 
+        /// <inheritdoc />
+        protected override async Task CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception)
+        {
+            await base.CloseSessionAsync(disconnectReason, exception);
+            var hostSession = this.hostSession;
+            if (hostSession != null)
+            {
+                await hostSession.CloseAsync();
+                hostSession.Dispose();
+            }
+        }
+
         #region IRelayClient
 
         /// <inheritdoc />
@@ -166,15 +178,8 @@ namespace Microsoft.VsSaaS.TunnelService
         }
 
         /// <inheritdoc />
-        async Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception)
-        {
-            var hostSession = this.hostSession;
-            if (hostSession != null)
-            {
-                await hostSession.CloseAsync();
-                hostSession.Dispose();
-            }
-        }
+        Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception) =>
+            CloseSessionAsync(disconnectReason, exception);
 
         /// <inheritdoc />
         Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>

--- a/cs/src/Management/TunnelAccessTokenProperties.cs
+++ b/cs/src/Management/TunnelAccessTokenProperties.cs
@@ -169,6 +169,24 @@ public class TunnelAccessTokenProperties
     }
 
     /// <summary>
+    /// Gets token representation for tracing.
+    /// </summary>
+    public static string GetTokenTrace(string? token)
+    {
+        if (token == null)
+        {
+            return "<null>";
+        }
+
+        if (token == string.Empty)
+        {
+            return "<empty>";
+        }
+
+        return TryParse(token) is TunnelAccessTokenProperties t ? $"<JWT: {t}>" : "<token>";
+    }
+
+    /// <summary>
     /// Attempts to parse a tunnel access token (JWT). This does NOT validate the token
     /// signature or any claims.
     /// </summary>

--- a/cs/test/TunnelsSDK.Test/LocalPortsFixture.cs
+++ b/cs/test/TunnelsSDK.Test/LocalPortsFixture.cs
@@ -1,0 +1,32 @@
+﻿using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.VsSaaS.TunnelService.Test
+{
+    public class LocalPortsFixture : IDisposable
+    {
+        private readonly TcpListener listener;
+        private readonly TcpListener listener1;
+
+        public LocalPortsFixture()
+        {
+            // Get the local tcp ports
+            this.listener = new TcpListener(IPAddress.Loopback, port: 0);
+            this.listener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, false);
+            this.listener.Start();
+
+            this.listener1 = new TcpListener(IPAddress.Loopback, port: 0);
+            this.listener1.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, false);
+            this.listener1.Start();
+        }
+
+        public ushort Port => (ushort)(((IPEndPoint)this.listener.LocalEndpoint).Port);
+        public ushort Port1 => (ushort)(((IPEndPoint)this.listener1.LocalEndpoint).Port);
+
+        public void Dispose()
+        {
+            this.listener.Stop();
+            this.listener1.Stop();
+        }
+    }
+}

--- a/cs/test/TunnelsSDK.Test/Mocks/MockTunnelRelayStreamFactory.cs
+++ b/cs/test/TunnelsSDK.Test/Mocks/MockTunnelRelayStreamFactory.cs
@@ -1,8 +1,3 @@
-
-using System;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.VsSaaS.TunnelService.Test.Mocks;
@@ -12,11 +7,14 @@ public class MockTunnelRelayStreamFactory : ITunnelRelayStreamFactory
     private readonly string connectionType;
     private readonly Stream stream;
 
-    public MockTunnelRelayStreamFactory(string connectionType, Stream stream)
+    public MockTunnelRelayStreamFactory(string connectionType, Stream stream = null)
     {
         this.connectionType = connectionType;
         this.stream = stream;
+        StreamFactory = (string accessToken) => Task.FromResult(this.stream);
     }
+
+    public Func<string, Task<Stream>> StreamFactory { get; set; }
 
     public Task<Stream> CreateRelayStreamAsync(
         Uri relayUri,
@@ -28,6 +26,6 @@ public class MockTunnelRelayStreamFactory : ITunnelRelayStreamFactory
         Assert.NotNull(accessToken);
         Assert.Equal(this.connectionType, connectionType);
 
-        return Task.FromResult(stream);
+        return StreamFactory(accessToken);
     }
 }

--- a/cs/test/TunnelsSDK.Test/TestTunnelRelayTunnelClient.cs
+++ b/cs/test/TunnelsSDK.Test/TestTunnelRelayTunnelClient.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+
+namespace Microsoft.VsSaaS.TunnelService.Test;
+
+internal class TestTunnelRelayTunnelClient : TunnelRelayTunnelClient
+{
+    public TestTunnelRelayTunnelClient(TraceSource trace) : base(trace)
+    {
+    }
+
+    protected override void OnSshSessionClosed(Exception exception)
+    {
+        base.OnSshSessionClosed(exception);
+        SshSessionClosed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public new event EventHandler SshSessionClosed;
+}

--- a/cs/test/TunnelsSDK.Test/TunnelsSDK.Test.csproj
+++ b/cs/test/TunnelsSDK.Test/TunnelsSDK.Test.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.Streams" Version="2.5.76" />
+    <PackageReference Include="Microsoft.VisualStudio.Ssh.Tcp" Version="$(VsSshPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix for [#412](https://github.com/microsoft/basis-planning/issues/412) and [#413](https://github.com/microsoft/basis-planning/issues/413)

- Enable SSH session reconnection.
- Retry connection to Relay server when it fails, or is disconnected with exponential backoffs.
- Do not retry on unrecoverable errors.
- Handle 401 errors and fire a new event to let the customers supply a fresh tunnel access token.
- Abstract relay connection logic into a separate class and use it from the tunnel client and host
- Add a common base class for the tunnel client and host, and add an event for tunnel access token refresh there.
- Add some unit tests; more incoming later.
