### PR TITLE
Add flatten plugin to correctly resolve revision variable in mvn deploy

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -99,6 +99,31 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->


### PR DESCRIPTION
The version number in the published POM was not correctly being rewritten to the `revision` variable passed in through our GH publish action. This was causing problems installing the latest version using gradle (maven works fine). The flatten plugin takes care of this. See https://maven.apache.org/maven-ci-friendly.html#install-deploy.

Compare the version property in the POM of [1.4](https://github.com/microsoft/dev-tunnels/packages/1375564?version=0.1.4) published from this branch with the POM of [1.3](https://github.com/microsoft/dev-tunnels/packages/1375564?version=0.1.3) from main.