### PR TITLE
Remove unused reference to rustc-serialize

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -64,7 +64,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "rustc-serialize",
  "serde",
  "time",
  "winapi",
@@ -675,12 +674,6 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "ryu"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-chrono = { version = "0.4", features = ["serde", "rustc-serialize"] }
+chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.11", features = ["default", "json"] }
 url = "2"
 opentelemetry = { version = "0.17", features = ["trace"], optional = true }


### PR DESCRIPTION
The `ruestc-serialize` dependency is not used and triggered a dependabot alert: https://github.com/microsoft/dev-tunnels/security/dependabot/6