### PR TITLE
Redact tokens from log, check expiration on client

### DIFF
--- a/cs/src/Management/TunnelAccessTokenProperties.cs
+++ b/cs/src/Management/TunnelAccessTokenProperties.cs
@@ -1,0 +1,226 @@
+﻿// <copyright file="TunnelAccessTokenProperties.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Supports parsing tunnel access token JWT properties to allow for some pre-validation
+/// and diagnostics.
+/// </summary>
+/// <remarks>
+/// Applications generally should not attempt to interpret or rely on any token properties
+/// other than <see cref="TunnelAccessTokenProperties.Expiration" />, because the service
+/// may change or omit those claims in the future. Other claims are exposed here only for
+/// diagnostic purposes.
+/// </remarks> 
+public class TunnelAccessTokenProperties
+{
+    private const string ClusterIdClaimName = "clusterId";
+    private const string TunnelIdClaimName = "tunnelId";
+    private const string TunnelPortClaimName = "tunnelPort";
+    private const string ScopeClaimName = "scp";
+    private const string IssuerClaimName = "iss";
+    private const string ExpirationClaimName = "exp";
+
+    /// <summary>
+    /// Gets or sets the token cluster ID claim.
+    /// </summary>
+    [JsonPropertyName(ClusterIdClaimName)]
+    public string? ClusterId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the token tunnel ID claim.
+    /// </summary>
+    [JsonPropertyName(TunnelIdClaimName)]
+    public string? TunnelId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the token tunnel port claim.
+    /// </summary>
+    [JsonPropertyName(TunnelPortClaimName)]
+    public int? TunnelPort { get; set; }
+
+    /// <summary>
+    /// Gets or sets the token scope claim, as a space-separated list of scope names.
+    /// </summary>
+    [JsonPropertyName(ScopeClaimName)]
+    public string Scope { get; set; } = null!;
+
+    /// <summary>
+    /// Gets the token scopes as a string array.
+    /// </summary>
+    [JsonIgnore]
+    public string[]? Scopes
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(Scope))
+            {
+                return null;
+            }
+
+            return Scope.Split(' ');
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the token issuer URI.
+    /// </summary>
+    [JsonPropertyName(IssuerClaimName)]
+    public string? Issuer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the token expiration timestamp.
+    /// </summary>
+    [JsonPropertyName(ExpirationClaimName)]
+    public int ExpirationTimestamp { get; set; }
+
+    /// <summary>
+    /// Gets the token expiration as a <see cref="System.DateTime" />.
+    /// </summary>
+    [JsonIgnore]
+    public DateTime? Expiration
+    {
+        get
+        {
+            if (ExpirationTimestamp == 0)
+            {
+                return null;
+            }
+
+            return DateTimeOffset.FromUnixTimeSeconds(ExpirationTimestamp).UtcDateTime;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        var s = new StringBuilder();
+
+        if (!string.IsNullOrEmpty(TunnelId))
+        {
+            s.Append("tunnel=");
+            s.Append(TunnelId);
+
+            if (!string.IsNullOrEmpty(ClusterId))
+            {
+                s.Append('.');
+                s.Append(ClusterId);
+            }
+        }
+
+        if (TunnelPort != null)
+        {
+            if (s.Length > 0) s.Append(", ");
+            s.Append("port=");
+            s.Append(TunnelPort);
+        }
+
+        var scopes = Scopes;
+        if (scopes != null)
+        {
+            if (s.Length > 0) s.Append(", ");
+            s.AppendFormat("scopes=[{0}]", string.Join(", ", scopes));
+        }
+
+        if (!string.IsNullOrEmpty(Issuer))
+        {
+            if (s.Length > 0) s.Append(", ");
+            s.Append("issuer=");
+            s.Append(Issuer);
+        }
+
+        var expiration = Expiration;
+        if (expiration != null)
+        {
+            if (s.Length > 0) s.Append(", ");
+
+            // Get the current date-time without fractional seconds.
+            var nowTicks = DateTime.UtcNow.Ticks;
+            var now = new DateTime(nowTicks - nowTicks % 10000000, DateTimeKind.Utc);
+
+            var lifetime = expiration.Value >= now
+                ? (expiration.Value - now).ToString() + " remaining"
+                : (now - expiration.Value) + " ago";
+            s.AppendFormat("expiration={0:s}Z ({1})", expiration.Value, lifetime);
+        }
+
+        return s.ToString();
+    }
+
+    /// <summary>
+    /// Checks if the tunnel access token expiration claim is in the past.
+    /// </summary>
+    /// <exception cref="UnauthorizedAccessException">The token is expired.</exception>
+    /// <remarks>Note this does not throw if the token is an invalid format.</remarks>
+    public static void ValidateTokenExpiration(string token)
+    {
+        var t = TryParse(token);
+        if (t?.Expiration <= DateTime.UtcNow)
+        {
+            throw new UnauthorizedAccessException("The access token is expired: " + t);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to parse a tunnel access token (JWT). This does NOT validate the token
+    /// signature or any claims.
+    /// </summary>
+    /// <returns>The parsed token properties, or null if the token is an invalid format.</returns>
+    /// <remarks>
+    /// Applications generally should not attempt to interpret or rely on any token properties
+    /// other than <see cref="Expiration" />, because the service may change or omit those claims
+    /// in the future. Other claims are exposed here only for diagnostic purposes.
+    /// </remarks>
+    public static TunnelAccessTokenProperties? TryParse(string token)
+    {
+        Requires.NotNullOrEmpty(token, nameof(token));
+
+        // JWTs are encoded in 3 parts: header, body, and signature.
+        var tokenParts = token.Split('.');
+        if (tokenParts.Length != 3)
+        {
+            return null;
+        }
+
+        var tokenBodyJson = Base64UrlDecode(tokenParts[1]);
+        if (tokenBodyJson == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var tokenProperties = JsonSerializer.Deserialize<TunnelAccessTokenProperties>(tokenBodyJson)!;
+            return tokenProperties;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? Base64UrlDecode(string encodedString)
+    {
+        // Convert from base64url encoding to base64 encoding: replace chars and add padding.
+        encodedString = encodedString.Replace('-', '+').Replace('_', '/');
+        encodedString += new string('=', 3 - ((encodedString.Length - 1) % 4));
+
+        try
+        {
+            var bytes = Convert.FromBase64String(encodedString);
+            var result = Encoding.UTF8.GetString(bytes);
+            return result;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+}

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -51,21 +51,21 @@ namespace Microsoft.VsSaaS.TunnelService
             TunnelUserAgent.GetUserAgent(typeof(TunnelManagementClient).Assembly, "Visual-Studio-Tunnel-Service-SDK")!;
 
         private readonly HttpClient httpClient;
-        private readonly Func<Task<AuthenticationHeaderValue?>> accessTokenCallback;
+        private readonly Func<Task<AuthenticationHeaderValue?>> userTokenCallback;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TunnelManagementClient"/> class
         /// with an optional client authentication callback.
         /// </summary>
         /// <param name="userAgent">User agent.</param>
-        /// <param name="accessTokenCallback">Optional async callback for retrieving a client
+        /// <param name="userTokenCallback">Optional async callback for retrieving a client
         /// authentication header, for AAD or GitHub user authentication. This may be null
         /// for anonymous tunnel clients, or if tunnel access tokens will be specified via
         /// <see cref="TunnelRequestOptions.AccessToken"/>.</param>
         public TunnelManagementClient(
             ProductInfoHeaderValue userAgent,
-            Func<Task<AuthenticationHeaderValue?>>? accessTokenCallback = null)
-            : this(new[] { userAgent }, accessTokenCallback, tunnelServiceUri: null, httpHandler: null)
+            Func<Task<AuthenticationHeaderValue?>>? userTokenCallback = null)
+            : this(new[] { userAgent }, userTokenCallback, tunnelServiceUri: null, httpHandler: null)
         {
         }
 
@@ -76,14 +76,14 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <param name="userAgents">User agent. Muiltiple user agents can be supplied in the 
         /// case that this SDK is used in a program, such as a CLI, that has users that want 
         /// to be differentiated. </param>
-        /// <param name="accessTokenCallback">Optional async callback for retrieving a client
+        /// <param name="userTokenCallback">Optional async callback for retrieving a client
         /// authentication header, for AAD or GitHub user authentication. This may be null
         /// for anonymous tunnel clients, or if tunnel access tokens will be specified via
         /// <see cref="TunnelRequestOptions.AccessToken"/>.</param>
         public TunnelManagementClient(
             ProductInfoHeaderValue[] userAgents,
-            Func<Task<AuthenticationHeaderValue?>>? accessTokenCallback = null)
-            : this(userAgents, accessTokenCallback, tunnelServiceUri: null, httpHandler: null)
+            Func<Task<AuthenticationHeaderValue?>>? userTokenCallback = null)
+            : this(userAgents, userTokenCallback, tunnelServiceUri: null, httpHandler: null)
         {
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// with a client authentication callback, service URI, and HTTP handler.
         /// </summary>
         /// <param name="userAgent">User agent.</param>
-        /// <param name="accessTokenCallback">Optional async callback for retrieving a client
+        /// <param name="userTokenCallback">Optional async callback for retrieving a client
         /// authentication header value with access token, for AAD or GitHub user authentication.
         /// This may be null for anonymous tunnel clients, or if tunnel access tokens will be
         /// specified via <see cref="TunnelRequestOptions.AccessToken"/>.</param>
@@ -105,10 +105,10 @@ namespace Microsoft.VsSaaS.TunnelService
         /// by <see cref="Dispose"/>.</param>
         public TunnelManagementClient(
             ProductInfoHeaderValue userAgent,
-            Func<Task<AuthenticationHeaderValue?>>? accessTokenCallback = null,
+            Func<Task<AuthenticationHeaderValue?>>? userTokenCallback = null,
             Uri? tunnelServiceUri = null,
             HttpMessageHandler? httpHandler = null)
-            : this(new[] { userAgent }, accessTokenCallback, tunnelServiceUri, httpHandler)
+            : this(new[] { userAgent }, userTokenCallback, tunnelServiceUri, httpHandler)
         {
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <param name="userAgents">User agent. Muiltiple user agents can be supplied in the 
         /// case that this SDK is used in a program, such as a CLI, that has users that want 
         /// to be differentiated. </param>
-        /// <param name="accessTokenCallback">Optional async callback for retrieving a client
+        /// <param name="userTokenCallback">Optional async callback for retrieving a client
         /// authentication header value with access token, for AAD or GitHub user authentication.
         /// This may be null for anonymous tunnel clients, or if tunnel access tokens will be
         /// specified via <see cref="TunnelRequestOptions.AccessToken"/>.</param>
@@ -132,14 +132,14 @@ namespace Microsoft.VsSaaS.TunnelService
         /// by <see cref="Dispose"/>.</param>
         public TunnelManagementClient(
             ProductInfoHeaderValue[] userAgents,
-            Func<Task<AuthenticationHeaderValue?>>? accessTokenCallback = null,
+            Func<Task<AuthenticationHeaderValue?>>? userTokenCallback = null,
             Uri? tunnelServiceUri = null,
             HttpMessageHandler? httpHandler = null)
         {
             Requires.NotNullEmptyOrNullElements(userAgents, nameof(userAgents));
             UserAgents = Requires.NotNull(userAgents, nameof(userAgents));
 
-            this.accessTokenCallback = accessTokenCallback ??
+            this.userTokenCallback = userTokenCallback ??
                 (() => Task.FromResult<AuthenticationHeaderValue?>(null));
 
             httpHandler ??= new SocketsHttpHandler
@@ -546,13 +546,14 @@ namespace Microsoft.VsSaaS.TunnelService
 
             if (!string.IsNullOrEmpty(options?.AccessToken))
             {
+                TunnelAccessTokenProperties.ValidateTokenExpiration(options.AccessToken);
                 token = new AuthenticationHeaderValue(
                     TunnelAuthenticationScheme, options.AccessToken);
             }
 
             if (token == null)
             {
-                token = await this.accessTokenCallback();
+                token = await this.userTokenCallback();
             }
 
             if (token == null && tunnel?.AccessTokens != null)
@@ -562,6 +563,7 @@ namespace Microsoft.VsSaaS.TunnelService
                     if (tunnel.AccessTokens.TryGetValue(scope, out var accessToken) == true &&
                         !string.IsNullOrEmpty(accessToken))
                     {
+                        TunnelAccessTokenProperties.ValidateTokenExpiration(accessToken);
                         token = new AuthenticationHeaderValue(
                             TunnelAuthenticationScheme, accessToken);
                         break;

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -68,7 +68,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
   };
 
   private ProductHeaderValue[] userAgents;
-  private Supplier<String> accessTokenCallback;
+  private Supplier<String> userTokenCallback;
   private String baseAddress;
 
   public TunnelManagementClient(ProductHeaderValue[] userAgents) {
@@ -77,29 +77,29 @@ public class TunnelManagementClient implements ITunnelManagementClient {
 
   public TunnelManagementClient(
       ProductHeaderValue[] userAgents,
-      Supplier<String> accessTokenCallback) {
-    this(userAgents, accessTokenCallback, null);
+      Supplier<String> userTokenCallback) {
+    this(userAgents, userTokenCallback, null);
   }
 
   /**
    * Initiates a new instance of the TunnelManagementClient class.
    *
-   * @param userAgents          List of User-Agent headers given as a
-   *                            {@link ProductHeaderValue}.
-   * @param accessTokenCallback A callback which should resolve to the
-   *                            Authentication header value.
-   * @param tunnelServiceUri    Uri for the tunnel service. Defaults to the
-   *                            production service url.
+   * @param userAgents        List of User-Agent headers given as a
+   *                          {@link ProductHeaderValue}.
+   * @param userTokenCallback A callback which should resolve to the
+   *                          Authentication header value.
+   * @param tunnelServiceUri  Uri for the tunnel service. Defaults to the
+   *                          production service url.
    */
   public TunnelManagementClient(
       ProductHeaderValue[] userAgents,
-      Supplier<String> accessTokenCallback,
+      Supplier<String> userTokenCallback,
       String tunnelServiceUri) {
     if (userAgents.length == 0) {
       throw new IllegalArgumentException("user agents cannot be empty");
     }
     this.userAgents = userAgents;
-    this.accessTokenCallback = accessTokenCallback != null ? accessTokenCallback : () -> "";
+    this.userTokenCallback = userTokenCallback != null ? userTokenCallback : () -> "";
     this.baseAddress = tunnelServiceUri != null ? tunnelServiceUri : prodServiceUri;
   }
 
@@ -132,7 +132,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
     }
 
     if (StringUtils.isBlank(authHeaderValue)) {
-      authHeaderValue = this.accessTokenCallback.get();
+      authHeaderValue = this.userTokenCallback.get();
     }
 
     if (StringUtils.isBlank(authHeaderValue) && tunnel != null && tunnel.accessTokens != null) {

--- a/ts/src/connections/tunnelRelayTunnelClient.ts
+++ b/ts/src/connections/tunnelRelayTunnelClient.ts
@@ -8,6 +8,7 @@ import {
     TunnelRelayTunnelEndpoint,
     TunnelAccessScopes,
 } from '@vs/tunnels-contracts';
+import { TunnelAccessTokenProperties } from '@vs/tunnels-management';
 import { TraceLevel } from '@vs/vs-ssh';
 import { TunnelRelayStreamFactory, DefaultTunnelRelayStreamFactory } from '.';
 import { TunnelClientBase } from './tunnelClientBase';
@@ -63,7 +64,8 @@ export class TunnelRelayTunnelClient extends TunnelClientBase {
             `Sec-WebSocket-Protocol: ${TunnelRelayTunnelClient.webSocketSubProtocol}`,
         );
         if (accessToken) {
-            this.trace(TraceLevel.Verbose, 0, `Authorization: tunnel ${accessToken}`);
+            const token = TunnelAccessTokenProperties.tryParse(accessToken)?.toString() ?? 'token';
+            this.trace(TraceLevel.Verbose, 0, `Authorization: tunnel <${token}>`);
         }
 
         try {

--- a/ts/src/connections/tunnelRelayTunnelHost.ts
+++ b/ts/src/connections/tunnelRelayTunnelHost.ts
@@ -7,7 +7,7 @@ import {
     TunnelConnectionMode,
     TunnelRelayTunnelEndpoint,
 } from '@vs/tunnels-contracts';
-import { TunnelManagementClient } from '@vs/tunnels-management';
+import { TunnelAccessTokenProperties, TunnelManagementClient } from '@vs/tunnels-management';
 import {
     MultiChannelStream,
     SshChannelOpeningEventArgs,
@@ -95,7 +95,8 @@ export class TunnelRelayTunnelHost extends TunnelHostBase {
             `Sec-WebSocket-Protocol: ${TunnelRelayTunnelHost.webSocketSubProtocol}`,
         );
         if (accessToken) {
-            this.trace(TraceLevel.Verbose, 0, `Authorization: tunnel ${accessToken}`);
+            const token = TunnelAccessTokenProperties.tryParse(accessToken)?.toString() ?? 'token';
+            this.trace(TraceLevel.Verbose, 0, `Authorization: tunnel ${token}`);
         }
 
         try {

--- a/ts/src/management/index.ts
+++ b/ts/src/management/index.ts
@@ -4,3 +4,4 @@
 export * from './tunnelManagementHttpClient';
 export * from './tunnelManagementClient';
 export * from './tunnelRequestOptions';
+export * from './tunnelAccessTokenProperties';

--- a/ts/src/management/tunnelAccessTokenProperties.ts
+++ b/ts/src/management/tunnelAccessTokenProperties.ts
@@ -92,7 +92,6 @@ export class TunnelAccessTokenProperties {
         }
 
         try {
-            const jsonObj = JSON.parse(tokenBodyJson);
             const result = new TunnelAccessTokenProperties();
             Object.assign(result, JSON.parse(tokenBodyJson));
             return result;

--- a/ts/src/management/tunnelAccessTokenProperties.ts
+++ b/ts/src/management/tunnelAccessTokenProperties.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Supports parsing tunnel access token JWT properties to allow for some pre-validation
+ * and diagnostics.
+ *
+ * Applications generally should not attempt to interpret or rely on any token properties
+ * other than `expiration`, because the service may change or omit those claims in the future.
+ * Other claims are exposed here only for diagnostic purposes.
+ */
+export class TunnelAccessTokenProperties {
+    public clusterId?: string;
+    public tunnelId?: string;
+    public tunnelPort?: number;
+    public scp?: string;
+    public iss?: string;
+    public exp?: number;
+
+    public toString(): string {
+        let s = '';
+
+        if (this.tunnelId) {
+            s += 'tunnel=';
+            s += this.tunnelId;
+
+            if (this.clusterId) {
+                s += '.';
+                s += this.clusterId;
+            }
+        }
+
+        if (typeof this.tunnelPort === 'number') {
+            if (s.length > 0) s += ', ';
+            s += 'port=';
+            s += this.tunnelPort;
+        }
+
+        if (this.scp) {
+            if (s.length > 0) s += ', ';
+            const scopes = this.scp.split(' ');
+            s += `scopes=[${scopes.join(', ')}]`;
+        }
+
+        if (this.iss) {
+            if (s.length > 0) s += ', ';
+            s += 'issuer=';
+            s += this.iss;
+        }
+
+        if (this.exp) {
+            if (s.length > 0) s += ', ';
+            const expiration = new Date(this.exp * 1000);
+            s += 'expiration=';
+            s += expiration.toString().replace('.000Z', 'Z');
+        }
+
+        return s;
+    }
+
+    /**
+     * Checks if the tunnel access token expiration claim is in the past.
+     *
+     * (Does not throw if the token is an invalid format.)
+     */
+    public static validateTokenExpiration(token: string): void {
+        const t = TunnelAccessTokenProperties.tryParse(token);
+        if (typeof t?.exp === 'number') {
+            const expiration = new Date(t.exp * 1000);
+            if (expiration < new Date()) {
+                throw new Error('The access token is expired: ' + t);
+            }
+        }
+    }
+
+    /**
+     * Attempts to parse a tunnel access token (JWT). This does NOT validate the token
+     * signature or any claims.
+     */
+    public static tryParse(token: string): TunnelAccessTokenProperties | null {
+        if (typeof token !== 'string') throw new TypeError('Token string expected.');
+
+        // JWTs are encoded in 3 parts: header, body, and signature.
+        const tokenParts = token.split('.');
+        if (tokenParts.length !== 3) {
+            return null;
+        }
+
+        const tokenBodyJson = TunnelAccessTokenProperties.base64UrlDecode(tokenParts[1]);
+        if (!tokenBodyJson) {
+            return null;
+        }
+
+        try {
+            const jsonObj = JSON.parse(tokenBodyJson);
+            const result = new TunnelAccessTokenProperties();
+            Object.assign(result, JSON.parse(tokenBodyJson));
+            return result;
+        } catch {
+            return null;
+        }
+    }
+
+    private static base64UrlDecode(encodedString: string): string | null {
+        // Convert from base64url encoding to base64 encoding: replace chars and add padding.
+        encodedString = encodedString.replace('-', '+');
+        while (encodedString.length % 4 !== 0) {
+            encodedString += '=';
+        }
+
+        try {
+            const result = atob(encodedString);
+            return result;
+        } catch {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/microsoft/basis-planning/issues/88
Fixes: https://github.com/microsoft/basis-planning/issues/224#issuecomment-1197070218

 - Add new `TunnelAccessTokenProperties` class that is capable of parsing tunnel access token JWTs. (Only in C# and TS for now.)
 - Check access token expiration date in the client before attempting to use the token in a request.
    - Note this does not apply to AAD/GH user tokens because those are opaque to us: AAD tokens are encrypted and GH tokens are not JWTs.
 - When tracing TS client requests, replace access token with the token properties. The token properties are helpful for diagnostics but don't need to be kept secret like the actual token. Also redact AAD & GH tokens in the Authorization header.
    - C# client tracing is done via an HTTP handler set up by the CLI, so I'll have a following PR in that repo.
 - Rename `accessTokenCallback` to `userTokenCallback` to more clearly distinguish that the purpose of that callback is to obtain AAD/GH tokens rather than tunnel access tokens.