### PR TITLE
Report connection error status code

### DIFF
--- a/cs/src/Connections/TunnelConnectionException.cs
+++ b/cs/src/Connections/TunnelConnectionException.cs
@@ -4,23 +4,84 @@
 // </copyright>
 
 using System;
+using System.Net;
 
-namespace Microsoft.VsSaaS.TunnelService
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Exception thrown when a host or client failed to connect to a tunnel.
+/// </summary>
+public class TunnelConnectionException : Exception
 {
+    private const string HttpStatusCodeKey = "HttpStatusCode";
+
     /// <summary>
-    /// Exception thrown when a host or client failed to connect to a tunnel.
+    /// Creates a new instance of the <see cref="TunnelConnectionException" /> class
+    /// with a message and optional inner exception.
     /// </summary>
-    public class TunnelConnectionException : Exception
+    /// <param name="message">Exception message.</param>
+    /// <param name="innerException">Optional inner exception.</param>
+    public TunnelConnectionException(string message, Exception? innerException = null)
+        : base(message, innerException)
     {
-        /// <summary>
-        /// Creates a new instance of the <see cref="TunnelConnectionException" /> class
-        /// with a message and optional inner exception.
-        /// </summary>
-        /// <param name="message">Exception message.</param>
-        /// <param name="innerException">Optional inner exception.</param>
-        public TunnelConnectionException(string message, Exception? innerException = null)
-            : base(message, innerException)
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="TunnelConnectionException" /> class
+    /// with a message, HTTP status code, and optional inner exception.
+    /// </summary>
+    /// <param name="message">Exception message.</param>
+    /// <param name="statusCode">HTTP status code.</param>
+    /// <param name="innerException">Optional inner exception.</param>
+    public TunnelConnectionException(
+        string message,
+        HttpStatusCode statusCode,
+        Exception? innerException = null)
+        : this(message, innerException)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>
+    /// Gets the HTTP status code from the exception, or null if no status code is available.
+    /// </summary>
+    public HttpStatusCode? StatusCode { get; private set; }
+
+    internal static TunnelConnectionException FromInnerException(Exception innerException)
+    {
+        var statusCode = GetHttpStatusCode(innerException);
+        if (statusCode == default)
         {
+            return new TunnelConnectionException("Tunnel relay connection failed.", innerException);
         }
+        else
+        {
+            var message = GetMessageForStatusCode(statusCode);
+            return new TunnelConnectionException(message, statusCode, innerException);
+        }
+    }
+
+    private static string GetMessageForStatusCode(HttpStatusCode statusCode)
+    {
+        return statusCode switch
+        {
+            HttpStatusCode.BadRequest => "Connection request was invalid.",
+            HttpStatusCode.Unauthorized => "Connection request was unauthorized.",
+            HttpStatusCode.Forbidden => "Connection request was forbidden.",
+            HttpStatusCode.NotFound => "Tunnel not found.",
+            HttpStatusCode.TooManyRequests => "Connection limit exceeded.",
+            _ => $"Connection failed. Tunnel relay returned status code: {statusCode}",
+        };
+    }
+
+    internal static HttpStatusCode GetHttpStatusCode(Exception ex)
+    {
+        var value = ex.Data[HttpStatusCodeKey];
+        return value is HttpStatusCode ? (HttpStatusCode)value : default;
+    }
+
+    internal static void SetHttpStatusCode(Exception ex, HttpStatusCode statusCode)
+    {
+        ex.Data[HttpStatusCodeKey] = statusCode;
     }
 }

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -11,91 +11,90 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VsSaaS.TunnelService.Contracts;
 
-namespace Microsoft.VsSaaS.TunnelService
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Tunnel client implementation that connects via a tunnel relay.
+/// </summary>
+public class TunnelRelayTunnelClient : TunnelClientBase
 {
     /// <summary>
-    /// Tunnel client implementation that connects via a tunnel relay.
+    /// Web socket sub-protocol to connect to the tunnel relay endpoint.
     /// </summary>
-    public class TunnelRelayTunnelClient : TunnelClientBase
+    public const string WebSocketSubProtocol = "tunnel-relay-client";
+
+    /// <summary>
+    /// Creates a new instance of a client that connects to a tunnel via a tunnel relay.
+    /// </summary>
+    public TunnelRelayTunnelClient(TraceSource trace) : base(trace) { }
+
+    /// <summary>
+    /// Gets or sets a factory for creating relay streams.
+    /// </summary>
+    /// <remarks>
+    /// Normally the default <see cref="TunnelRelayStreamFactory" /> can be used. However a
+    /// different factory class may be used to customize the connection (or mock the connection
+    /// for testing).
+    /// </remarks>
+    public ITunnelRelayStreamFactory StreamFactory { get; set; } = new TunnelRelayStreamFactory();
+
+    /// <inheritdoc />
+    public override IReadOnlyCollection<TunnelConnectionMode> ConnectionModes
+         => new[] { TunnelConnectionMode.TunnelRelay };
+
+    /// <inheritdoc />
+    protected override async Task ConnectAsync(
+        Tunnel tunnel,
+        IEnumerable<TunnelEndpoint> endpoints,
+        CancellationToken cancellation)
     {
-        /// <summary>
-        /// Web socket sub-protocol to connect to the tunnel relay endpoint.
-        /// </summary>
-        public const string WebSocketSubProtocol = "tunnel-relay-client";
+        var endpoint = endpoints
+            .OfType<TunnelRelayTunnelEndpoint>()
+            .SingleOrDefault() ??
+            throw new InvalidOperationException(
+                "The host is not currently accepting Tunnel relay connections.");
 
-        /// <summary>
-        /// Creates a new instance of a client that connects to a tunnel via a tunnel relay.
-        /// </summary>
-        public TunnelRelayTunnelClient(TraceSource trace) : base(trace) { }
+        Requires.Argument(
+            !string.IsNullOrEmpty(endpoint?.ClientRelayUri),
+            nameof(tunnel),
+            $"The tunnel client relay endpoint URI is missing.");
 
-        /// <summary>
-        /// Gets or sets a factory for creating relay streams.
-        /// </summary>
-        /// <remarks>
-        /// Normally the default <see cref="TunnelRelayStreamFactory" /> can be used. However a
-        /// different factory class may be used to customize the connection (or mock the connection
-        /// for testing).
-        /// </remarks>
-        public ITunnelRelayStreamFactory StreamFactory { get; set; } = new TunnelRelayStreamFactory();
+        var clientRelayUri = endpoint.ClientRelayUri;
 
-        /// <inheritdoc />
-        public override IReadOnlyCollection<TunnelConnectionMode> ConnectionModes
-             => new[] { TunnelConnectionMode.TunnelRelay };
+        // The access token might be null if connecting to a tunnel that allows anonymous access.
+        string? accessToken = null!;
+        tunnel.AccessTokens?.TryGetValue(TunnelAccessScopes.Connect, out accessToken);
 
-        /// <inheritdoc />
-        protected override async Task ConnectAsync(
-            Tunnel tunnel,
-            IEnumerable<TunnelEndpoint> endpoints,
-            CancellationToken cancellation)
+        await ConnectAsync(clientRelayUri, accessToken, cancellation);
+    }
+
+    /// <summary>
+    /// Connect to the <paramref name="clientRelayUri"/> using <paramref name="accessToken"/>.
+    /// </summary>
+    protected async Task ConnectAsync(string clientRelayUri, string? accessToken, CancellationToken cancellation)
+    {
+        Requires.NotNullOrEmpty(clientRelayUri, nameof(clientRelayUri));            
+        Trace.TraceInformation("Connecting to client tunnel relay {0}", clientRelayUri);
+        try
         {
-            var endpoint = endpoints
-                .OfType<TunnelRelayTunnelEndpoint>()
-                .SingleOrDefault() ??
-                throw new InvalidOperationException(
-                    "The host is not currently accepting Tunnel relay connections.");
-
-            Requires.Argument(
-                !string.IsNullOrEmpty(endpoint?.ClientRelayUri),
-                nameof(tunnel),
-                $"The tunnel client relay endpoint URI is missing.");
-
-            var clientRelayUri = endpoint.ClientRelayUri;
-
-            // The access token might be null if connecting to a tunnel that allows anonymous access.
-            string? accessToken = null!;
-            tunnel.AccessTokens?.TryGetValue(TunnelAccessScopes.Connect, out accessToken);
-
-            await ConnectAsync(clientRelayUri, accessToken, cancellation);
-        }
-
-        /// <summary>
-        /// Connect to the <paramref name="clientRelayUri"/> using <paramref name="accessToken"/>.
-        /// </summary>
-        protected async Task ConnectAsync(string clientRelayUri, string? accessToken, CancellationToken cancellation)
-        {
-            Requires.NotNullOrEmpty(clientRelayUri, nameof(clientRelayUri));            
-            Trace.TraceInformation("Connecting to client tunnel relay {0}", clientRelayUri);
+            var stream = await StreamFactory.CreateRelayStreamAsync(
+                new Uri(clientRelayUri, UriKind.Absolute),
+                accessToken,
+                WebSocketSubProtocol,
+                cancellation);
             try
             {
-                var stream = await StreamFactory.CreateRelayStreamAsync(
-                    new Uri(clientRelayUri, UriKind.Absolute),
-                    accessToken,
-                    WebSocketSubProtocol,
-                    cancellation);
-                try
-                {
-                    await StartSshSessionAsync(stream, cancellation);
-                }
-                catch
-                {
-                    stream.Dispose();
-                    throw;
-                }
+                await StartSshSessionAsync(stream, cancellation);
             }
-            catch (Exception exception)
+            catch
             {
-                throw new TunnelConnectionException("Failed to connect to tunnel relay.", exception);
+                stream.Dispose();
+                throw;
             }
+        }
+        catch (Exception ex)
+        {
+            throw TunnelConnectionException.FromInnerException(ex);
         }
     }
 }

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,370 +17,369 @@ using Microsoft.VisualStudio.Ssh.Messages;
 using Microsoft.VisualStudio.Ssh.Tcp;
 using Microsoft.VsSaaS.TunnelService.Contracts;
 
-namespace Microsoft.VsSaaS.TunnelService
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Tunnel host implementation that uses data-plane relay
+/// to accept client connections.
+/// </summary>
+public class TunnelRelayTunnelHost : TunnelHostBase
 {
     /// <summary>
-    /// Tunnel host implementation that uses data-plane relay
-    /// to accept client connections.
+    /// Web socket sub-protocol to connect to the tunnel relay endpoint.
     /// </summary>
-    public class TunnelRelayTunnelHost : TunnelHostBase
+    public const string WebSocketSubProtocol = "tunnel-relay-host";
+
+    /// <summary>
+    /// Ssh channel type in host relay ssh session where client session streams are passed.
+    /// </summary>
+    public const string ClientStreamChannelType = "client-ssh-session-stream";
+
+    private readonly CancellationTokenSource disposeCts = new CancellationTokenSource();
+    private readonly IList<Task> clientSessionTasks = new List<Task>();
+    private readonly string hostId;
+
+    private MultiChannelStream? hostSession;
+
+    /// <summary>
+    /// Creates a new instance of a host that connects to a tunnel via a tunnel relay.
+    /// </summary>
+    public TunnelRelayTunnelHost(ITunnelManagementClient managementClient, TraceSource trace)
+        : base(managementClient, trace)
     {
-        /// <summary>
-        /// Web socket sub-protocol to connect to the tunnel relay endpoint.
-        /// </summary>
-        public const string WebSocketSubProtocol = "tunnel-relay-host";
+        this.hostId = MultiModeTunnelHost.HostId;
+    }
 
-        /// <summary>
-        /// Ssh channel type in host relay ssh session where client session streams are passed.
-        /// </summary>
-        public const string ClientStreamChannelType = "client-ssh-session-stream";
+    /// <summary>
+    /// Gets or sets a factory for creating relay streams.
+    /// </summary>
+    /// <remarks>
+    /// Normally the default <see cref="TunnelRelayStreamFactory" /> can be used. However a
+    /// different factory class may be used to customize the connection (or mock the connection
+    /// for testing).
+    /// </remarks>
+    public ITunnelRelayStreamFactory StreamFactory { get; set; } = new TunnelRelayStreamFactory();
 
-        private readonly CancellationTokenSource disposeCts = new CancellationTokenSource();
-        private readonly IList<Task> clientSessionTasks = new List<Task>();
-        private readonly string hostId;
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        this.disposeCts.Cancel();
 
-        private MultiChannelStream? hostSession;
-
-        /// <summary>
-        /// Creates a new instance of a host that connects to a tunnel via a tunnel relay.
-        /// </summary>
-        public TunnelRelayTunnelHost(ITunnelManagementClient managementClient, TraceSource trace)
-            : base(managementClient, trace)
+        var hostSession = this.hostSession;
+        if (hostSession != null)
         {
-            this.hostId = MultiModeTunnelHost.HostId;
+            this.hostSession = null;
+            await hostSession.CloseAsync();
         }
 
-        /// <summary>
-        /// Gets or sets a factory for creating relay streams.
-        /// </summary>
-        /// <remarks>
-        /// Normally the default <see cref="TunnelRelayStreamFactory" /> can be used. However a
-        /// different factory class may be used to customize the connection (or mock the connection
-        /// for testing).
-        /// </remarks>
-        public ITunnelRelayStreamFactory StreamFactory { get; set; } = new TunnelRelayStreamFactory();
-
-        /// <inheritdoc />
-        public override async ValueTask DisposeAsync()
+        List<Task> tasks;
+        lock (this.clientSessionTasks)
         {
-            this.disposeCts.Cancel();
-
-            var hostSession = this.hostSession;
-            if (hostSession != null)
-            {
-                this.hostSession = null;
-                await hostSession.CloseAsync();
-            }
-
-            List<Task> tasks;
-            lock (this.clientSessionTasks)
-            {
-                tasks = new List<Task>(this.clientSessionTasks);
-                this.clientSessionTasks.Clear();
-            }
-
-            if (Tunnel != null)
-            {
-                tasks.Add(ManagementClient.DeleteTunnelEndpointsAsync(Tunnel, this.hostId, TunnelConnectionMode.TunnelRelay));
-            }
-
-            foreach (RemotePortForwarder forwarder in RemoteForwarders.Values)
-            {
-                forwarder.Dispose();
-            }
-
-            while (this.SshSessions.TryTake(out var sshSession))
-            {
-                tasks.Add(sshSession.CloseAsync(SshDisconnectReason.ByApplication));
-            }
-
-            await Task.WhenAll(tasks);
+            tasks = new List<Task>(this.clientSessionTasks);
             this.clientSessionTasks.Clear();
         }
 
-        /// <inheritdoc />
-        protected override async Task StartAsync(Tunnel tunnel, string[]? hostPublicKeys, CancellationToken cancellation)
+        if (Tunnel != null)
         {
-            string? accessToken = null;
-            tunnel.AccessTokens?.TryGetValue(TunnelAccessScopes.Host, out accessToken);
-            Requires.Argument(
-                accessToken != null,
-                nameof(tunnel),
-                $"There is no access token for {nameof(TunnelAccessScopes.Host)} scope on the tunnel.");
+            tasks.Add(ManagementClient.DeleteTunnelEndpointsAsync(Tunnel, this.hostId, TunnelConnectionMode.TunnelRelay));
+        }
 
-            var endpoint = new TunnelRelayTunnelEndpoint
-            {
-                HostId = this.hostId,
-                HostPublicKeys = hostPublicKeys,
-            };
+        foreach (RemotePortForwarder forwarder in RemoteForwarders.Values)
+        {
+            forwarder.Dispose();
+        }
 
-            endpoint = (TunnelRelayTunnelEndpoint)await ManagementClient.UpdateTunnelEndpointAsync(
-                tunnel,
-                endpoint,
-                options: null,
+        while (this.SshSessions.TryTake(out var sshSession))
+        {
+            tasks.Add(sshSession.CloseAsync(SshDisconnectReason.ByApplication));
+        }
+
+        await Task.WhenAll(tasks);
+        this.clientSessionTasks.Clear();
+    }
+
+    /// <inheritdoc />
+    protected override async Task StartAsync(Tunnel tunnel, string[]? hostPublicKeys, CancellationToken cancellation)
+    {
+        string? accessToken = null;
+        tunnel.AccessTokens?.TryGetValue(TunnelAccessScopes.Host, out accessToken);
+        Requires.Argument(
+            accessToken != null,
+            nameof(tunnel),
+            $"There is no access token for {nameof(TunnelAccessScopes.Host)} scope on the tunnel.");
+
+        var endpoint = new TunnelRelayTunnelEndpoint
+        {
+            HostId = this.hostId,
+            HostPublicKeys = hostPublicKeys,
+        };
+
+        endpoint = (TunnelRelayTunnelEndpoint)await ManagementClient.UpdateTunnelEndpointAsync(
+            tunnel,
+            endpoint,
+            options: null,
+            cancellation);
+
+        Tunnel = tunnel;
+
+        Requires.Argument(
+            !string.IsNullOrEmpty(endpoint?.HostRelayUri),
+            nameof(tunnel),
+            $"The tunnel host relay endpoint URI is missing.");
+
+        var hostRelayUri = endpoint.HostRelayUri;
+        Trace.TraceInformation("Connecting to host tunnel relay {0}", hostRelayUri);
+
+        try
+        {
+            var stream = await StreamFactory.CreateRelayStreamAsync(
+                new Uri(hostRelayUri, UriKind.Absolute),
+                accessToken,
+                WebSocketSubProtocol,
                 cancellation);
 
-            Tunnel = tunnel;
-
-            Requires.Argument(
-                !string.IsNullOrEmpty(endpoint?.HostRelayUri),
-                nameof(tunnel),
-                $"The tunnel host relay endpoint URI is missing.");
-
-            var hostRelayUri = endpoint.HostRelayUri;
-            Trace.TraceInformation("Connecting to host tunnel relay {0}", hostRelayUri);
-
+            this.hostSession = new MultiChannelStream(stream, Trace.WithName("HostSSH"));
+            this.hostSession.ChannelOpening += HostSession_ChannelOpening;
+            this.hostSession.Closed += HostSession_Closed;
             try
             {
-                var stream = await StreamFactory.CreateRelayStreamAsync(
-                    new Uri(hostRelayUri, UriKind.Absolute),
-                    accessToken,
-                    WebSocketSubProtocol,
-                    cancellation);
+                await this.hostSession.ConnectAsync(cancellation);
+            }
+            catch
+            {
+                await this.hostSession.CloseAsync();
+                throw;
+            }
+        }
+        catch (Exception ex)
+        {
+            throw TunnelConnectionException.FromInnerException(ex);
+        }
+    }
 
-                this.hostSession = new MultiChannelStream(stream, Trace.WithName("HostSSH"));
-                this.hostSession.ChannelOpening += HostSession_ChannelOpening;
-                this.hostSession.Closed += HostSession_Closed;
-                try
-                {
-                    await this.hostSession.ConnectAsync(cancellation);
-                }
-                catch
-                {
-                    await this.hostSession.CloseAsync();
-                    throw;
-                }
+    private void HostSession_Closed(object? sender, SshSessionClosedEventArgs e)
+    {
+        var session = (MultiChannelStream)sender!;
+        session.Closed -= HostSession_Closed;
+        session.ChannelOpening -= HostSession_ChannelOpening;
+        this.hostSession = null;
+        Trace.TraceInformation("Connection to host tunnel relay closed.");
+    }
+
+    private void HostSession_ChannelOpening(object? sender, SshChannelOpeningEventArgs e)
+    {
+        if (!e.IsRemoteRequest)
+        {
+            // Auto approve all local requests (not that there are any for the time being).
+            return;
+        }
+
+        if (e.Channel.ChannelType != ClientStreamChannelType)
+        {
+            e.FailureDescription = $"Unexpected channel type. Only {ClientStreamChannelType} is supported.";
+            e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
+            return;
+        }
+
+        Task task;
+        lock (this.clientSessionTasks)
+        {
+            if (this.disposeCts.IsCancellationRequested)
+            {
+                e.FailureDescription = $"The host is disconnecting.";
+                e.FailureReason = SshChannelOpenFailureReason.ConnectFailed;
+                return;
+            }
+
+            task = AcceptClientSessionAsync((MultiChannelStream)sender!, this.disposeCts.Token);
+            this.clientSessionTasks.Add(task);
+        }
+
+        task.ContinueWith(RemoveClientSessionTask);
+
+        void RemoveClientSessionTask(Task t)
+        {
+            lock (this.clientSessionTasks)
+            {
+                this.clientSessionTasks.Remove(t);
+            }
+        }
+    }
+
+    private async Task AcceptClientSessionAsync(MultiChannelStream hostSession, CancellationToken cancellation)
+    {
+        try
+        {
+            using var stream = await hostSession.AcceptStreamAsync(ClientStreamChannelType, cancellation);
+            await ConnectAndRunClientSessionAsync(stream, cancellation);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception exception)
+        {
+            Trace.TraceEvent(TraceEventType.Error, 0, "Error running client SSH session: {0}", exception.Message);
+        }
+    }
+
+    private async Task ConnectAndRunClientSessionAsync(Stream stream, CancellationToken cancellation)
+    {
+        var serverConfig = new SshSessionConfiguration();
+
+        // Enable port-forwarding via the SSH protocol.
+        serverConfig.AddService(typeof(PortForwardingService));
+
+        var session = new SshServerSession(serverConfig, Trace.WithName("ClientSSH"));
+        session.Credentials = new SshServerCredentials(this.HostPrivateKey);
+
+        var tcs = new TaskCompletionSource<object?>();
+        using var tokenRegistration = cancellation.CanBeCanceled ?
+            cancellation.Register(() => tcs.TrySetCanceled(cancellation)) : default;
+
+        session.Authenticating += OnSshClientAuthenticating;
+        session.ClientAuthenticated += OnSshClientAuthenticated;
+        session.ChannelOpening += OnSshChannelOpening;
+        session.Closed += Session_Closed;
+
+        try
+        {
+            var portForwardingService = session.ActivateService<PortForwardingService>();
+
+            // All tunnel hosts and clients should disable this because they do not use it (for now) and leaving it enabled is a potential security issue.
+            portForwardingService.AcceptRemoteConnectionsForNonForwardedPorts = false;
+
+            await session.ConnectAsync(stream, cancellation);
+            this.SshSessions.Add(session);
+            await tcs.Task;
+        }
+        finally
+        {
+            session.Authenticating -= OnSshClientAuthenticating;
+            session.ChannelOpening -= OnSshChannelOpening;
+            session.Closed -= Session_Closed;
+        }
+
+        void Session_Closed(object? sender, SshSessionClosedEventArgs e)
+        {
+            if (e.Reason == SshDisconnectReason.ByApplication)
+            {
+                Trace.TraceInformation("Client ssh session closed.");
+            }
+            else if (cancellation.IsCancellationRequested)
+            {
+                Trace.TraceInformation("Client ssh session cancelled.");
+            }
+            else
+            {
+                Trace.TraceEvent(
+                    TraceEventType.Error,
+                    0,
+                    "Client ssh session closed unexpectely due to {0}, \"{1}\"\n{2}",
+                    e.Reason,
+                    e.Message,
+                    e.Exception);
+            }
+
+            tcs.TrySetResult(null);
+        }
+    }
+
+    private void OnSshClientAuthenticating(object? sender, SshAuthenticatingEventArgs e)
+    {
+        if (e.AuthenticationType == SshAuthenticationType.ClientNone)
+        {
+            // For now, the client is allowed to skip SSH authentication;
+            // they must have a valid tunnel access token already to get this far.
+            e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
+        }
+        else
+        {
+            // Other authentication types are not implemented. Doing nothing here
+            // results in a client authentication failure.
+        }
+    }
+
+    private async void OnSshClientAuthenticated(object? sender, EventArgs e)
+    {
+        // After the client session authenicated, automatically start forwarding existing ports.
+        var session = (SshServerSession)sender!;
+        var pfs = session.ActivateService<PortForwardingService>();
+
+        foreach (TunnelPort port in Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>())
+        {
+            try
+            {
+                await ForwardPortAsync(pfs, port, CancellationToken.None);
             }
             catch (Exception exception)
             {
-                throw new TunnelConnectionException("Failed to connect to tunnel relay.", exception);
+                Trace.TraceEvent(
+                    TraceEventType.Error,
+                    0,
+                    "Error forwarding port {0} to client: {1}",
+                    port.PortNumber,
+                    exception.Message);
             }
         }
+    }
 
-        private void HostSession_Closed(object? sender, SshSessionClosedEventArgs e)
+    private void OnSshChannelOpening(object? sender, SshChannelOpeningEventArgs e)
+    {
+        if (e.Request is not PortForwardChannelOpenMessage portForwardRequest)
         {
-            var session = (MultiChannelStream)sender!;
-            session.Closed -= HostSession_Closed;
-            session.ChannelOpening -= HostSession_ChannelOpening;
-            this.hostSession = null;
-            Trace.TraceInformation("Connection to host tunnel relay closed.");
-        }
-
-        private void HostSession_ChannelOpening(object? sender, SshChannelOpeningEventArgs e)
-        {
-            if (!e.IsRemoteRequest)
+            if (e.Request is ChannelOpenMessage channelOpenMessage)
             {
-                // Auto approve all local requests (not that there are any for the time being).
-                return;
-            }
-
-            if (e.Channel.ChannelType != ClientStreamChannelType)
-            {
-                e.FailureDescription = $"Unexpected channel type. Only {ClientStreamChannelType} is supported.";
-                e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
-                return;
-            }
-
-            Task task;
-            lock (this.clientSessionTasks)
-            {
-                if (this.disposeCts.IsCancellationRequested)
+                // This allows the Go SDK to open an unused terminal channel
+                if (channelOpenMessage.ChannelType == "session")
                 {
-                    e.FailureDescription = $"The host is disconnecting.";
+                    return;
+                }
+            }
+
+            Trace.Warning("Rejecting request to open non-portforwarding channel.");
+            e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
+            return;
+        }
+
+        if (portForwardRequest.ChannelType == "direct-tcpip")
+        {
+            if (!Tunnel!.Ports!.Any((p) => p.PortNumber == portForwardRequest.Port))
+            {
+                Trace.Warning("Rejecting request to connect to non-forwarded port:" +
+                    portForwardRequest.Port);
+                e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
+            }
+        }
+        else if (portForwardRequest.ChannelType == "forwarded-tcpip")
+        {
+            if (sender is not SshServerSession sshSession)
+            {
+                Trace.Warning("Rejecting request due to invalid sender");
+                e.FailureReason = SshChannelOpenFailureReason.ConnectFailed;
+                return;
+            }
+            else
+            {
+                var sessionId = sshSession.SessionId;
+                if (sessionId == null)
+                {
+                    Trace.Warning("Rejecting request as session has no Id");
                     e.FailureReason = SshChannelOpenFailureReason.ConnectFailed;
                     return;
                 }
 
-                task = AcceptClientSessionAsync((MultiChannelStream)sender!, this.disposeCts.Token);
-                this.clientSessionTasks.Add(task);
-            }
-
-            task.ContinueWith(RemoveClientSessionTask);
-
-            void RemoveClientSessionTask(Task t)
-            {
-                lock (this.clientSessionTasks)
-                {
-                    this.clientSessionTasks.Remove(t);
-                }
-            }
-        }
-
-        private async Task AcceptClientSessionAsync(MultiChannelStream hostSession, CancellationToken cancellation)
-        {
-            try
-            {
-                using var stream = await hostSession.AcceptStreamAsync(ClientStreamChannelType, cancellation);
-                await ConnectAndRunClientSessionAsync(stream, cancellation);
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception exception)
-            {
-                Trace.TraceEvent(TraceEventType.Error, 0, "Error running client SSH session: {0}", exception.Message);
-            }
-        }
-
-        private async Task ConnectAndRunClientSessionAsync(Stream stream, CancellationToken cancellation)
-        {
-            var serverConfig = new SshSessionConfiguration();
-
-            // Enable port-forwarding via the SSH protocol.
-            serverConfig.AddService(typeof(PortForwardingService));
-
-            var session = new SshServerSession(serverConfig, Trace.WithName("ClientSSH"));
-            session.Credentials = new SshServerCredentials(this.HostPrivateKey);
-
-            var tcs = new TaskCompletionSource<object?>();
-            using var tokenRegistration = cancellation.CanBeCanceled ?
-                cancellation.Register(() => tcs.TrySetCanceled(cancellation)) : default;
-
-            session.Authenticating += OnSshClientAuthenticating;
-            session.ClientAuthenticated += OnSshClientAuthenticated;
-            session.ChannelOpening += OnSshChannelOpening;
-            session.Closed += Session_Closed;
-
-            try
-            {
-                var portForwardingService = session.ActivateService<PortForwardingService>();
-
-                // All tunnel hosts and clients should disable this because they do not use it (for now) and leaving it enabled is a potential security issue.
-                portForwardingService.AcceptRemoteConnectionsForNonForwardedPorts = false;
-
-                await session.ConnectAsync(stream, cancellation);
-                this.SshSessions.Add(session);
-                await tcs.Task;
-            }
-            finally
-            {
-                session.Authenticating -= OnSshClientAuthenticating;
-                session.ChannelOpening -= OnSshChannelOpening;
-                session.Closed -= Session_Closed;
-            }
-
-            void Session_Closed(object? sender, SshSessionClosedEventArgs e)
-            {
-                if (e.Reason == SshDisconnectReason.ByApplication)
-                {
-                    Trace.TraceInformation("Client ssh session closed.");
-                }
-                else if (cancellation.IsCancellationRequested)
-                {
-                    Trace.TraceInformation("Client ssh session cancelled.");
-                }
-                else
-                {
-                    Trace.TraceEvent(
-                        TraceEventType.Error,
-                        0,
-                        "Client ssh session closed unexpectely due to {0}, \"{1}\"\n{2}",
-                        e.Reason,
-                        e.Message,
-                        e.Exception);
-                }
-
-                tcs.TrySetResult(null);
-            }
-        }
-
-        private void OnSshClientAuthenticating(object? sender, SshAuthenticatingEventArgs e)
-        {
-            if (e.AuthenticationType == SshAuthenticationType.ClientNone)
-            {
-                // For now, the client is allowed to skip SSH authentication;
-                // they must have a valid tunnel access token already to get this far.
-                e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
-            }
-            else
-            {
-                // Other authentication types are not implemented. Doing nothing here
-                // results in a client authentication failure.
-            }
-        }
-
-        private async void OnSshClientAuthenticated(object? sender, EventArgs e)
-        {
-            // After the client session authenicated, automatically start forwarding existing ports.
-            var session = (SshServerSession)sender!;
-            var pfs = session.ActivateService<PortForwardingService>();
-
-            foreach (TunnelPort port in Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>())
-            {
-                try
-                {
-                    await ForwardPortAsync(pfs, port, CancellationToken.None);
-                }
-                catch (Exception exception)
-                {
-                    Trace.TraceEvent(
-                        TraceEventType.Error,
-                        0,
-                        "Error forwarding port {0} to client: {1}",
-                        port.PortNumber,
-                        exception.Message);
-                }
-            }
-        }
-
-        private void OnSshChannelOpening(object? sender, SshChannelOpeningEventArgs e)
-        {
-            if (e.Request is not PortForwardChannelOpenMessage portForwardRequest)
-            {
-                if (e.Request is ChannelOpenMessage channelOpenMessage)
-                {
-                    // This allows the Go SDK to open an unused terminal channel
-                    if (channelOpenMessage.ChannelType == "session")
-                    {
-                        return;
-                    }
-                }
-
-                Trace.Warning("Rejecting request to open non-portforwarding channel.");
-                e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
-                return;
-            }
-
-            if (portForwardRequest.ChannelType == "direct-tcpip")
-            {
-                if (!Tunnel!.Ports!.Any((p) => p.PortNumber == portForwardRequest.Port))
+                if (!RemoteForwarders.ContainsKey(new SessionPortKey(sessionId, (ushort)portForwardRequest.Port)))
                 {
                     Trace.Warning("Rejecting request to connect to non-forwarded port:" +
                         portForwardRequest.Port);
                     e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
                 }
             }
-            else if (portForwardRequest.ChannelType == "forwarded-tcpip")
-            {
-                if (sender is not SshServerSession sshSession)
-                {
-                    Trace.Warning("Rejecting request due to invalid sender");
-                    e.FailureReason = SshChannelOpenFailureReason.ConnectFailed;
-                    return;
-                }
-                else
-                {
-                    var sessionId = sshSession.SessionId;
-                    if (sessionId == null)
-                    {
-                        Trace.Warning("Rejecting request as session has no Id");
-                        e.FailureReason = SshChannelOpenFailureReason.ConnectFailed;
-                        return;
-                    }
-
-                    if (!RemoteForwarders.ContainsKey(new SessionPortKey(sessionId, (ushort)portForwardRequest.Port)))
-                    {
-                        Trace.Warning("Rejecting request to connect to non-forwarded port:" +
-                            portForwardRequest.Port);
-                        e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
-                    }
-                }
-            }
-            else
-            {
-                Trace.Warning("Nonrecognized channel type " + portForwardRequest.ChannelType);
-                e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
-            }
+        }
+        else
+        {
+            Trace.Warning("Nonrecognized channel type " + portForwardRequest.ChannelType);
+            e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
         }
     }
 }

--- a/cs/src/Connections/WebSocketStream.cs
+++ b/cs/src/Connections/WebSocketStream.cs
@@ -6,457 +6,449 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.VsSaaS.TunnelService
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Wraps a <see cref="WebSocket"/> to adapt it to <see cref="Stream"/>.
+/// </summary>
+/// <remarks>
+/// Cancelling reads or writes will abort the web socket connection.
+/// If backs SshSession when it is closed, SshSession cancels the read from the stream, which will abort the web socket.
+/// </remarks>
+public class WebSocketStream : Stream
 {
     /// <summary>
-    /// Wraps a <see cref="WebSocket"/> to adapt it to <see cref="Stream"/>.
+    /// Maximum length of close description. Everything longer will be truncted.
+    /// </summary>
+    public const int CloseDescriptionMaxLength = 123;
+
+    private const int LastWriteTimeoutBeforeCloseMs = 15_000;
+    private const int CloseTimeoutMs = 15_000;
+
+    private readonly object lockObject = new object();
+    private readonly CancellationTokenSource writeCts = new CancellationTokenSource();
+    private readonly TaskCompletionSource<object?> disposeCompletion = new TaskCompletionSource<object?>();
+
+    // Thread-safety:
+    // - It's acceptable to call ReceiveAsync and SendAsync in parallel.  One of each may run concurrently.
+    // - It's acceptable to have a pending ReceiveAsync while CloseOutputAsync or CloseAsync is called.
+    // - Attempting to invoke any other operations in parallel may corrupt the instance.  Attempting to invoke
+    //   a send operation while another is in progress or a receive operation while another is in progress will
+    //   result in an exception.
+    private readonly WebSocket socket;
+
+    private WebSocketCloseStatus? closeStatus;
+    private string? closeStatusDescription;
+    private Task? lastWriteTask;
+    private bool isDisposed;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="WebSocket"/> wrapping connected <paramref name="socket"/>.
+    /// If the <paramref name="socket"/> is not in <see cref="WebSocketState.Open"/> it will be closed.
+    /// </summary>
+    /// <param name="socket">Web socket to wrap.</param>
+    /// <exception cref="ArgumentNullException">If <paramref name="socket"/> is null.</exception>
+    /// <exception cref="ArgumentException">If <paramref name="socket"/> has not connected yet (i.e in <see cref="WebSocketState.Connecting"/> state).</exception>
+    public WebSocketStream(WebSocket socket)
+    {
+        this.socket = Requires.NotNull(socket, nameof(socket));
+        Requires.Argument(socket.State != WebSocketState.Connecting, nameof(socket), "The web socket has not connected yet.");
+        if (socket.State != WebSocketState.Open)
+        {
+            Close();
+        }
+    }
+
+    /// <summary>
+    /// Current web socket close status or null if not closed.
+    /// </summary>
+    public WebSocketCloseStatus? CloseStatus
+    {
+        get => this.socket.CloseStatus;
+        set => this.closeStatus = value;
+    }
+
+    /// <summary>
+    /// Current web socket close status description..
+    /// </summary>
+    public string? CloseStatusDescription
+    {
+        get => this.socket.CloseStatusDescription;
+        set => this.closeStatusDescription = value;
+    }
+
+    /// <summary>
+    /// Connect to web socket.
+    /// </summary>
+    public static async Task<WebSocketStream> ConnectToWebSocketAsync(
+        Uri uri,
+        Action<ClientWebSocketOptions>? configure = default,
+        CancellationToken cancellation = default)
+    {
+        var socket = new ClientWebSocket();
+        try
+        {
+            configure?.Invoke(socket.Options);
+            await socket.ConnectAsync(uri, cancellation);
+            return new WebSocketStream(socket);
+        }
+        catch (WebSocketException wse)
+        when (wse.WebSocketErrorCode == WebSocketError.NotAWebSocket)
+        {
+            // ClientWebSocket.HttpStatusCode will be available in the future:
+            // https://github.com/dotnet/runtime/issues/25918
+            // Until then, the status code can be parsed from the exception message.
+            var statusCodeMessage = "server returned status code '";
+            var messageIndex = wse.Message.IndexOf(statusCodeMessage);
+            if (messageIndex > 0)
+            {
+                var offset = messageIndex + statusCodeMessage.Length;
+                var length = 3; // Length of numeric HTTP status code.
+                if (offset + length < wse.Message.Length && wse.Message[offset + length] == '\'')
+                {
+                    var statusCodeString = wse.Message.Substring(offset, length);
+                    if (Enum.TryParse<HttpStatusCode>(statusCodeString, out var statusCode))
+                    {
+                        TunnelConnectionException.SetHttpStatusCode(wse, statusCode);
+                    }
+                }
+            }
+
+            socket.Dispose();
+            throw;
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Close stream and the web socket with <paramref name="closeStatus"/> and <paramref name="closeStatusDescription"/>.
     /// </summary>
     /// <remarks>
-    /// Cancelling reads or writes will abort the web socket connection.
-    /// If backs SshSession when it is closed, SshSession cancels the read from the stream, which will abort the web socket.
+    /// If the socket is already closed, this is no-op, <see cref="CloseStatus"/> and <see cref="CloseStatusDescription"/> do not change.
     /// </remarks>
-    public class WebSocketStream : Stream
+    public ValueTask CloseAsync(WebSocketCloseStatus closeStatus, string? closeStatusDescription = default)
     {
-        /// <summary>
-        /// Maximum length of close description. Everything longer will be truncted.
-        /// </summary>
-        public const int CloseDescriptionMaxLength = 123;
+        this.closeStatus = closeStatus;
+        this.closeStatusDescription = closeStatusDescription;
+        return DisposeAsync();
+    }
 
-        private const int LastWriteTimeoutBeforeCloseMs = 15_000;
-        private const int CloseTimeoutMs = 15_000;
-
-        private readonly object lockObject = new object();
-        private readonly CancellationTokenSource writeCts = new CancellationTokenSource();
-        private readonly TaskCompletionSource<object?> disposeCompletion = new TaskCompletionSource<object?>();
-
-        // Thread-safety:
-        // - It's acceptable to call ReceiveAsync and SendAsync in parallel.  One of each may run concurrently.
-        // - It's acceptable to have a pending ReceiveAsync while CloseOutputAsync or CloseAsync is called.
-        // - Attempting to invoke any other operations in parallel may corrupt the instance.  Attempting to invoke
-        //   a send operation while another is in progress or a receive operation while another is in progress will
-        //   result in an exception.
-        private readonly WebSocket socket;
-
-        private WebSocketCloseStatus? closeStatus;
-        private string? closeStatusDescription;
-        private Task? lastWriteTask;
-        private bool isDisposed;
-
-        /// <summary>
-        /// Creates a new instance of <see cref="WebSocket"/> wrapping connected <paramref name="socket"/>.
-        /// If the <paramref name="socket"/> is not in <see cref="WebSocketState.Open"/> it will be closed.
-        /// </summary>
-        /// <param name="socket">Web socket to wrap.</param>
-        /// <exception cref="ArgumentNullException">If <paramref name="socket"/> is null.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="socket"/> has not connected yet (i.e in <see cref="WebSocketState.Connecting"/> state).</exception>
-        public WebSocketStream(WebSocket socket)
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !this.isDisposed)
         {
-            this.socket = Requires.NotNull(socket, nameof(socket));
-            Requires.Argument(socket.State != WebSocketState.Connecting, nameof(socket), "The web socket has not connected yet.");
-            if (socket.State != WebSocketState.Open)
+            DisposeAsync().AsTask().Wait();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask DisposeAsync()
+    {
+        Task? lastWriteTask = null;
+        bool disposing = false;
+        if (!this.isDisposed)
+        {
+            lock (this.lockObject)
             {
-                Close();
+                disposing = !this.isDisposed;
+                this.isDisposed = true;
+                lastWriteTask = this.lastWriteTask;
             }
         }
 
-        /// <summary>
-        /// Current web socket close status or null if not closed.
-        /// </summary>
-        public WebSocketCloseStatus? CloseStatus
+        if (!disposing)
         {
-            get => this.socket.CloseStatus;
-            set => this.closeStatus = value;
+            await this.disposeCompletion.Task;
+            return;
         }
 
-        /// <summary>
-        /// Current web socket close status description..
-        /// </summary>
-        public string? CloseStatusDescription
+        // We cannot write in parallel with closing the socket, so we need to wait for the last write task.
+        // We will give it some timeout if there is no debugger attached.
+        if (lastWriteTask != null)
         {
-            get => this.socket.CloseStatusDescription;
-            set => this.closeStatusDescription = value;
-        }
+            if (!Debugger.IsAttached)
+            {
+                this.writeCts.CancelAfter(LastWriteTimeoutBeforeCloseMs);
+            }
 
-        /// <summary>
-        /// Connect to web socket.
-        /// </summary>
-        public static async Task<WebSocketStream> ConnectToWebSocketAsync(Uri uri, Action<ClientWebSocketOptions>? configure = default, CancellationToken cancellation = default)
-        {
-            var socket = new ClientWebSocket();
             try
             {
-                configure?.Invoke(socket.Options);
-                await socket.ConnectAsync(uri, cancellation);
-                return new WebSocketStream(socket);
+                await lastWriteTask.ConfigureAwait(false);
             }
             catch
             {
-                socket.Dispose();
-                throw;
+                // Ignore exceptions here. The caller of the last write will observer them.
             }
         }
 
-        /// <summary>
-        /// Close stream and the web socket with <paramref name="closeStatus"/> and <paramref name="closeStatusDescription"/>.
-        /// </summary>
-        /// <remarks>
-        /// If the socket is already closed, this is no-op, <see cref="CloseStatus"/> and <see cref="CloseStatusDescription"/> do not change.
-        /// </remarks>
-        public ValueTask CloseAsync(WebSocketCloseStatus closeStatus, string? closeStatusDescription = default)
+        this.writeCts.Dispose();
+
+        if (this.socket.State != WebSocketState.Closed && this.socket.State != WebSocketState.Aborted)
         {
-            this.closeStatus = closeStatus;
-            this.closeStatusDescription = closeStatusDescription;
-            return DisposeAsync();
-        }
-
-        /// <inheritdoc/>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && !this.isDisposed)
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            try
             {
-                DisposeAsync().AsTask().Wait();
-            }
+                // The socket must be in one of the following states now. It's OK to call CloseAsync on it.
+                // WebSocketState.Open, WebSocketState.CloseReceived, WebSocketState.CloseSent
 
-            base.Dispose(disposing);
-        }
+                var closeStatus = this.closeStatus ?? WebSocketCloseStatus.NormalClosure;
+                string? closeStatusDescription =
+                    this.closeStatusDescription == null ? null :
+                    this.closeStatusDescription.Length <= CloseDescriptionMaxLength ? this.closeStatusDescription :
+                    this.closeStatusDescription.Substring(0, CloseDescriptionMaxLength);
 
-        /// <inheritdoc/>
-        public override async ValueTask DisposeAsync()
-        {
-            Task? lastWriteTask = null;
-            bool disposing = false;
-            if (!this.isDisposed)
-            {
-                lock (this.lockObject)
-                {
-                    disposing = !this.isDisposed;
-                    this.isDisposed = true;
-                    lastWriteTask = this.lastWriteTask;
-                }
-            }
-
-            if (!disposing)
-            {
-                await this.disposeCompletion.Task;
-                return;
-            }
-
-            // We cannot write in parallel with closing the socket, so we need to wait for the last write task.
-            // We will give it some timeout if there is no debugger attached.
-            if (lastWriteTask != null)
-            {
                 if (!Debugger.IsAttached)
                 {
-                    this.writeCts.CancelAfter(LastWriteTimeoutBeforeCloseMs);
+                    cts.CancelAfter(CloseTimeoutMs);
                 }
 
-                try
-                {
-                    await lastWriteTask.ConfigureAwait(false);
-                }
-                catch
-                {
-                    // Ignore exceptions here. The caller of the last write will observer them.
-                }
-            }
-
-            this.writeCts.Dispose();
-
-            if (this.socket.State != WebSocketState.Closed && this.socket.State != WebSocketState.Aborted)
-            {
-                using CancellationTokenSource cts = new CancellationTokenSource();
-                try
-                {
-                    // The socket must be in one of the following states now. It's OK to call CloseAsync on it.
-                    // WebSocketState.Open, WebSocketState.CloseReceived, WebSocketState.CloseSent
-
-                    var closeStatus = this.closeStatus ?? WebSocketCloseStatus.NormalClosure;
-                    string? closeStatusDescription =
-                        this.closeStatusDescription == null ? null :
-                        this.closeStatusDescription.Length <= CloseDescriptionMaxLength ? this.closeStatusDescription :
-                        this.closeStatusDescription.Substring(0, CloseDescriptionMaxLength);
-
-                    if (!Debugger.IsAttached)
-                    {
-                        cts.CancelAfter(CloseTimeoutMs);
-                    }
-
-                    await this.socket.CloseAsync(closeStatus, closeStatusDescription, cts.Token).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Timed out waiting for close handshake.
-                }
-                catch (ObjectDisposedException)
-                {
-                    // Already disposed.
-                }
-                catch (WebSocketException wse)
-                when (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
-                {
-                    // Other party closed connection prematurely.
-                }
-                catch (Exception)
-                {
-                    // TODO: log the exception.
-                    // Do not throw from DisposeAsync.
-                }
-            }
-
-            this.socket.Dispose();
-            await base.DisposeAsync();
-            this.disposeCompletion.TrySetResult(null);
-        }
-
-        /// <inheritdoc/>
-        public override bool CanRead => !this.isDisposed;
-
-        /// <inheritdoc/>
-        public override bool CanSeek => false;
-
-        /// <inheritdoc/>
-        public override bool CanWrite => !this.isDisposed;
-
-        /// <inheritdoc/>
-        public override bool CanTimeout => false;
-
-        /// <inheritdoc/>
-        public override long Length =>
-            throw new InvalidOperationException();
-
-        /// <inheritdoc/>
-        public override long Position
-        {
-            get => throw new InvalidOperationException();
-            set => throw new InvalidOperationException();
-        }
-
-        /// <inheritdoc/>
-        public override void Flush()
-        {
-            ThrowIfDisposed();
-        }
-
-        /// <inheritdoc/>
-        public override Task FlushAsync(CancellationToken cancellationToken)
-        {
-            ThrowIfDisposed();
-            return Task.CompletedTask;
-        }
-
-        /// <inheritdoc/>
-        public override int Read(byte[] buffer, int offset, int count) =>
-            ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
-
-        /// <inheritdoc/>
-        public override long Seek(long offset, SeekOrigin origin) =>
-            throw new InvalidOperationException();
-
-        /// <inheritdoc/>
-        public override void SetLength(long value) =>
-            throw new InvalidOperationException();
-
-        /// <inheritdoc/>
-        public override void Write(byte[] buffer, int offset, int count) =>
-            WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
-
-        /// <inheritdoc/>
-        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            Requires.NotNull(buffer, nameof(buffer));
-            Requires.Range(offset >= 0 && offset < buffer.Length, nameof(offset));
-            Requires.Range(count >= 0 && count <= buffer.Length - offset, nameof(count));
-
-            if (!CanReadFromSocket)
-            {
-                return 0;
-            }
-
-            try
-            {
-                Task<WebSocketReceiveResult> task;
-                lock (this.lockObject)
-                {
-                    if (!CanReadFromSocket)
-                    {
-                        return 0;
-                    }
-
-                    task = this.socket.ReceiveAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
-                }
-
-                var result = await task.ConfigureAwait(false);
-                if (result.MessageType == WebSocketMessageType.Close)
-                {
-                    // Other party is closing the socket.
-                    Close();
-                    return 0;
-                }
-
-                return result.Count;
+                await this.socket.CloseAsync(closeStatus, closeStatusDescription, cts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
-                // Cancellation requested or socket was closed.
-                // If the socket was closed, treat this as the end of the stream.
-                if (!CanReadFromSocket)
-                {
-                    return 0;
-                }
-
-                throw;
+                // Timed out waiting for close handshake.
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed.
             }
             catch (WebSocketException wse)
             when (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
             {
                 // Other party closed connection prematurely.
-                Close();
-                return 0;
+            }
+            catch (Exception)
+            {
+                // TODO: log the exception.
+                // Do not throw from DisposeAsync.
             }
         }
 
-        /// <inheritdoc/>
-        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        this.socket.Dispose();
+        await base.DisposeAsync();
+        this.disposeCompletion.TrySetResult(null);
+    }
+
+    /// <inheritdoc/>
+    public override bool CanRead => !this.isDisposed;
+
+    /// <inheritdoc/>
+    public override bool CanSeek => false;
+
+    /// <inheritdoc/>
+    public override bool CanWrite => !this.isDisposed;
+
+    /// <inheritdoc/>
+    public override bool CanTimeout => false;
+
+    /// <inheritdoc/>
+    public override long Length =>
+        throw new InvalidOperationException();
+
+    /// <inheritdoc/>
+    public override long Position
+    {
+        get => throw new InvalidOperationException();
+        set => throw new InvalidOperationException();
+    }
+
+    /// <inheritdoc/>
+    public override void Flush()
+    {
+        ThrowIfDisposed();
+    }
+
+    /// <inheritdoc/>
+    public override Task FlushAsync(CancellationToken cancellationToken)
+    {
+        ThrowIfDisposed();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public override int Read(byte[] buffer, int offset, int count) =>
+        ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
+
+    /// <inheritdoc/>
+    public override long Seek(long offset, SeekOrigin origin) =>
+        throw new InvalidOperationException();
+
+    /// <inheritdoc/>
+    public override void SetLength(long value) =>
+        throw new InvalidOperationException();
+
+    /// <inheritdoc/>
+    public override void Write(byte[] buffer, int offset, int count) =>
+        WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
+
+    /// <inheritdoc/>
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        Requires.NotNull(buffer, nameof(buffer));
+        Requires.Range(offset >= 0 && offset < buffer.Length, nameof(offset));
+        Requires.Range(count >= 0 && count <= buffer.Length - offset, nameof(count));
+
+        if (!CanReadFromSocket)
         {
-            if (!CanReadFromSocket)
+            return 0;
+        }
+
+        try
+        {
+            Task<WebSocketReceiveResult> task;
+            lock (this.lockObject)
             {
-                return 0;
-            }
-
-            try
-            {
-                ValueTask<ValueWebSocketReceiveResult> task;
-                lock (this.lockObject)
-                {
-                    if (!CanReadFromSocket)
-                    {
-                        return 0;
-                    }
-
-                    task = this.socket.ReceiveAsync(buffer, cancellationToken);
-                }
-
-                var result = await task.ConfigureAwait(false);
-                if (result.MessageType == WebSocketMessageType.Close)
-                {
-                    // Other party is closing the socket.
-                    Close();
-                    return 0;
-                }
-
-                return result.Count;
-            }
-            catch (OperationCanceledException)
-            {
-                // Cancellation requested or socket was closed.
-                // If the socket was closed, treat this as the end of the stream.
                 if (!CanReadFromSocket)
                 {
                     return 0;
                 }
 
-                throw;
+                task = this.socket.ReceiveAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
             }
-            catch (WebSocketException wse)
-            when (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
+
+            var result = await task.ConfigureAwait(false);
+            if (result.MessageType == WebSocketMessageType.Close)
             {
-                // Other party closed connection prematurely.
+                // Other party is closing the socket.
                 Close();
                 return 0;
             }
+
+            return result.Count;
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation requested or socket was closed.
+            // If the socket was closed, treat this as the end of the stream.
+            if (!CanReadFromSocket)
+            {
+                return 0;
+            }
+
+            throw;
+        }
+        catch (WebSocketException wse)
+        when (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
+        {
+            // Other party closed connection prematurely.
+            Close();
+            return 0;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (!CanReadFromSocket)
+        {
+            return 0;
         }
 
-        /// <inheritdoc/>
-        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        try
         {
-            Requires.NotNull(buffer, nameof(buffer));
-            Requires.Range(offset >= 0 && offset < buffer.Length, nameof(offset));
-            Requires.Range(count >= 0 && count <= buffer.Length - offset, nameof(count));
-
-            ThrowIfCannotWrite();
-
-            var cts = cancellationToken.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.writeCts.Token) : default;
-            Task? writeTask = null;
-            try
+            ValueTask<ValueWebSocketReceiveResult> task;
+            lock (this.lockObject)
             {
-                lock (this.lockObject)
+                if (!CanReadFromSocket)
                 {
-                    ThrowIfCannotWrite();
-
-                    writeTask = this.socket.SendAsync(
-                        new ArraySegment<byte>(buffer, offset, count),
-                        WebSocketMessageType.Binary,
-                        true /* end of message */,
-                        cancellationToken.CanBeCanceled ? cts!.Token : this.writeCts.Token);
-
-                    this.lastWriteTask = writeTask;
+                    return 0;
                 }
 
-                await writeTask.ConfigureAwait(false);
+                task = this.socket.ReceiveAsync(buffer, cancellationToken);
             }
-            catch (OperationCanceledException oce)
-            when (this.writeCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+
+            var result = await task.ConfigureAwait(false);
+            if (result.MessageType == WebSocketMessageType.Close)
             {
-                // Other thread is trying to dispose and is cancelling this write.
-                // Report that the object is disposed to the caller.
-                throw new ObjectDisposedException(GetType().Name, oce);
-            }
-            catch (WebSocketException wse)
-            {
+                // Other party is closing the socket.
                 Close();
-                if (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
-                {
-                    // Socket closed prematurely, treat as if the connection closed.
-                    throw new ObjectDisposedException(GetType().Name, wse);
-                }
-
-                throw;
+                return 0;
             }
-            finally
-            {
-                if (writeTask != null)
-                {
-                    lock (this.lockObject)
-                    {
-                        if (this.lastWriteTask == writeTask)
-                        {
-                            this.lastWriteTask = null;
-                        }
-                    }
-                }
 
-                cts?.Dispose();
-            }
+            return result.Count;
         }
-
-        /// <inheritdoc/>
-        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        catch (OperationCanceledException)
         {
-            ThrowIfCannotWrite();
-
-            var cts = cancellationToken.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.writeCts.Token) : default;
-            Task? writeTask = null;
-            try
+            // Cancellation requested or socket was closed.
+            // If the socket was closed, treat this as the end of the stream.
+            if (!CanReadFromSocket)
             {
-                lock (this.lockObject)
-                {
-                    ThrowIfCannotWrite();
+                return 0;
+            }
 
-                    writeTask = this.socket.SendAsync(
-                        buffer,
-                        WebSocketMessageType.Binary,
-                        true /* end of message */,
-                        cancellationToken.CanBeCanceled ? cts!.Token : this.writeCts.Token).AsTask();
+            throw;
+        }
+        catch (WebSocketException wse)
+        when (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
+        {
+            // Other party closed connection prematurely.
+            Close();
+            return 0;
+        }
+    }
 
-                    this.lastWriteTask = writeTask;
-                }
+    /// <inheritdoc/>
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        Requires.NotNull(buffer, nameof(buffer));
+        Requires.Range(offset >= 0 && offset < buffer.Length, nameof(offset));
+        Requires.Range(count >= 0 && count <= buffer.Length - offset, nameof(count));
 
-                await writeTask.ConfigureAwait(false);
+        ThrowIfCannotWrite();
 
+        var cts = cancellationToken.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.writeCts.Token) : default;
+        Task? writeTask = null;
+        try
+        {
+            lock (this.lockObject)
+            {
+                ThrowIfCannotWrite();
+
+                writeTask = this.socket.SendAsync(
+                    new ArraySegment<byte>(buffer, offset, count),
+                    WebSocketMessageType.Binary,
+                    true /* end of message */,
+                    cancellationToken.CanBeCanceled ? cts!.Token : this.writeCts.Token);
+
+                this.lastWriteTask = writeTask;
+            }
+
+            await writeTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException oce)
+        when (this.writeCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // Other thread is trying to dispose and is cancelling this write.
+            // Report that the object is disposed to the caller.
+            throw new ObjectDisposedException(GetType().Name, oce);
+        }
+        catch (WebSocketException wse)
+        {
+            Close();
+            if (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
+            {
+                // Socket closed prematurely, treat as if the connection closed.
+                throw new ObjectDisposedException(GetType().Name, wse);
+            }
+
+            throw;
+        }
+        finally
+        {
+            if (writeTask != null)
+            {
                 lock (this.lockObject)
                 {
                     if (this.lastWriteTask == writeTask)
@@ -465,60 +457,96 @@ namespace Microsoft.VsSaaS.TunnelService
                     }
                 }
             }
-            catch (OperationCanceledException oce)
-            when (this.writeCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-            {
-                // Other thread is trying to dispose and is cancelling this write.
-                // Report that the object is disposed to the caller.
-                throw new ObjectDisposedException(GetType().Name, oce);
-            }
-            catch (WebSocketException wse)
-            {
-                Close();
-                if (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
-                {
-                    // Socket closed prematurely, treat as if the connection closed.
-                    throw new ObjectDisposedException(GetType().Name, wse);
-                }
 
-                throw;
-            }
-            finally
+            cts?.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        ThrowIfCannotWrite();
+
+        var cts = cancellationToken.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.writeCts.Token) : default;
+        Task? writeTask = null;
+        try
+        {
+            lock (this.lockObject)
             {
-                if (writeTask != null)
+                ThrowIfCannotWrite();
+
+                writeTask = this.socket.SendAsync(
+                    buffer,
+                    WebSocketMessageType.Binary,
+                    true /* end of message */,
+                    cancellationToken.CanBeCanceled ? cts!.Token : this.writeCts.Token).AsTask();
+
+                this.lastWriteTask = writeTask;
+            }
+
+            await writeTask.ConfigureAwait(false);
+
+            lock (this.lockObject)
+            {
+                if (this.lastWriteTask == writeTask)
                 {
-                    lock (this.lockObject)
+                    this.lastWriteTask = null;
+                }
+            }
+        }
+        catch (OperationCanceledException oce)
+        when (this.writeCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // Other thread is trying to dispose and is cancelling this write.
+            // Report that the object is disposed to the caller.
+            throw new ObjectDisposedException(GetType().Name, oce);
+        }
+        catch (WebSocketException wse)
+        {
+            Close();
+            if (wse.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
+            {
+                // Socket closed prematurely, treat as if the connection closed.
+                throw new ObjectDisposedException(GetType().Name, wse);
+            }
+
+            throw;
+        }
+        finally
+        {
+            if (writeTask != null)
+            {
+                lock (this.lockObject)
+                {
+                    if (this.lastWriteTask == writeTask)
                     {
-                        if (this.lastWriteTask == writeTask)
-                        {
-                            this.lastWriteTask = null;
-                        }
+                        this.lastWriteTask = null;
                     }
                 }
-
-                cts?.Dispose();
             }
+
+            cts?.Dispose();
         }
+    }
 
-        private bool CanReadFromSocket =>
-            (this.socket.State == WebSocketState.Open || this.socket.State == WebSocketState.CloseSent) &&
-            !this.isDisposed;
+    private bool CanReadFromSocket =>
+        (this.socket.State == WebSocketState.Open || this.socket.State == WebSocketState.CloseSent) &&
+        !this.isDisposed;
 
-        private void ThrowIfCannotWrite()
+    private void ThrowIfCannotWrite()
+    {
+        ThrowIfDisposed();
+        if (this.socket.State != WebSocketState.Open && this.socket.State != WebSocketState.CloseReceived)
         {
-            ThrowIfDisposed();
-            if (this.socket.State != WebSocketState.Open && this.socket.State != WebSocketState.CloseReceived)
-            {
-                throw new ObjectDisposedException(GetType().Name);
-            }
+            throw new ObjectDisposedException(GetType().Name);
         }
+    }
 
-        private void ThrowIfDisposed()
+    private void ThrowIfDisposed()
+    {
+        if (this.isDisposed)
         {
-            if (this.isDisposed)
-            {
-                throw new ObjectDisposedException(GetType().Name);
-            }
+            throw new ObjectDisposedException(GetType().Name);
         }
     }
 }


### PR DESCRIPTION
When a websocket connection to the relay fails, check the HTTP status code and use that to generate a better error message in the `TunnelConnectionException`. That exception message will also be displayed by the CLI.