### PR TITLE
Do not check host RemoteForwarders when PFS channel opens

### DIFF
--- a/cs/src/Connections/TunnelHostBase.cs
+++ b/cs/src/Connections/TunnelHostBase.cs
@@ -191,6 +191,12 @@ namespace Microsoft.VsSaaS.TunnelService
                 return;
             }
 
+            // Capture the remote forwarder for the session id / remote port pair.
+            // This is needed later to stop forwarding for this port when the remote forwarder is disposed.
+            // Note when the client tries to open an SSH channel to PFS, the port forwarding service checks
+            // its remoteConnectors whether the port is being forwarded.
+            // Disposing of the RemotePortForwarder stops the forwarding and removes the remote connector
+            // from PFS.remoteConnectors.
             RemoteForwarders.TryAdd(
                 new SessionPortKey(sessionId, (ushort)forwarder.RemotePort),
                 forwarder);

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -458,12 +458,14 @@ namespace Microsoft.VsSaaS.TunnelService
                         return;
                     }
 
-                    if (!RemoteForwarders.ContainsKey(new SessionPortKey(sessionId, (ushort)portForwardRequest.Port)))
-                    {
-                        Trace.Warning("Rejecting request to connect to non-forwarded port:" +
-                            portForwardRequest.Port);
-                        e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
-                    }
+                    // Do not check RemoteForwarders because they may not be updated yet.
+                    // There is a small time interval in ForwardPortAsync() between the port
+                    // being forwarded with ForwardFromRemotePortAsync() and RemoteForwarders updated.
+                    // See https://github.com/microsoft/basis-planning/issues/467
+
+                    // Setting PFS.AcceptRemoteConnectionsForNonForwardedPorts to false makes PFS reject forwarding requests from the
+                    // clients for the ports that are not forwarded and are missing in PFS.remoteConnectors.
+                    // Call to PFS.ForwardFromRemotePortAsync() in ForwardPortAsync() adds the connector to PFS.remoteConnectors.
                 }
             }
             else

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -443,8 +443,6 @@ namespace Microsoft.VsSaaS.TunnelService
             // For forwarded-tcpip do not check RemoteForwarders because they may not be updated yet.
             // There is a small time interval in ForwardPortAsync() between the port
             // being forwarded with ForwardFromRemotePortAsync() and RemoteForwarders updated.
-            // See https://github.com/microsoft/basis-planning/issues/467
-
             // Setting PFS.AcceptRemoteConnectionsForNonForwardedPorts to false makes PFS reject forwarding requests from the
             // clients for the ports that are not forwarded and are missing in PFS.remoteConnectors.
             // Call to PFS.ForwardFromRemotePortAsync() in ForwardPortAsync() adds the connector to PFS.remoteConnectors.

--- a/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
@@ -763,6 +763,33 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
     }
 
     [Fact]
+    public async Task ConnectRelayHostThenConnectRelayClientToDifferentPort_Fails()
+    {
+        var managementClient = new MockTunnelManagementClient();
+        managementClient.HostRelayUri = MockHostRelayUri;
+        var relayHost = new TunnelRelayTunnelHost(managementClient, TestTS);
+
+        var port = GetAvailableTcpPort();
+        var tunnel = CreateRelayTunnel(port);
+
+        using var multiChannelStream = await StartRelayHostAsync(relayHost, tunnel);
+
+        using var clientRelayStream = await multiChannelStream.OpenStreamAsync(
+            TunnelRelayTunnelHost.ClientStreamChannelType);
+
+        using var clientSshSession = CreateSshClientSession();
+        await clientSshSession.ConnectAsync(clientRelayStream).WithTimeout(Timeout);
+        var clientCredentials = new SshClientCredentials("tunnel", password: null);
+        await clientSshSession.AuthenticateAsync(clientCredentials);
+
+        await clientSshSession.WaitForForwardedPortAsync(port, TimeoutToken);
+
+        var differentPort = port < 60_000 ? port + 1 : port - 1;
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => clientSshSession.ConnectToForwardedPortAsync(differentPort, TimeoutToken));
+    }
+
+    [Fact]
     public async Task ConnectRelayHostAddPort()
     {
         var managementClient = new MockTunnelManagementClient();


### PR DESCRIPTION
There is a small time interval in `ForwardPortAsync()` between the port being forwarded with `ForwardFromRemotePortAsync()` and `RemoteForwarders` updated.

See https://github.com/microsoft/basis-planning/issues/467

The check is redundant because setting `AcceptRemoteConnectionsForNonForwardedPorts` to false makes PFS reject forwarding requests from the clients for the ports that are not forwarded and are missing in `PFS.remoteConnectors`.
Call to `PFS.ForwardFromRemotePortAsync()` in `ForwardPortAsync()` adds the connector to `PFS.remoteConnectors`.