### PR TITLE
Add event to enable observing & cancelling tunnel connection retries

### DIFF
--- a/cs/src/Connections/IRelayClient.cs
+++ b/cs/src/Connections/IRelayClient.cs
@@ -46,4 +46,9 @@ internal interface IRelayClient
     /// Refresh tunnel access token. This may be useful when the Relay service responds with 401 Unauthorized.
     /// </summary>
     Task<bool> RefreshTunnelAccessTokenAsync(CancellationToken cancellation);
+
+    /// <summary>
+    /// Notifies about a connection retry, giving the relay client a chance to delay or cancel it.
+    /// </summary>
+    void OnRetrying(RetryingTunnelConnectionEventArgs e);
 }

--- a/cs/src/Connections/MultiModeTunnelClient.cs
+++ b/cs/src/Connections/MultiModeTunnelClient.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VsSaaS.TunnelService
     /// <summary>
     /// Tunnel client implementation that selects one of multiple available connection modes.
     /// </summary>
-    public class MultiModeTunnelClient : TunnelBase, ITunnelClient
+    public class MultiModeTunnelClient : TunnelConnection, ITunnelClient
     {
         /// <summary>
         /// Creates a new instance of the <see cref="MultiModeTunnelClient" /> class

--- a/cs/src/Connections/MultiModeTunnelHost.cs
+++ b/cs/src/Connections/MultiModeTunnelHost.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VsSaaS.TunnelService
     /// <summary>
     /// Aggregation of multiple tunnel hosts.
     /// </summary>
-    public class MultiModeTunnelHost : TunnelBase, ITunnelHost
+    public class MultiModeTunnelHost : TunnelConnection, ITunnelHost
     {
         /// <summary>
         /// Gets or sets a host ID. An initial value is automatically generated for the process.

--- a/cs/src/Connections/RelayTunnelConnector.cs
+++ b/cs/src/Connections/RelayTunnelConnector.cs
@@ -23,15 +23,11 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
     private const int ReconnectInitialDelayMs = 100;
 
     private readonly IRelayClient relayClient;
-    private readonly Action<RetryingTunnelConnectionEventArgs> retryHandler;
 
-    public RelayTunnelConnector(
-        IRelayClient relayClient,
-        Action<RetryingTunnelConnectionEventArgs> retryHandler)
+    public RelayTunnelConnector(IRelayClient relayClient)
     {
         this.relayClient = Requires.NotNull(relayClient, nameof(relayClient));
         Requires.NotNull(relayClient.Trace, nameof(IRelayClient.Trace));
-        this.retryHandler = Requires.NotNull(retryHandler, nameof(retryHandler));
     }
 
     private TraceSource Trace => this.relayClient.Trace;
@@ -173,7 +169,7 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
             {
                 var retryDelay = TimeSpan.FromMilliseconds(isDelayNeeded ? attemptDelayMs : 0);
                 var retryingArgs = new RetryingTunnelConnectionEventArgs(exception, retryDelay);
-                this.retryHandler(retryingArgs);
+                this.relayClient.OnRetrying(retryingArgs);
                 if (!retryingArgs.Retry)
                 {
                     throw exception;

--- a/cs/src/Connections/RelayTunnelConnector.cs
+++ b/cs/src/Connections/RelayTunnelConnector.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,24 +23,30 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
     private const int ReconnectInitialDelayMs = 100;
 
     private readonly IRelayClient relayClient;
+    private readonly Action<RetryingTunnelConnectionEventArgs> retryHandler;
 
-    public RelayTunnelConnector(IRelayClient relayClient)
+    public RelayTunnelConnector(
+        IRelayClient relayClient,
+        Action<RetryingTunnelConnectionEventArgs> retryHandler)
     {
         this.relayClient = Requires.NotNull(relayClient, nameof(relayClient));
         Requires.NotNull(relayClient.Trace, nameof(IRelayClient.Trace));
+        this.retryHandler = Requires.NotNull(retryHandler, nameof(retryHandler));
     }
 
     private TraceSource Trace => this.relayClient.Trace;
 
     /// <inheritdoc/>
-    public async Task ConnectSessionAsync(bool isReconnect, CancellationToken cancellation)
+    public async Task ConnectSessionAsync(
+        bool isReconnect,
+        CancellationToken cancellation)
     {
         int attempt = 0;
-        int attempDelayMs = ReconnectInitialDelayMs;
+        int attemptDelayMs = ReconnectInitialDelayMs;
         bool isTunnelAccessTokenRefreshed = false;
 
         bool isDelayNeeded;
-        object? errorDescription;
+        string? errorDescription;
         SshDisconnectReason disconnectReason;
         Exception? exception;
 
@@ -94,25 +101,29 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
 
                 if (wse.WebSocketErrorCode == WebSocketError.NotAWebSocket)
                 {
-                    int? statusCode = wse.Data.Contains("HttpStatusCode") ? (int)wse.Data["HttpStatusCode"]! : null;
+                    var statusCode = TunnelConnectionException.GetHttpStatusCode(wse);
                     switch (statusCode)
                     {
-                        case 401:
+                        case HttpStatusCode.Unauthorized:
                             // Unauthorized error may happen when the tunnel access token is no longer valid, e.g. expired.
                             // Try refreshing it.
                             await RefreshTunnelAccessTokenAsync(wse);
+                            exception = new UnauthorizedAccessException(
+                                $"Unauthorized (401). Provide a fresh tunnel access token with '{this.relayClient.TunnelAccessScope}' scope.",
+                                wse);
                             break;
 
-                        case 403:
+                        case HttpStatusCode.Forbidden:
                             throw exception = new UnauthorizedAccessException(
                                 $"Forbidden (403). Provide a fresh tunnel access token with '{this.relayClient.TunnelAccessScope}' scope.", 
                                 wse);
 
-                        case 404:
+                        case HttpStatusCode.NotFound:
                             throw exception = new TunnelConnectionException($"The tunnel or port is not found (404).", wse);
 
-                        case 429:
+                        case HttpStatusCode.TooManyRequests:
                             errorDescription = "Rate limit exceeded (429). Too many requests in a given amount of time.";
+                            exception = new TunnelConnectionException(errorDescription, wse);
                             break;
 
                         default:
@@ -122,8 +133,8 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
                 }
 
                 // Other web socket errors may be recoverable
+                exception ??= wse;
                 errorDescription ??= wse.Message;
-                exception = wse;
             }
             catch (OperationCanceledException)
             {
@@ -142,7 +153,7 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
                     throw;
                 }
 
-                errorDescription = ex;
+                errorDescription = ex.Message;
                 exception = ex;
             }
             finally
@@ -158,21 +169,38 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
                 }
             }
 
-            var retryTiming = isDelayNeeded ? $" in {(attempDelayMs < 1000 ? $"0.{attempDelayMs / 100}s" : $"{attempDelayMs / 1000}s")}" : string.Empty;
+            if (exception != null)
+            {
+                var retryDelay = TimeSpan.FromMilliseconds(isDelayNeeded ? attemptDelayMs : 0);
+                var retryingArgs = new RetryingTunnelConnectionEventArgs(exception, retryDelay);
+                this.retryHandler(retryingArgs);
+                if (!retryingArgs.Retry)
+                {
+                    throw exception;
+                }
+                else if (retryingArgs.Delay >= TimeSpan.Zero)
+                {
+                    attemptDelayMs = (int)retryingArgs.Delay.TotalMilliseconds;
+                    isDelayNeeded = attemptDelayMs > 0;
+                }
+            }
+
+            var retryTiming = isDelayNeeded ? $" in {(attemptDelayMs < 1000 ? $"0.{attemptDelayMs / 100}s" : $"{attemptDelayMs / 1000}s")}" : string.Empty;
             Trace.Verbose($"Error connecting to tunnel SSH session, retrying{retryTiming}{(errorDescription != null ? $": {errorDescription}" : string.Empty)}");
 
             if (isDelayNeeded)
             {
-                await Task.Delay(attempDelayMs, cancellation);
+                await Task.Delay(attemptDelayMs, cancellation);
                 if (attempt < ReconnectAttemptsDoublingDelay)
                 {
-                    attempDelayMs <<= 1;
+                    attemptDelayMs <<= 1;
                 }
             }
 
             async Task RefreshTunnelAccessTokenAsync(Exception exception)
             {
-                var statusCode = exception.Data.Contains("HttpStatusCode") ? $" ({exception.Data["HttpStatusCode"]})" : string.Empty;
+                var statusCode = TunnelConnectionException.GetHttpStatusCode(exception);
+                var statusCodeText = statusCode != default ? $" ({(int)statusCode})" : string.Empty;
                 if (!isTunnelAccessTokenRefreshed)
                 {
                     try

--- a/cs/src/Connections/RetryingTunnelConnectionEventArgs.cs
+++ b/cs/src/Connections/RetryingTunnelConnectionEventArgs.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="RetryingTunnelConnectionEventArgs.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Event args for tunnel connection retry event.
+/// </summary>
+public class RetryingTunnelConnectionEventArgs : EventArgs
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="RetryingTunnelConnectionEventArgs"/> class.
+    /// </summary>
+    public RetryingTunnelConnectionEventArgs(Exception exception, TimeSpan delay)
+    {
+        Exception = Requires.NotNull(exception, nameof(exception));
+        Retry = true;
+    }
+
+    /// <summary>
+    /// Gets the exception that caused the retry.
+    /// </summary>
+    /// <remarks>
+    /// For an au
+    /// </remarks>
+    public Exception Exception { get; }
+
+    /// <summary>
+    /// Gets the amount of time to wait before retrying. An event handler may change this value
+    /// to adjust the delay.
+    /// </summary>
+    public TimeSpan Delay { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the retry will proceed. An event handler may
+    /// set this to false to stop retrying.
+    /// </summary>
+    public bool Retry { get; set; }
+}

--- a/cs/src/Connections/TunnelBase.cs
+++ b/cs/src/Connections/TunnelBase.cs
@@ -138,6 +138,14 @@ public abstract class TunnelBase : IAsyncDisposable
     public event EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken;
 
     /// <summary>
+    /// Event raised when a tunnel connection attempt failed and is about to be retried.
+    /// </summary>
+    /// <remarks>
+    /// An event handler can cancel the retry by setting <see cref="RetryingTunnelConnectionEventArgs.Retry"/> to false.
+    /// </remarks>
+    public event EventHandler<RetryingTunnelConnectionEventArgs>? RetryingTunnelConnection;
+
+    /// <summary>
     /// Connection status changed event.
     /// </summary>
     public event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
@@ -346,5 +354,13 @@ public abstract class TunnelBase : IAsyncDisposable
         {
             this.reconnectTask = null;
         }
+    }
+
+    /// <summary>
+    /// Raise an event that allows event-handlers to be aware of retry and potentially cancel it.
+    /// </summary>
+    internal void OnRetrying(RetryingTunnelConnectionEventArgs e)
+    {
+        RetryingTunnelConnection?.Invoke(this, e);
     }
 }

--- a/cs/src/Connections/TunnelClient.cs
+++ b/cs/src/Connections/TunnelClient.cs
@@ -23,14 +23,14 @@ namespace Microsoft.VsSaaS.TunnelService;
 /// <summary>
 /// Base class for clients that connect to a single host
 /// </summary>
-public abstract class TunnelClientBase : TunnelBase, ITunnelClient
+public abstract class TunnelClient : TunnelConnection, ITunnelClient
 {
     private bool acceptLocalConnectionsForForwardedPorts = true;
 
     /// <summary>
-    /// Creates a new instance of the <see cref="TunnelClientBase" /> class.
+    /// Creates a new instance of the <see cref="TunnelClient" /> class.
     /// </summary>
-    public TunnelClientBase(ITunnelManagementClient? managementClient, TraceSource trace) : base(managementClient, trace)
+    public TunnelClient(ITunnelManagementClient? managementClient, TraceSource trace) : base(managementClient, trace)
     {
     }
 
@@ -129,7 +129,7 @@ public abstract class TunnelClientBase : TunnelBase, ITunnelClient
     /// </summary>
     /// <remarks>
     /// Overwrites <see cref="SshSession"/> property.
-    /// SSH session reconnect is enabled only if <see cref="TunnelBase.connector"/> is not null.
+    /// SSH session reconnect is enabled only if <see cref="TunnelConnection.connector"/> is not null.
     /// </remarks>
     protected async Task StartSshSessionAsync(Stream stream, CancellationToken cancellation)
     {

--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -357,7 +357,7 @@ public abstract class TunnelConnection : IAsyncDisposable
     }
 
     /// <summary>
-    /// Raise an event that allows event-handlers to be aware of retry and potentially cancel it.
+    /// Notifies about a connection retry, giving the application a chance to delay or cancel it.
     /// </summary>
     internal void OnRetrying(RetryingTunnelConnectionEventArgs e)
     {

--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -15,16 +15,16 @@ namespace Microsoft.VsSaaS.TunnelService;
 /// <summary>
 /// Base class for tunnel client and host.
 /// </summary>
-public abstract class TunnelBase : IAsyncDisposable
+public abstract class TunnelConnection : IAsyncDisposable
 {
     private readonly CancellationTokenSource disposeCts = new();
     private Task? reconnectTask;
     private ConnectionStatus connectionStatus;
 
     /// <summary>
-    /// Creates a new instance of the <see cref="TunnelBase"/> class.
+    /// Creates a new instance of the <see cref="TunnelConnection"/> class.
     /// </summary>
-    public TunnelBase(ITunnelManagementClient? managementClient, TraceSource trace)
+    public TunnelConnection(ITunnelManagementClient? managementClient, TraceSource trace)
     {
         ManagementClient = managementClient;
         Trace = Requires.NotNull(trace, nameof(trace));

--- a/cs/src/Connections/TunnelConnectionException.cs
+++ b/cs/src/Connections/TunnelConnectionException.cs
@@ -4,23 +4,65 @@
 // </copyright>
 
 using System;
+using System.Net;
 
-namespace Microsoft.VsSaaS.TunnelService
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Exception thrown when a host or client failed to connect to a tunnel.
+/// </summary>
+public class TunnelConnectionException : Exception
 {
+    private const string HttpStatusCodeKey = "HttpStatusCode";
+
     /// <summary>
-    /// Exception thrown when a host or client failed to connect to a tunnel.
+    /// Creates a new instance of the <see cref="TunnelConnectionException" /> class
+    /// with a message and optional inner exception.
     /// </summary>
-    public class TunnelConnectionException : Exception
+    /// <param name="message">Exception message.</param>
+    /// <param name="innerException">Optional inner exception.</param>
+    public TunnelConnectionException(string message, Exception? innerException = null)
+        : base(message, innerException)
     {
-        /// <summary>
-        /// Creates a new instance of the <see cref="TunnelConnectionException" /> class
-        /// with a message and optional inner exception.
-        /// </summary>
-        /// <param name="message">Exception message.</param>
-        /// <param name="innerException">Optional inner exception.</param>
-        public TunnelConnectionException(string message, Exception? innerException = null)
-            : base(message, innerException)
+        if (innerException != null)
         {
+            var statusCode = GetHttpStatusCode(innerException);
+            if (statusCode != default)
+            {
+                StatusCode = statusCode;
+            }
         }
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="TunnelConnectionException" /> class
+    /// with a message, HTTP status code, and optional inner exception.
+    /// </summary>
+    /// <param name="message">Exception message.</param>
+    /// <param name="statusCode">HTTP status code.</param>
+    /// <param name="innerException">Optional inner exception.</param>
+    public TunnelConnectionException(
+        string message,
+        HttpStatusCode statusCode,
+        Exception? innerException = null)
+        : this(message, innerException)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>
+    /// Gets the HTTP status code from the exception, or null if no status code is available.
+    /// </summary>
+    public HttpStatusCode? StatusCode { get; private set; }
+
+    internal static HttpStatusCode GetHttpStatusCode(Exception ex)
+    {
+        var value = ex.Data[HttpStatusCodeKey];
+        return value is HttpStatusCode ? (HttpStatusCode)value : default;
+    }
+
+    internal static void SetHttpStatusCode(Exception ex, HttpStatusCode statusCode)
+    {
+        ex.Data[HttpStatusCodeKey] = statusCode;
     }
 }

--- a/cs/src/Connections/TunnelHost.cs
+++ b/cs/src/Connections/TunnelHost.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VsSaaS.TunnelService
     /// <summary>
     /// Base class for Hosts that host one tunnel
     /// </summary>
-    public abstract class TunnelHostBase : TunnelBase, ITunnelHost
+    public abstract class TunnelHost : TunnelConnection, ITunnelHost
     {
         /// <summary>
         /// Sessions created between this host and clients. Lock on this hash set to be thread-safe.
@@ -29,9 +29,9 @@ namespace Microsoft.VsSaaS.TunnelService
         protected HashSet<SshServerSession> sshSessions = new();
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TunnelHostBase" /> class.
+        /// Creates a new instance of the <see cref="TunnelHost" /> class.
         /// </summary>
-        public TunnelHostBase(ITunnelManagementClient managementClient, TraceSource trace) : base(managementClient, trace)
+        public TunnelHost(ITunnelManagementClient managementClient, TraceSource trace) : base(managementClient, trace)
         {
         }
 

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -92,7 +92,7 @@ namespace Microsoft.VsSaaS.TunnelService
             Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken);
             this.relayUri = new Uri(endpoint.ClientRelayUri, UriKind.Absolute);
 
-            ITunnelConnector result = new RelayTunnelConnector(this, OnRetrying);
+            ITunnelConnector result = new RelayTunnelConnector(this);
             return Task.FromResult(result);
         }
 
@@ -107,7 +107,7 @@ namespace Microsoft.VsSaaS.TunnelService
                 {
                     this.relayUri = new Uri(clientRelayUri, UriKind.Absolute);
                     this.accessToken = accessToken;
-                    this.connector = new RelayTunnelConnector(this, OnRetrying);
+                    this.connector = new RelayTunnelConnector(this);
                     return this.connector.ConnectSessionAsync(isReconnect: false, cancellation);
                 },
                 cancellation);
@@ -165,6 +165,9 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <inheritdoc />
         Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>
             RefreshTunnelAccessTokenAsync(cancellation);
+
+        /// <inheritdoc />
+        void IRelayClient.OnRetrying(RetryingTunnelConnectionEventArgs e) => OnRetrying(e);
 
         #endregion IRelayClient
     }

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VsSaaS.TunnelService
     /// <summary>
     /// Tunnel client implementation that connects via a tunnel relay.
     /// </summary>
-    public class TunnelRelayTunnelClient : TunnelClientBase, IRelayClient
+    public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
     {
         /// <summary>
         /// Web socket sub-protocol to connect to the tunnel relay endpoint.

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -92,7 +92,7 @@ namespace Microsoft.VsSaaS.TunnelService
             Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken);
             this.relayUri = new Uri(endpoint.ClientRelayUri, UriKind.Absolute);
 
-            ITunnelConnector result = new RelayTunnelConnector(this);
+            ITunnelConnector result = new RelayTunnelConnector(this, OnRetrying);
             return Task.FromResult(result);
         }
 
@@ -107,7 +107,7 @@ namespace Microsoft.VsSaaS.TunnelService
                 {
                     this.relayUri = new Uri(clientRelayUri, UriKind.Absolute);
                     this.accessToken = accessToken;
-                    this.connector = new RelayTunnelConnector(this);
+                    this.connector = new RelayTunnelConnector(this, OnRetrying);
                     return this.connector.ConnectSessionAsync(isReconnect: false, cancellation);
                 },
                 cancellation);

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -127,7 +127,7 @@ namespace Microsoft.VsSaaS.TunnelService
 
             this.relayUri = new Uri(endpoint.HostRelayUri, UriKind.Absolute);
 
-            return new RelayTunnelConnector(this, OnRetrying);
+            return new RelayTunnelConnector(this);
         }
 
         /// <summary>
@@ -184,6 +184,9 @@ namespace Microsoft.VsSaaS.TunnelService
         /// <inheritdoc />
         Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>
             RefreshTunnelAccessTokenAsync(cancellation);
+
+        /// <inheritdoc />
+        void IRelayClient.OnRetrying(RetryingTunnelConnectionEventArgs e) => OnRetrying(e);
 
         #endregion IRelayClient
 

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -127,7 +127,7 @@ namespace Microsoft.VsSaaS.TunnelService
 
             this.relayUri = new Uri(endpoint.HostRelayUri, UriKind.Absolute);
 
-            return new RelayTunnelConnector(this);
+            return new RelayTunnelConnector(this, OnRetrying);
         }
 
         /// <summary>
@@ -420,7 +420,7 @@ namespace Microsoft.VsSaaS.TunnelService
                 if (e.Request is ChannelOpenMessage channelOpenMessage)
                 {
                     // This allows the Go SDK to open an unused terminal channel
-                    if (channelOpenMessage.ChannelType == "session")
+                    if (channelOpenMessage.ChannelType == SshChannel.SessionChannelType)
                     {
                         return;
                     }

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VsSaaS.TunnelService
     /// Tunnel host implementation that uses data-plane relay
     /// to accept client connections.
     /// </summary>
-    public class TunnelRelayTunnelHost : TunnelHostBase, IRelayClient
+    public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
     {
         /// <summary>
         /// Web socket sub-protocol to connect to the tunnel relay endpoint.

--- a/cs/src/Connections/WebSocketStream.cs
+++ b/cs/src/Connections/WebSocketStream.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Net;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -113,7 +114,7 @@ namespace Microsoft.VsSaaS.TunnelService
                             out var statusCode) &&
                         statusCode != 101)
                     {
-                        wse.Data["HttpStatusCode"] = statusCode;
+                        TunnelConnectionException.SetHttpStatusCode(wse, (HttpStatusCode)statusCode);
                         socket.Dispose();
                         throw wse;
                     }


### PR DESCRIPTION
 - Add `RetryingTunnelConnection` event on the base connection class, and update `RelayTunnelConnector` to invoke the event when processing retries.
 - Rename `TunnelBase` -> `TunnelConnection` because it has the connection behavior that is shared between host and client subclasses. (It's not the base of a Tunnel.) Also rename `TunnelHostBase`->`TunnelHost` and `TunnelClientBase`->`TunnelClient` because the "Base" suffix is not conventionally used in public APIs.
 - Refactor get/set of HTTP status code for an exception, and expose that as a property on `TunnelConnectionException`.