### PR TITLE
rs: re-add support for async auth providers

### DIFF
--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -10,6 +10,7 @@ reqwest = { version = "0.11", features = ["default", "json"] }
 url = "2"
 opentelemetry = { version = "0.17", features = ["trace"], optional = true }
 serde_json = "1"
+async-trait = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["rt", "macros"] }

--- a/rs/src/management/authorization.rs
+++ b/rs/src/management/authorization.rs
@@ -1,3 +1,7 @@
+use async_trait::async_trait;
+
+use super::HttpError;
+
 #[derive(Clone)]
 pub enum Authorization {
     /// No authorization.
@@ -21,5 +25,19 @@ impl Authorization {
             Authorization::Bearer(token) => Some(format!("bearer {}", token)),
             Authorization::Anonymous => None,
         }
+    }
+}
+
+#[async_trait]
+pub trait AuthorizationProvider: Send + Sync {
+    async fn get_authorization(&self) -> Result<Authorization, HttpError>;
+}
+
+pub(crate) struct StaticAuthorizationProvider(pub Authorization);
+
+#[async_trait]
+impl AuthorizationProvider for StaticAuthorizationProvider {
+    async fn get_authorization(&self) -> Result<Authorization, HttpError> {
+        Ok(self.0.clone())
     }
 }

--- a/rs/src/management/errors.rs
+++ b/rs/src/management/errors.rs
@@ -19,14 +19,13 @@ pub enum HttpError {
     /// An error returned from the remote server.
     ResponseError(ResponseError),
     /// An error was returned from the authorization callback.
-    AuthorizationError(Box<dyn Error>),
+    AuthorizationError(String),
 }
 
 impl Error for HttpError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             HttpError::ConnectionError(e) => Some(e),
-            HttpError::AuthorizationError(e) => Some(e.as_ref()),
             _ => None,
         }
     }

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+use std::sync::Arc;
+
 use reqwest::{
     header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE},
     Client, Method, Request,
@@ -14,13 +16,14 @@ use crate::contracts::{
 };
 
 use super::{
-    Authorization, HttpError, HttpResult, ResponseError, TunnelLocator, TunnelRequestOptions,
+    Authorization, AuthorizationProvider, HttpError, HttpResult, ResponseError, TunnelLocator,
+    TunnelRequestOptions,
 };
 
 #[derive(Clone)]
 pub struct TunnelManagementClient {
     client: Client,
-    authorization: Authorization,
+    authorization: Arc<Box<dyn AuthorizationProvider>>,
     user_agent: HeaderValue,
     environment: TunnelServiceProperties,
 }
@@ -411,8 +414,8 @@ impl TunnelManagementClient {
         let headers = request.headers_mut();
         headers.insert("User-Agent", self.user_agent.clone());
 
-        if let Some(a) = &self.authorization.as_header() {
-            headers.insert(AUTHORIZATION, HeaderValue::from_str(a).unwrap());
+        if let Some(a) = self.authorization.get_authorization().await?.as_header() {
+            headers.insert(AUTHORIZATION, HeaderValue::from_str(&a).unwrap());
         }
 
         Ok(request)
@@ -430,7 +433,7 @@ where
 }
 
 pub struct TunnelClientBuilder {
-    authorization: Authorization,
+    authorization: Box<dyn AuthorizationProvider>,
     client: Option<Client>,
     user_agent: HeaderValue,
     environment: TunnelServiceProperties,
@@ -440,7 +443,7 @@ pub struct TunnelClientBuilder {
 /// to get the client instance (or cast automatically).
 pub fn new_tunnel_management(user_agent: &str) -> TunnelClientBuilder {
     TunnelClientBuilder {
-        authorization: Authorization::Anonymous,
+        authorization: Box::new(super::StaticAuthorizationProvider(Authorization::Anonymous)),
         client: None,
         user_agent: HeaderValue::from_str(user_agent).unwrap(),
         environment: env_production(),
@@ -449,7 +452,15 @@ pub fn new_tunnel_management(user_agent: &str) -> TunnelClientBuilder {
 
 impl TunnelClientBuilder {
     pub fn authorization(&mut self, authorization: Authorization) -> &mut Self {
-        self.authorization = authorization;
+        self.authorization = Box::new(super::StaticAuthorizationProvider(authorization));
+        self
+    }
+
+    pub fn authorization_provider(
+        &mut self,
+        provider: impl AuthorizationProvider + 'static,
+    ) -> &mut Self {
+        self.authorization = Box::new(provider);
         self
     }
 
@@ -467,7 +478,7 @@ impl TunnelClientBuilder {
 impl From<TunnelClientBuilder> for TunnelManagementClient {
     fn from(builder: TunnelClientBuilder) -> Self {
         TunnelManagementClient {
-            authorization: builder.authorization,
+            authorization: Arc::new(builder.authorization),
             client: builder.client.unwrap_or_else(Client::new),
             user_agent: builder.user_agent,
             environment: builder.environment,


### PR DESCRIPTION
Using a trait here works _much_ better than trying to take a free-floating function. Making the trait as `Send + Sync` requires it to be usable and sendable on multiple threads, which avoids the previous issues we faced.

Consumers can implement the trait like so,

```rs
#[async_trait]
impl AuthorizationProvider for Auth {
    async fn get_authorization(&self) -> Result<Authorization, HttpError> {
        self.get_basis_authentication()
            .await
            .map_err(|e| HttpError::AuthorizationError(e.to_string()))
    }
}
```