### PR TITLE
Make TunnelManagementClient extensible

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -712,14 +712,7 @@ namespace Microsoft.VsSaaS.TunnelService
                 options);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="tunnel"></param>
-        /// <param name="accessTokenScopes"></param>
-        /// <param name="options"></param>
-        /// <returns></returns>
-        protected virtual async Task<AuthenticationHeaderValue?> GetAuthenticationHeaderAsync(
+        private async Task<AuthenticationHeaderValue?> GetAuthenticationHeaderAsync(
             Tunnel? tunnel,
             string[]? accessTokenScopes,
             TunnelRequestOptions? options)


### PR DESCRIPTION
 - Define protected `SendTunnelRequestAsync()` and `SendRequestAsync()` methods in C# `TunnelManagementClient` enabling subclasses to support additional management APIs without duplicating a lot of code to format requests and handle responses and errors. (We'll use this for internal APIs.)
 - Apply equivalent changes to TS. (No specific need for this yet but it's good to keep parity with C#.)
 - Fix handling of 404 responses in TS which was not correct for some APIs.

I tried to make the new APIs cleaner and more consistent, and they are well-documented. The PR diff has a lot of changes but much of it is just renaming/reordering parameters, or doc-comments.