### PR TITLE
API to make host refresh ports from service

### DIFF
--- a/cs/src/Connections/ITunnelClient.cs
+++ b/cs/src/Connections/ITunnelClient.cs
@@ -107,6 +107,21 @@ namespace Microsoft.VsSaaS.TunnelService
         Task<Stream?> ConnectToForwardedPortAsync(int forwardedPort, CancellationToken cancellation);
 
         /// <summary>
+        /// Sends a request to the host to refresh ports that were updated using the management API,
+        /// and waits for the refresh to complete.
+        /// </summary>
+        /// <param name="cancellation">Cancellation token.</param>
+        /// <remarks>
+        /// After calling <see cref="ITunnelManagementClient.CreateTunnelPortAsync"/> or
+        /// <see cref="ITunnelManagementClient.DeleteTunnelPortAsync"/>, call this method to have a
+        /// connected client notify the host to update its cached list of ports. Any added or
+        /// removed ports will then propagate back to the set of ports forwarded by the current
+        /// client. After the returned task has completed, any newly added ports are usable from
+        /// the current client.
+        /// </remarks>
+        Task RefreshPortsAsync(CancellationToken cancellation);
+
+        /// <summary>
         /// Event handler for refreshing the tunnel access token.
         /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
         /// </summary>

--- a/cs/src/Connections/ITunnelHost.cs
+++ b/cs/src/Connections/ITunnelHost.cs
@@ -8,96 +8,62 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VsSaaS.TunnelService.Contracts;
 
-namespace Microsoft.VsSaaS.TunnelService
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Interface for a host capable of sharing local ports via a tunnel and accepting
+/// tunneled connections to those ports.
+/// </summary>
+public interface ITunnelHost : IAsyncDisposable
 {
     /// <summary>
-    /// Interface for a host capable of sharing local ports via a tunnel and accepting
-    /// tunneled connections to those ports.
+    /// Gets the connection status.
     /// </summary>
-    public interface ITunnelHost : IAsyncDisposable
-    {
-        /// <summary>
-        /// Gets the connection status.
-        /// </summary>
-        ConnectionStatus ConnectionStatus { get; }
+    ConnectionStatus ConnectionStatus { get; }
 
-        /// <summary>
-        /// Gets the exception that caused disconnection.
-        /// Null if not yet connected or disconnection was caused by disposing of this object.
-        /// </summary>
-        Exception? DisconnectException { get; }
+    /// <summary>
+    /// Gets the exception that caused disconnection.
+    /// Null if not yet connected or disconnection was caused by disposing of this object.
+    /// </summary>
+    Exception? DisconnectException { get; }
 
-        /// <summary>
-        /// Connects to a tunnel as a host and starts accepting incoming connections
-        /// to local ports as defined on the tunnel.
-        /// </summary>
-        /// <param name="tunnel">Information about the tunnel to connect to.</param>
-        /// <param name="cancellation">Cancellation token.</param>
-        /// <remarks>
-        /// The host either needs to be logged in as the owner identity, or have
-        /// an access token with "host" scope for the tunnel.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
-        /// <exception cref="UnauthorizedAccessException">The host does not have
-        /// access to host the tunnel.</exception>
-        /// <exception cref="TunnelConnectionException">The host failed to connect to the
-        /// tunnel, or connected but encountered a protocol errror.</exception>
-        Task StartAsync(Tunnel tunnel, CancellationToken cancellation);
+    /// <summary>
+    /// Connects to a tunnel as a host and starts accepting incoming connections
+    /// to local ports as defined on the tunnel.
+    /// </summary>
+    /// <param name="tunnel">Information about the tunnel to connect to.</param>
+    /// <param name="cancellation">Cancellation token.</param>
+    /// <remarks>
+    /// The host either needs to be logged in as the owner identity, or have
+    /// an access token with "host" scope for the tunnel.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
+    /// <exception cref="UnauthorizedAccessException">The host does not have
+    /// access to host the tunnel.</exception>
+    /// <exception cref="TunnelConnectionException">The host failed to connect to the
+    /// tunnel, or connected but encountered a protocol errror.</exception>
+    Task StartAsync(Tunnel tunnel, CancellationToken cancellation);
 
-        /// <summary>
-        /// Adds and starts forwarding a port to a tunnel that is currently being hosted through StartAsync
-        /// </summary>
-        /// <param name="portToAdd">Port to add to hosted tunnel.</param>
-        /// <param name="cancellation">Cancellation token.</param>
-        /// <remarks>
-        /// The host either needs to be logged in as the owner identity, or have
-        /// an access token with "host" scope for the tunnel.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">The tunnel was not running or port was already added.</exception>
-        /// <returns>Added port object as returned by the service</returns>
-        Task<TunnelPort> AddPortAsync(
-            TunnelPort portToAdd,
-            CancellationToken cancellation);
+    /// <summary>
+    /// Refreshes ports that were updated using the management API.
+    /// </summary>
+    /// <param name="cancellation">Cancellation token.</param>
+    /// <remarks>
+    /// After calling <see cref="ITunnelManagementClient.CreateTunnelPortAsync"/> or
+    /// <see cref="ITunnelManagementClient.DeleteTunnelPortAsync"/>, call this method to have the
+    /// host to update its cached list of ports. Any added or removed ports will then propagate to
+    /// the set of ports forwarded by all connected clients.
+    /// </remarks>
+    Task RefreshPortsAsync(CancellationToken cancellation);
 
-        /// <summary>
-        /// Removes a port to a tunnel that is currently being hosted through StartAsync
-        /// </summary>
-        /// <param name="portNumberToRemove">Port number to be removed from hosted tunnel.</param>
-        /// <param name="cancellation">Cancellation token.</param>
-        /// <remarks>
-        /// The host either needs to be logged in as the owner identity, or have
-        /// an access token with "host" scope for the tunnel.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">The tunnel was not running or did not have ports.</exception>
-        /// <returns>Boolean of if port was deleted</returns>
-        Task<bool> RemovePortAsync(
-            ushort portNumberToRemove,
-            CancellationToken cancellation);
+    /// <summary>
+    /// Event handler for refreshing the tunnel access token.
+    /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
+    /// </summary>
+    event EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken;
 
-        /// <summary>
-        /// Updates a port in a tunnel that is currently being hosted through StartAsync
-        /// </summary>
-        /// <param name="updatedPort">Port to update in hosted tunnel.</param>
-        /// <param name="cancellation">Cancellation token.</param>
-        /// <remarks>
-        /// The host either needs to be logged in as the owner identity, or have
-        /// an access token with "host" scope for the tunnel.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">The tunnel was not running.</exception>
-        /// <returns>Updated port object, refreshed from the service</returns>
-        Task<TunnelPort> UpdatePortAsync(
-            TunnelPort updatedPort,
-            CancellationToken cancellation);
-
-        /// <summary>
-        /// Event handler for refreshing the tunnel access token.
-        /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
-        /// </summary>
-        event EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken;
-
-        /// <summary>
-        /// Connection status changed event.
-        /// </summary>
-        event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
-    }
+    /// <summary>
+    /// Connection status changed event.
+    /// </summary>
+    event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
 }

--- a/cs/src/Connections/ITunnelHost.cs
+++ b/cs/src/Connections/ITunnelHost.cs
@@ -51,7 +51,7 @@ public interface ITunnelHost : IAsyncDisposable
     /// <remarks>
     /// After calling <see cref="ITunnelManagementClient.CreateTunnelPortAsync"/> or
     /// <see cref="ITunnelManagementClient.DeleteTunnelPortAsync"/>, call this method to have the
-    /// host to update its cached list of ports. Any added or removed ports will then propagate to
+    /// host update its cached list of ports. Any added or removed ports will then propagate to
     /// the set of ports forwarded by all connected clients.
     /// </remarks>
     Task RefreshPortsAsync(CancellationToken cancellation);

--- a/cs/src/Connections/MultiModeTunnelClient.cs
+++ b/cs/src/Connections/MultiModeTunnelClient.cs
@@ -110,5 +110,12 @@ namespace Microsoft.VsSaaS.TunnelService
         {
             throw new NotImplementedException();
         }
+
+        /// <inheritdoc />
+        public async Task RefreshPortsAsync(CancellationToken cancellation)
+        {
+            await Task.WhenAll(
+                Clients.Select((c) => c.RefreshPortsAsync(cancellation)));
+        }
     }
 }

--- a/cs/src/Connections/MultiModeTunnelClient.cs
+++ b/cs/src/Connections/MultiModeTunnelClient.cs
@@ -112,10 +112,9 @@ namespace Microsoft.VsSaaS.TunnelService
         }
 
         /// <inheritdoc />
-        public async Task RefreshPortsAsync(CancellationToken cancellation)
+        public Task RefreshPortsAsync(CancellationToken cancellation)
         {
-            await Task.WhenAll(
-                Clients.Select((c) => c.RefreshPortsAsync(cancellation)));
+            throw new NotImplementedException();
         }
     }
 }

--- a/cs/src/Connections/MultiModeTunnelHost.cs
+++ b/cs/src/Connections/MultiModeTunnelHost.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VsSaaS.TunnelService.Contracts;
@@ -78,54 +79,16 @@ namespace Microsoft.VsSaaS.TunnelService
         }
 
         /// <inheritdoc />
-        public async Task<TunnelPort> AddPortAsync(TunnelPort portToAdd, CancellationToken cancellation)
-        {
-            var addTasks = new List<Task>();
-            foreach (ITunnelHost host in Hosts)
-            {
-                addTasks.Add(host.AddPortAsync(portToAdd, cancellation));
-            }
-
-            await Task.WhenAll(addTasks);
-            return portToAdd;
-        }
-
-        /// <inheritdoc />
-        public async Task<bool> RemovePortAsync(ushort portNumberToRemove, CancellationToken cancellation)
-        {
-            var result = true;
-            var removeTasks = new List<Task<bool>>();
-            foreach (ITunnelHost host in Hosts)
-            {
-                removeTasks.Add(host.RemovePortAsync(portNumberToRemove, cancellation));
-            }
-
-            var results = await Task.WhenAll(removeTasks);
-            foreach (bool res in results)
-            {
-                result = result && res;
-            }
-
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<TunnelPort> UpdatePortAsync(TunnelPort updatedPort, CancellationToken cancellation)
-        {
-            var updateTasks = new List<Task>();
-            foreach (ITunnelHost host in Hosts)
-            {
-                updateTasks.Add(host.UpdatePortAsync(updatedPort, cancellation));
-            }
-
-            await Task.WhenAll(updateTasks);
-            return updatedPort;
-        }
-
-        /// <inheritdoc />
         protected override Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
         {
             throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public async Task RefreshPortsAsync(CancellationToken cancellation)
+        {
+            await Task.WhenAll(
+                Hosts.Select((c) => c.RefreshPortsAsync(cancellation)));
         }
     }
 }

--- a/cs/src/Connections/TunnelClient.cs
+++ b/cs/src/Connections/TunnelClient.cs
@@ -299,6 +299,22 @@ public abstract class TunnelClient : TunnelConnection, ITunnelClient
         return null;
     }
 
+    /// <inheritdoc />
+    public async Task RefreshPortsAsync(CancellationToken cancellation)
+    {
+        if (SshSession == null || SshSession.IsClosed)
+        {
+            throw new InvalidOperationException("Not connected.");
+        }
+
+        var request = new SessionRequestMessage
+        {
+            RequestType = TunnelHost.RefreshPortsRequestType,
+            WantReply = true,
+        };
+        await SshSession.RequestAsync(request, cancellation);
+    }
+
     private void SshSession_Closed(object? sender, SshSessionClosedEventArgs e)
     {
         if (sender is SshSession sshSession)

--- a/cs/src/Connections/TunnelHost.cs
+++ b/cs/src/Connections/TunnelHost.cs
@@ -128,7 +128,7 @@ public abstract class TunnelHost : TunnelConnection, ITunnelHost
         // Disposing of the RemotePortForwarder stops the forwarding and removes the remote connector
         // from PFS.remoteConnectors.
         RemoteForwarders.TryAdd(
-            new SessionPortKey(sessionId, (ushort)forwarder.RemotePort),
+            new SessionPortKey(sessionId, (ushort)forwarder.LocalPort),
             forwarder);
         return;
     }

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -17,443 +17,460 @@ using Microsoft.VisualStudio.Ssh.Messages;
 using Microsoft.VisualStudio.Ssh.Tcp;
 using Microsoft.VsSaaS.TunnelService.Contracts;
 
-namespace Microsoft.VsSaaS.TunnelService
+namespace Microsoft.VsSaaS.TunnelService;
+
+/// <summary>
+/// Tunnel host implementation that uses data-plane relay
+/// to accept client connections.
+/// </summary>
+public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
 {
     /// <summary>
-    /// Tunnel host implementation that uses data-plane relay
-    /// to accept client connections.
+    /// Web socket sub-protocol to connect to the tunnel relay endpoint.
     /// </summary>
-    public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
+    public const string WebSocketSubProtocol = "tunnel-relay-host";
+
+    /// <summary>
+    /// Ssh channel type in host relay ssh session where client session streams are passed.
+    /// </summary>
+    public const string ClientStreamChannelType = "client-ssh-session-stream";
+
+    private readonly IList<Task> clientSessionTasks = new List<Task>();
+    private readonly string hostId;
+    private readonly ICollection<SshServerSession> reconnectableSessions = new List<SshServerSession>();
+
+    private MultiChannelStream? hostSession;
+    private Uri? relayUri;
+    
+    /// <summary>
+    /// Creates a new instance of a host that connects to a tunnel via a tunnel relay.
+    /// </summary>
+    public TunnelRelayTunnelHost(ITunnelManagementClient managementClient, TraceSource trace)
+        : base(managementClient, trace)
     {
-        /// <summary>
-        /// Web socket sub-protocol to connect to the tunnel relay endpoint.
-        /// </summary>
-        public const string WebSocketSubProtocol = "tunnel-relay-host";
+        this.hostId = MultiModeTunnelHost.HostId;
+    }
 
-        /// <summary>
-        /// Ssh channel type in host relay ssh session where client session streams are passed.
-        /// </summary>
-        public const string ClientStreamChannelType = "client-ssh-session-stream";
+    /// <summary>
+    /// Gets or sets a factory for creating relay streams.
+    /// </summary>
+    /// <remarks>
+    /// Normally the default <see cref="TunnelRelayStreamFactory" /> can be used. However a
+    /// different factory class may be used to customize the connection (or mock the connection
+    /// for testing).
+    /// </remarks>
+    public ITunnelRelayStreamFactory StreamFactory { get; set; } = new TunnelRelayStreamFactory();
 
-        private readonly IList<Task> clientSessionTasks = new List<Task>();
-        private readonly string hostId;
-        private readonly ICollection<SshServerSession> reconnectableSessions = new List<SshServerSession>();
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
 
-        private MultiChannelStream? hostSession;
-        private Uri? relayUri;
-        
-        /// <summary>
-        /// Creates a new instance of a host that connects to a tunnel via a tunnel relay.
-        /// </summary>
-        public TunnelRelayTunnelHost(ITunnelManagementClient managementClient, TraceSource trace)
-            : base(managementClient, trace)
+        var hostSession = this.hostSession;
+        if (hostSession != null)
         {
-            this.hostId = MultiModeTunnelHost.HostId;
-        }
-
-        /// <summary>
-        /// Gets or sets a factory for creating relay streams.
-        /// </summary>
-        /// <remarks>
-        /// Normally the default <see cref="TunnelRelayStreamFactory" /> can be used. However a
-        /// different factory class may be used to customize the connection (or mock the connection
-        /// for testing).
-        /// </remarks>
-        public ITunnelRelayStreamFactory StreamFactory { get; set; } = new TunnelRelayStreamFactory();
-
-        /// <inheritdoc />
-        public override async ValueTask DisposeAsync()
-        {
-            await base.DisposeAsync();
-
-            var hostSession = this.hostSession;
-            if (hostSession != null)
-            {
-                this.hostSession = null;
-                await hostSession.CloseAsync();
-                hostSession.Dispose();
-            }
-
-            List<Task> tasks;
-            lock (DisposeLock)
-            {
-                tasks = new List<Task>(this.clientSessionTasks);
-                this.clientSessionTasks.Clear();
-            }
-
-            if (Tunnel != null)
-            {
-                tasks.Add(ManagementClient!.DeleteTunnelEndpointsAsync(Tunnel, this.hostId, TunnelConnectionMode.TunnelRelay));
-            }
-
-            foreach (RemotePortForwarder forwarder in RemoteForwarders.Values)
-            {
-                forwarder.Dispose();
-            }
-
-            await Task.WhenAll(tasks);
-        }
-
-        /// <inheritdoc />
-        protected override async Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
-        {
-            Requires.NotNull(Tunnel!, nameof(Tunnel));
-
-            this.accessToken = null!;
-            Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken!);
-            Requires.Argument(this.accessToken != null, nameof(Tunnel), $"There is no access token for {TunnelAccessScope} scope on the tunnel.");
-
-            var hostPublicKeys = new[]
-            {
-                HostPrivateKey.GetPublicKeyBytes(HostPrivateKey.KeyAlgorithmName).ToBase64(),
-            };
-
-            var endpoint = new TunnelRelayTunnelEndpoint
-            {
-                HostId = this.hostId,
-                HostPublicKeys = hostPublicKeys,
-            };
-
-            endpoint = (TunnelRelayTunnelEndpoint)await ManagementClient!.UpdateTunnelEndpointAsync(
-                Tunnel,
-                endpoint,
-                options: null,
-                cancellation);
-
-            Requires.Argument(
-                !string.IsNullOrEmpty(endpoint?.HostRelayUri),
-                nameof(Tunnel),
-                $"The tunnel host relay endpoint URI is missing.");
-
-            this.relayUri = new Uri(endpoint.HostRelayUri, UriKind.Absolute);
-
-            return new RelayTunnelConnector(this);
-        }
-
-        /// <summary>
-        /// Create stream to the tunnel.
-        /// </summary>
-        protected virtual Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
-        {
-            ValidateAccessToken();
-            Trace.TraceInformation("Connecting to host tunnel relay {0}", this.relayUri!.AbsoluteUri);
-            return this.StreamFactory.CreateRelayStreamAsync(
-                this.relayUri!,
-                this.accessToken,
-                WebSocketSubProtocol,
-                cancellation);
-        }
-
-        /// <inheritdoc />
-        protected override async Task CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception)
-        {
-            await base.CloseSessionAsync(disconnectReason, exception);
-            var hostSession = this.hostSession;
-            if (hostSession != null)
-            {
-                await hostSession.CloseAsync();
-                hostSession.Dispose();
-            }
-        }
-
-        #region IRelayClient
-
-        /// <inheritdoc />
-        string IRelayClient.TunnelAccessScope => TunnelAccessScope;
-
-        /// <inheritdoc />
-        TraceSource IRelayClient.Trace => Trace;
-
-        /// <inheritdoc />
-        Task<Stream> IRelayClient.CreateSessionStreamAsync(CancellationToken cancellation) =>
-            CreateSessionStreamAsync(cancellation);
-
-        /// <inheritdoc />
-        async Task IRelayClient.ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
-        {
-            this.hostSession = new MultiChannelStream(stream, Trace.WithName("HostSSH"));
-            this.hostSession.ChannelOpening += HostSession_ChannelOpening;
-            this.hostSession.Closed += HostSession_Closed;
-            await this.hostSession.ConnectAsync(cancellation);
-        }
-
-        /// <inheritdoc />
-        Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception) =>
-            CloseSessionAsync(disconnectReason, exception);
-
-        /// <inheritdoc />
-        Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>
-            RefreshTunnelAccessTokenAsync(cancellation);
-
-        /// <inheritdoc />
-        void IRelayClient.OnRetrying(RetryingTunnelConnectionEventArgs e) => OnRetrying(e);
-
-        #endregion IRelayClient
-
-        private void HostSession_Closed(object? sender, SshSessionClosedEventArgs e)
-        {
-            var session = (MultiChannelStream)sender!;
-            session.Closed -= HostSession_Closed;
-            session.ChannelOpening -= HostSession_ChannelOpening;
             this.hostSession = null;
-            Trace.TraceInformation(
-                "Connection to host tunnel relay closed.{0}",
-                DisposeToken.IsCancellationRequested ? string.Empty : " Reconnecting.");
-
-            StartReconnectTaskIfNotDisposed();
+            await hostSession.CloseAsync();
+            hostSession.Dispose();
         }
 
-        private void HostSession_ChannelOpening(object? sender, SshChannelOpeningEventArgs e)
+        List<Task> tasks;
+        lock (DisposeLock)
         {
-            if (!e.IsRemoteRequest)
+            tasks = new List<Task>(this.clientSessionTasks);
+            this.clientSessionTasks.Clear();
+        }
+
+        if (Tunnel != null)
+        {
+            tasks.Add(ManagementClient!.DeleteTunnelEndpointsAsync(Tunnel, this.hostId, TunnelConnectionMode.TunnelRelay));
+        }
+
+        foreach (RemotePortForwarder forwarder in RemoteForwarders.Values)
+        {
+            forwarder.Dispose();
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    /// <inheritdoc />
+    protected override async Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
+    {
+        Requires.NotNull(Tunnel!, nameof(Tunnel));
+
+        this.accessToken = null!;
+        Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken!);
+        Requires.Argument(this.accessToken != null, nameof(Tunnel), $"There is no access token for {TunnelAccessScope} scope on the tunnel.");
+
+        var hostPublicKeys = new[]
+        {
+            HostPrivateKey.GetPublicKeyBytes(HostPrivateKey.KeyAlgorithmName).ToBase64(),
+        };
+
+        var endpoint = new TunnelRelayTunnelEndpoint
+        {
+            HostId = this.hostId,
+            HostPublicKeys = hostPublicKeys,
+        };
+
+        endpoint = (TunnelRelayTunnelEndpoint)await ManagementClient!.UpdateTunnelEndpointAsync(
+            Tunnel,
+            endpoint,
+            options: null,
+            cancellation);
+
+        Requires.Argument(
+            !string.IsNullOrEmpty(endpoint?.HostRelayUri),
+            nameof(Tunnel),
+            $"The tunnel host relay endpoint URI is missing.");
+
+        this.relayUri = new Uri(endpoint.HostRelayUri, UriKind.Absolute);
+
+        return new RelayTunnelConnector(this);
+    }
+
+    /// <summary>
+    /// Create stream to the tunnel.
+    /// </summary>
+    protected virtual Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
+    {
+        ValidateAccessToken();
+        Trace.TraceInformation("Connecting to host tunnel relay {0}", this.relayUri!.AbsoluteUri);
+        return this.StreamFactory.CreateRelayStreamAsync(
+            this.relayUri!,
+            this.accessToken,
+            WebSocketSubProtocol,
+            cancellation);
+    }
+
+    /// <inheritdoc />
+    protected override async Task CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception)
+    {
+        await base.CloseSessionAsync(disconnectReason, exception);
+        var hostSession = this.hostSession;
+        if (hostSession != null)
+        {
+            await hostSession.CloseAsync();
+            hostSession.Dispose();
+        }
+    }
+
+    #region IRelayClient
+
+    /// <inheritdoc />
+    string IRelayClient.TunnelAccessScope => TunnelAccessScope;
+
+    /// <inheritdoc />
+    TraceSource IRelayClient.Trace => Trace;
+
+    /// <inheritdoc />
+    Task<Stream> IRelayClient.CreateSessionStreamAsync(CancellationToken cancellation) =>
+        CreateSessionStreamAsync(cancellation);
+
+    /// <inheritdoc />
+    async Task IRelayClient.ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
+    {
+        this.hostSession = new MultiChannelStream(stream, Trace.WithName("HostSSH"));
+        this.hostSession.ChannelOpening += HostSession_ChannelOpening;
+        this.hostSession.Closed += HostSession_Closed;
+        await this.hostSession.ConnectAsync(cancellation);
+    }
+
+    /// <inheritdoc />
+    Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception) =>
+        CloseSessionAsync(disconnectReason, exception);
+
+    /// <inheritdoc />
+    Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>
+        RefreshTunnelAccessTokenAsync(cancellation);
+
+    /// <inheritdoc />
+    void IRelayClient.OnRetrying(RetryingTunnelConnectionEventArgs e) => OnRetrying(e);
+
+    #endregion IRelayClient
+
+    private void HostSession_Closed(object? sender, SshSessionClosedEventArgs e)
+    {
+        var session = (MultiChannelStream)sender!;
+        session.Closed -= HostSession_Closed;
+        session.ChannelOpening -= HostSession_ChannelOpening;
+        this.hostSession = null;
+        Trace.TraceInformation(
+            "Connection to host tunnel relay closed.{0}",
+            DisposeToken.IsCancellationRequested ? string.Empty : " Reconnecting.");
+
+        StartReconnectTaskIfNotDisposed();
+    }
+
+    private void HostSession_ChannelOpening(object? sender, SshChannelOpeningEventArgs e)
+    {
+        if (!e.IsRemoteRequest)
+        {
+            // Auto approve all local requests (not that there are any for the time being).
+            return;
+        }
+
+        if (e.Channel.ChannelType != ClientStreamChannelType)
+        {
+            e.FailureDescription = $"Unexpected channel type. Only {ClientStreamChannelType} is supported.";
+            e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
+            return;
+        }
+
+        Task task;
+        lock (DisposeLock)
+        {
+            if (DisposeToken.IsCancellationRequested)
             {
-                // Auto approve all local requests (not that there are any for the time being).
+                e.FailureDescription = $"The host is disconnecting.";
+                e.FailureReason = SshChannelOpenFailureReason.ConnectFailed;
                 return;
             }
 
-            if (e.Channel.ChannelType != ClientStreamChannelType)
-            {
-                e.FailureDescription = $"Unexpected channel type. Only {ClientStreamChannelType} is supported.";
-                e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
-                return;
-            }
+            task = AcceptClientSessionAsync((MultiChannelStream)sender!, DisposeToken);
+            this.clientSessionTasks.Add(task);
+        }
 
-            Task task;
+        task.ContinueWith(RemoveClientSessionTask);
+
+        void RemoveClientSessionTask(Task t)
+        {
             lock (DisposeLock)
             {
-                if (DisposeToken.IsCancellationRequested)
-                {
-                    e.FailureDescription = $"The host is disconnecting.";
-                    e.FailureReason = SshChannelOpenFailureReason.ConnectFailed;
-                    return;
-                }
-
-                task = AcceptClientSessionAsync((MultiChannelStream)sender!, DisposeToken);
-                this.clientSessionTasks.Add(task);
-            }
-
-            task.ContinueWith(RemoveClientSessionTask);
-
-            void RemoveClientSessionTask(Task t)
-            {
-                lock (DisposeLock)
-                {
-                    this.clientSessionTasks.Remove(t);
-                }
+                this.clientSessionTasks.Remove(t);
             }
         }
+    }
 
-        private async Task AcceptClientSessionAsync(MultiChannelStream hostSession, CancellationToken cancellation)
+    private async Task AcceptClientSessionAsync(MultiChannelStream hostSession, CancellationToken cancellation)
+    {
+        try
+        {
+            var stream = await hostSession.AcceptStreamAsync(ClientStreamChannelType, cancellation);
+            await ConnectAndRunClientSessionAsync(stream, cancellation);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception exception)
+        {
+            Trace.TraceEvent(TraceEventType.Error, 0, "Error running client SSH session: {0}", exception.Message);
+        }
+    }
+
+    private async Task ConnectAndRunClientSessionAsync(Stream stream, CancellationToken cancellation)
+    {
+        var sshSessionOwnsStream = false;
+        var tcs = new TaskCompletionSource<object?>();
+        try
+        {
+            // Always enable reconnect on client SSH server.
+            // When a client reconnects, relay service just opens another SSH channel of client-ssh-session-stream type for it.
+            var serverConfig = new SshSessionConfiguration(enableReconnect: true);
+
+            // Enable port-forwarding via the SSH protocol.
+            serverConfig.AddService(typeof(PortForwardingService));
+
+            var session = new SshServerSession(serverConfig, this.reconnectableSessions, Trace.WithName("ClientSSH"));
+            session.Credentials = new SshServerCredentials(this.HostPrivateKey);
+
+            using var tokenRegistration = cancellation.CanBeCanceled ?
+                cancellation.Register(() => tcs.TrySetCanceled(cancellation)) : default;
+
+            session.Authenticating += OnSshClientAuthenticating;
+            session.ClientAuthenticated += OnSshClientAuthenticated;
+            session.Reconnected += OnSshClientReconnected;
+            session.Request += OnClientSessionRequest;
+            session.ChannelOpening += OnSshChannelOpening;
+            session.Closed += Session_Closed;
+
+            try
+            {
+                var portForwardingService = session.ActivateService<PortForwardingService>();
+
+                // All tunnel hosts and clients should disable this because they do not use it (for now) and leaving it enabled is a potential security issue.
+                portForwardingService.AcceptRemoteConnectionsForNonForwardedPorts = false;
+
+                await session.ConnectAsync(stream, cancellation);
+                sshSessionOwnsStream = true;
+
+                AddClientSshSession(session);
+
+                await tcs.Task;
+            }
+            finally
+            {
+                if (!session.IsClosed)
+                {
+                    await session.CloseAsync(SshDisconnectReason.ByApplication);
+                }
+
+                session.Authenticating -= OnSshClientAuthenticating;
+                session.ClientAuthenticated -= OnSshClientAuthenticated;
+                session.Reconnected -= OnSshClientReconnected;
+                session.ChannelOpening -= OnSshChannelOpening;
+                session.Closed -= Session_Closed;
+
+                RemoveClientSshSession(session);
+            }
+        }
+        catch when (!sshSessionOwnsStream)
+        {
+            stream.Close();
+            throw;
+        }
+
+        void Session_Closed(object? sender, SshSessionClosedEventArgs e)
+        {
+            // Reconnecting client session may cause the new session close with 'None' reason and null exception.
+            if (cancellation.IsCancellationRequested)
+            {
+                Trace.TraceInformation("Client ssh session cancelled.");
+            }
+            else if (e.Reason == SshDisconnectReason.ByApplication)
+            {
+                Trace.TraceInformation("Client ssh session closed.");
+            }
+            else if (e.Reason != SshDisconnectReason.None || e.Exception != null)
+            {
+                Trace.TraceEvent(
+                    TraceEventType.Error,
+                    0,
+                    "Client ssh session closed unexpectely due to {0}, \"{1}\"\n{2}",
+                    e.Reason,
+                    e.Message,
+                    e.Exception);
+            }
+
+            tcs.TrySetResult(null);
+        }
+    }
+
+    private void OnClientSessionRequest(
+        object? sender,
+        SshRequestEventArgs<SessionRequestMessage> e)
+    {
+        if (e.RequestType == RefreshPortsRequestType)
+        {
+            e.ResponseTask = Task.Run<SshMessage>(async () =>
+            {
+                // This may send tcpip-forward or cancel-tcpip-forward requests to clients.
+                // Forward requests (but not cancellations) wait for client responses.
+                await RefreshPortsAsync(e.Cancellation);
+                return new SessionRequestSuccessMessage();
+            });
+        }
+    }
+
+    private void OnSshClientAuthenticating(object? sender, SshAuthenticatingEventArgs e)
+    {
+        if (e.AuthenticationType == SshAuthenticationType.ClientNone)
+        {
+            // For now, the client is allowed to skip SSH authentication;
+            // they must have a valid tunnel access token already to get this far.
+            e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
+        }
+        else
+        {
+            // Other authentication types are not implemented. Doing nothing here
+            // results in a client authentication failure.
+        }
+    }
+
+    private async void OnSshClientAuthenticated(object? sender, EventArgs e) =>
+        await StartForwardingExistingPortsAsync((SshServerSession)sender!);
+
+    private async void OnSshClientReconnected(object? sender, EventArgs e) =>
+        await StartForwardingExistingPortsAsync((SshServerSession)sender!, removeUnusedPorts: true);
+
+    private async Task StartForwardingExistingPortsAsync(
+        SshServerSession session, bool removeUnusedPorts = false)
+    {
+        var tunnelPorts = Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>();
+        var pfs = session.ActivateService<PortForwardingService>();
+        foreach (TunnelPort port in tunnelPorts)
         {
             try
             {
-                var stream = await hostSession.AcceptStreamAsync(ClientStreamChannelType, cancellation);
-                await ConnectAndRunClientSessionAsync(stream, cancellation);
-            }
-            catch (OperationCanceledException)
-            {
+                await ForwardPortAsync(pfs, port, CancellationToken.None);
             }
             catch (Exception exception)
             {
-                Trace.TraceEvent(TraceEventType.Error, 0, "Error running client SSH session: {0}", exception.Message);
+                Trace.TraceEvent(
+                    TraceEventType.Error,
+                    0,
+                    "Error forwarding port {0} to client: {1}",
+                    port.PortNumber,
+                    exception.Message);
             }
         }
 
-        private async Task ConnectAndRunClientSessionAsync(Stream stream, CancellationToken cancellation)
+        // If a tunnel client reconnects, its SSH session Port Forwarding service may
+        // have remote port forwarders for the ports no longer forwarded.
+        // Remove such forwarders.
+        if (removeUnusedPorts && session.SessionId != null)
         {
-            var sshSessionOwnsStream = false;
-            var tcs = new TaskCompletionSource<object?>();
-            try
+            tunnelPorts = Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>();
+            var unusedlocalPorts = new HashSet<int>(
+                pfs.LocalForwardedPorts
+                    .Select(p => p.LocalPort)
+                    .Where(localPort => localPort.HasValue && !tunnelPorts.Any(tp => tp.PortNumber == localPort))
+                    .Select(localPort => localPort!.Value));
+
+            var remoteForwardersToDispose = RemoteForwarders
+                .Where((kvp) =>
+                    Enumerable.SequenceEqual(kvp.Key.SessionId, session.SessionId) &&
+                    unusedlocalPorts.Contains(kvp.Value.LocalPort))
+                .Select(kvp => kvp.Key);
+
+            foreach (SessionPortKey key in remoteForwardersToDispose)
             {
-                // Always enable reconnect on client SSH server.
-                // When a client reconnects, relay service just opens another SSH channel of client-ssh-session-stream type for it.
-                var serverConfig = new SshSessionConfiguration(enableReconnect: true);
-
-                // Enable port-forwarding via the SSH protocol.
-                serverConfig.AddService(typeof(PortForwardingService));
-
-                var session = new SshServerSession(serverConfig, this.reconnectableSessions, Trace.WithName("ClientSSH"));
-                session.Credentials = new SshServerCredentials(this.HostPrivateKey);
-
-                using var tokenRegistration = cancellation.CanBeCanceled ?
-                    cancellation.Register(() => tcs.TrySetCanceled(cancellation)) : default;
-
-                session.Authenticating += OnSshClientAuthenticating;
-                session.ClientAuthenticated += OnSshClientAuthenticated;
-                session.Reconnected += OnSshClientReconnected;
-                session.ChannelOpening += OnSshChannelOpening;
-                session.Closed += Session_Closed;
-
-                try
+                if (RemoteForwarders.TryRemove(key, out var remoteForwarder))
                 {
-                    var portForwardingService = session.ActivateService<PortForwardingService>();
-
-                    // All tunnel hosts and clients should disable this because they do not use it (for now) and leaving it enabled is a potential security issue.
-                    portForwardingService.AcceptRemoteConnectionsForNonForwardedPorts = false;
-
-                    await session.ConnectAsync(stream, cancellation);
-                    sshSessionOwnsStream = true;
-
-                    AddClientSshSession(session);
-
-                    await tcs.Task;
-                }
-                finally
-                {
-                    if (!session.IsClosed)
-                    {
-                        await session.CloseAsync(SshDisconnectReason.ByApplication);
-                    }
-
-                    session.Authenticating -= OnSshClientAuthenticating;
-                    session.ClientAuthenticated -= OnSshClientAuthenticated;
-                    session.Reconnected -= OnSshClientReconnected;
-                    session.ChannelOpening -= OnSshChannelOpening;
-                    session.Closed -= Session_Closed;
-
-                    RemoveClientSshSession(session);
-                }
-            }
-            catch when (!sshSessionOwnsStream)
-            {
-                stream.Close();
-                throw;
-            }
-
-            void Session_Closed(object? sender, SshSessionClosedEventArgs e)
-            {
-                // Reconnecting client session may cause the new session close with 'None' reason and null exception.
-                if (cancellation.IsCancellationRequested)
-                {
-                    Trace.TraceInformation("Client ssh session cancelled.");
-                }
-                else if (e.Reason == SshDisconnectReason.ByApplication)
-                {
-                    Trace.TraceInformation("Client ssh session closed.");
-                }
-                else if (e.Reason != SshDisconnectReason.None || e.Exception != null)
-                {
-                    Trace.TraceEvent(
-                        TraceEventType.Error,
-                        0,
-                        "Client ssh session closed unexpectely due to {0}, \"{1}\"\n{2}",
-                        e.Reason,
-                        e.Message,
-                        e.Exception);
-                }
-
-                tcs.TrySetResult(null);
-            }
-        }
-
-        private void OnSshClientAuthenticating(object? sender, SshAuthenticatingEventArgs e)
-        {
-            if (e.AuthenticationType == SshAuthenticationType.ClientNone)
-            {
-                // For now, the client is allowed to skip SSH authentication;
-                // they must have a valid tunnel access token already to get this far.
-                e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
-            }
-            else
-            {
-                // Other authentication types are not implemented. Doing nothing here
-                // results in a client authentication failure.
-            }
-        }
-
-        private async void OnSshClientAuthenticated(object? sender, EventArgs e) =>
-            await StartForwardingExistingPortsAsync((SshServerSession)sender!);
-
-        private async void OnSshClientReconnected(object? sender, EventArgs e) =>
-            await StartForwardingExistingPortsAsync((SshServerSession)sender!, removeUnusedPorts: true);
-
-        private async Task StartForwardingExistingPortsAsync(SshServerSession session, bool removeUnusedPorts = false)
-        {
-            var tunnelPorts = Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>();
-            var pfs = session.ActivateService<PortForwardingService>();
-            foreach (TunnelPort port in tunnelPorts)
-            {
-                try
-                {
-                    await ForwardPortAsync(pfs, port, CancellationToken.None);
-                }
-                catch (Exception exception)
-                {
-                    Trace.TraceEvent(
-                        TraceEventType.Error,
-                        0,
-                        "Error forwarding port {0} to client: {1}",
-                        port.PortNumber,
-                        exception.Message);
-                }
-            }
-
-            // If a tunnel client reconnects, its SSH session Port Forwarding service may
-            // have remote port forwarders for the ports no longer forwarded.
-            // Remove such forwarders.
-            if (removeUnusedPorts && session.SessionId != null)
-            {
-                tunnelPorts = Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>();
-                var unusedlocalPorts = new HashSet<int>(
-                    pfs.LocalForwardedPorts
-                        .Select(p => p.LocalPort)
-                        .Where(localPort => localPort.HasValue && !tunnelPorts.Any(tp => tp.PortNumber == localPort))
-                        .Select(localPort => localPort!.Value));
-
-                var remoteForwardersToDispose = RemoteForwarders
-                    .Where((kvp) =>
-                        Enumerable.SequenceEqual(kvp.Key.SessionId, session.SessionId) &&
-                        unusedlocalPorts.Contains(kvp.Value.LocalPort))
-                    .Select(kvp => kvp.Key);
-
-                foreach (SessionPortKey key in remoteForwardersToDispose)
-                {
-                    if (RemoteForwarders.TryRemove(key, out var remoteForwarder))
-                    {
-                        remoteForwarder?.Dispose();
-                    }
+                    remoteForwarder?.Dispose();
                 }
             }
         }
+    }
 
-        private void OnSshChannelOpening(object? sender, SshChannelOpeningEventArgs e)
+    private void OnSshChannelOpening(object? sender, SshChannelOpeningEventArgs e)
+    {
+        if (e.Request is not PortForwardChannelOpenMessage portForwardRequest)
         {
-            if (e.Request is not PortForwardChannelOpenMessage portForwardRequest)
+            if (e.Request is ChannelOpenMessage channelOpenMessage)
             {
-                if (e.Request is ChannelOpenMessage channelOpenMessage)
+                // This allows the Go SDK to open an unused terminal channel
+                if (channelOpenMessage.ChannelType == SshChannel.SessionChannelType)
                 {
-                    // This allows the Go SDK to open an unused terminal channel
-                    if (channelOpenMessage.ChannelType == SshChannel.SessionChannelType)
-                    {
-                        return;
-                    }
+                    return;
                 }
+            }
 
-                Trace.Warning("Rejecting request to open non-portforwarding channel.");
+            Trace.Warning("Rejecting request to open non-portforwarding channel.");
+            e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
+            return;
+        }
+
+        if (portForwardRequest.ChannelType == "direct-tcpip")
+        {
+            if (!Tunnel!.Ports!.Any((p) => p.PortNumber == portForwardRequest.Port))
+            {
+                Trace.Warning("Rejecting request to connect to non-forwarded port:" +
+                    portForwardRequest.Port);
                 e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
-                return;
             }
-
-            if (portForwardRequest.ChannelType == "direct-tcpip")
-            {
-                if (!Tunnel!.Ports!.Any((p) => p.PortNumber == portForwardRequest.Port))
-                {
-                    Trace.Warning("Rejecting request to connect to non-forwarded port:" +
-                        portForwardRequest.Port);
-                    e.FailureReason = SshChannelOpenFailureReason.AdministrativelyProhibited;
-                }
-            }
-            // For forwarded-tcpip do not check RemoteForwarders because they may not be updated yet.
-            // There is a small time interval in ForwardPortAsync() between the port
-            // being forwarded with ForwardFromRemotePortAsync() and RemoteForwarders updated.
-            // Setting PFS.AcceptRemoteConnectionsForNonForwardedPorts to false makes PFS reject forwarding requests from the
-            // clients for the ports that are not forwarded and are missing in PFS.remoteConnectors.
-            // Call to PFS.ForwardFromRemotePortAsync() in ForwardPortAsync() adds the connector to PFS.remoteConnectors.
-            else if (portForwardRequest.ChannelType != "forwarded-tcpip")
-            {
-                Trace.Warning("Unrecognized channel type " + portForwardRequest.ChannelType);
-                e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
-            }
+        }
+        // For forwarded-tcpip do not check RemoteForwarders because they may not be updated yet.
+        // There is a small time interval in ForwardPortAsync() between the port
+        // being forwarded with ForwardFromRemotePortAsync() and RemoteForwarders updated.
+        // Setting PFS.AcceptRemoteConnectionsForNonForwardedPorts to false makes PFS reject forwarding requests from the
+        // clients for the ports that are not forwarded and are missing in PFS.remoteConnectors.
+        // Call to PFS.ForwardFromRemotePortAsync() in ForwardPortAsync() adds the connector to PFS.remoteConnectors.
+        else if (portForwardRequest.ChannelType != "forwarded-tcpip")
+        {
+            Trace.Warning("Unrecognized channel type " + portForwardRequest.ChannelType);
+            e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
         }
     }
 }

--- a/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
@@ -540,7 +540,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
             new TunnelPort { PortNumber = this.localPortsFixture.Port },
             options: null,
             CancellationToken.None);
-        await relayHost.RefreshPortsAsync(CancellationToken.None);
+        await relayClient.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port, await clientPortAdded.Task);
 
         // Reconnect the tunnel host
@@ -571,7 +571,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
            new TunnelPort { PortNumber = this.localPortsFixture.Port1 },
            options: null,
            CancellationToken.None);
-        await relayHost.RefreshPortsAsync(CancellationToken.None);
+        await relayClient.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port1, await clientPortAdded.Task);
         Assert.Contains(relayClient.ForwardedPorts, p => p.RemotePort == this.localPortsFixture.Port);
 
@@ -627,7 +627,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
             new TunnelPort { PortNumber = this.localPortsFixture.Port },
             options: null,
             CancellationToken.None);
-        await relayHost.RefreshPortsAsync(CancellationToken.None);
+        await relayClient.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port, await clientPortAdded.Task);
 
         // Reconnect the tunnel client
@@ -657,7 +657,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
             new TunnelPort { PortNumber = this.localPortsFixture.Port1 },
             options: null,
             CancellationToken.None);
-        await relayHost.RefreshPortsAsync(CancellationToken.None);
+        await relayClient.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port1, await clientPortAdded.Task);
 
         Assert.Contains(relayClient.ForwardedPorts, p => p.RemotePort == this.localPortsFixture.Port);

--- a/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
@@ -510,6 +510,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
 
         // Create and start tunnel host
         var tunnel = CreateRelayTunnel(addClientEndpoint: false); // Hosting a tunnel adds the endpoint
+        await managementClient.CreateTunnelAsync(tunnel, options: null, default);
         var relayHost = new TunnelRelayTunnelHost(managementClient, TestTS);
         var multiChannelStream = await StartRelayHostAsync(relayHost, tunnel);
         var clientMultiChannelStream = new TaskCompletionSource<MultiChannelStream>();
@@ -534,7 +535,12 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         var clientPortAdded = new TaskCompletionSource<int?>();
         relayClient.ForwardedPorts.PortAdded += (sender, args) => clientPortAdded.TrySetResult(args.Port.RemotePort);
 
-        await relayHost.AddPortAsync(new TunnelPort { PortNumber = this.localPortsFixture.Port }, CancellationToken.None);
+        await managementClient.CreateTunnelPortAsync(
+            tunnel,
+            new TunnelPort { PortNumber = this.localPortsFixture.Port },
+            options: null,
+            CancellationToken.None);
+        await relayHost.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port, await clientPortAdded.Task);
 
         // Reconnect the tunnel host
@@ -560,7 +566,12 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         clientMultiChannelStream.TrySetResult(newMultiChannelStream);
 
         clientPortAdded = new TaskCompletionSource<int?>();
-        await relayHost.AddPortAsync(new TunnelPort { PortNumber = this.localPortsFixture.Port1 }, CancellationToken.None);
+        await managementClient.CreateTunnelPortAsync(
+           tunnel,
+           new TunnelPort { PortNumber = this.localPortsFixture.Port1 },
+           options: null,
+           CancellationToken.None);
+        await relayHost.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port1, await clientPortAdded.Task);
         Assert.Contains(relayClient.ForwardedPorts, p => p.RemotePort == this.localPortsFixture.Port);
 
@@ -580,6 +591,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
 
         // Create and start tunnel host
         var tunnel = CreateRelayTunnel(addClientEndpoint: false); // Hosting a tunnel adds the endpoint
+        await managementClient.CreateTunnelAsync(tunnel, options: null, default);
         var relayHost = new TunnelRelayTunnelHost(managementClient, TestTS);
         var multiChannelStream = await StartRelayHostAsync(relayHost, tunnel);
         var clientMultiChannelStream = new TaskCompletionSource<MultiChannelStream>();
@@ -610,7 +622,12 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         relayClient.ForwardedPorts.PortAdded += (sender, args) =>
             clientPortAdded.TrySetResult(args.Port.RemotePort);
 
-        await relayHost.AddPortAsync(new TunnelPort { PortNumber = this.localPortsFixture.Port }, CancellationToken.None);
+        await managementClient.CreateTunnelPortAsync(
+            tunnel,
+            new TunnelPort { PortNumber = this.localPortsFixture.Port },
+            options: null,
+            CancellationToken.None);
+        await relayHost.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port, await clientPortAdded.Task);
 
         // Reconnect the tunnel client
@@ -635,7 +652,12 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         await relayClientReconnected.Task;
 
         clientPortAdded = new TaskCompletionSource<int?>();
-        await relayHost.AddPortAsync(new TunnelPort { PortNumber = this.localPortsFixture.Port1 }, CancellationToken.None);
+        await managementClient.CreateTunnelPortAsync(
+            tunnel,
+            new TunnelPort { PortNumber = this.localPortsFixture.Port1 },
+            options: null,
+            CancellationToken.None);
+        await relayHost.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port1, await clientPortAdded.Task);
 
         Assert.Contains(relayClient.ForwardedPorts, p => p.RemotePort == this.localPortsFixture.Port);
@@ -656,6 +678,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
 
         // Create and start tunnel host
         var tunnel = CreateRelayTunnel(addClientEndpoint: false); // Hosting a tunnel adds the endpoint
+        await managementClient.CreateTunnelAsync(tunnel, options: null, default);
         var relayHost = new TunnelRelayTunnelHost(managementClient, TestTS);
         var multiChannelStream = await StartRelayHostAsync(relayHost, tunnel);
         var clientMultiChannelStream = new TaskCompletionSource<MultiChannelStream>();
@@ -686,7 +709,12 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         relayClient.ForwardedPorts.PortAdded += (sender, args) =>
             clientPortAdded.TrySetResult(args.Port.RemotePort);
 
-        await relayHost.AddPortAsync(new TunnelPort { PortNumber = this.localPortsFixture.Port }, CancellationToken.None);
+        await managementClient.CreateTunnelPortAsync(
+            tunnel,
+            new TunnelPort { PortNumber = this.localPortsFixture.Port },
+            options: null,
+            CancellationToken.None);
+        await relayHost.RefreshPortsAsync(CancellationToken.None);
         Assert.Equal(this.localPortsFixture.Port, await clientPortAdded.Task);
 
         // Expect disconnection
@@ -819,6 +847,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         var relayHost = new TunnelRelayTunnelHost(managementClient, TestTS);
 
         var tunnel = CreateRelayTunnel();
+        await managementClient.CreateTunnelAsync(tunnel, options: null, default);
 
         using var multiChannelStream = await StartRelayHostAsync(relayHost, tunnel);
 
@@ -833,8 +862,12 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         Assert.Empty(relayHost.RemoteForwarders);
 
         var testPort = GetAvailableTcpPort();
-        await relayHost.AddPortAsync(
-            new TunnelPort { PortNumber = (ushort)testPort }, CancellationToken.None);
+        await managementClient.CreateTunnelPortAsync(
+            tunnel,
+            new TunnelPort { PortNumber = (ushort)testPort },
+            options: null,
+            CancellationToken.None);
+        await relayHost.RefreshPortsAsync(CancellationToken.None);
         var forwarder = relayHost.RemoteForwarders.Values.Single();
         var forwardedPort = tunnel.Ports.Single();
         Assert.Equal((int)forwardedPort.PortNumber, forwarder.LocalPort);
@@ -864,7 +897,12 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         await TaskExtensions.WaitUntil(() => relayHost.RemoteForwarders.Count > 0)
             .WithTimeout(Timeout);
 
-        await relayHost.RemovePortAsync((ushort)testPort, CancellationToken.None);
+        await managementClient.DeleteTunnelPortAsync(
+            tunnel,
+            (ushort)testPort,
+            options: null,
+            CancellationToken.None);
+        await relayHost.RefreshPortsAsync(CancellationToken.None);
         Assert.Empty(relayHost.RemoteForwarders);
         Assert.Empty(tunnel.Ports);
     }

--- a/ts/.npmrc
+++ b/ts/.npmrc
@@ -1,4 +1,4 @@
 @vs:registry=https://devdiv.pkgs.visualstudio.com/_packaging/VS/npm/registry/
-https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/
+registry=https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/
 
 always-auth=true

--- a/ts/src/connections/multiModeTunnelClient.ts
+++ b/ts/src/connections/multiModeTunnelClient.ts
@@ -50,6 +50,10 @@ export class MultiModeTunnelClient implements TunnelClient {
         throw new Error('Method not implemented.');
     }
 
+    public async refreshPorts(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
     public dispose(): void {
         this.clients.forEach((client) => {
             client.dispose();

--- a/ts/src/connections/multiModeTunnelHost.ts
+++ b/ts/src/connections/multiModeTunnelHost.ts
@@ -26,39 +26,14 @@ export class MultiModeTunnelHost implements TunnelHost {
         await Promise.all(startTasks);
     }
 
-    public async addPort(portToAdd: TunnelPort): Promise<TunnelPort> {
-        let addTasks: Promise<TunnelPort>[] = [];
+    public async refreshPorts(): Promise<void> {
+        let refreshTasks: Promise<void>[] = [];
+
         this.hosts.forEach((host) => {
-            addTasks.push(host.addPort(portToAdd));
-        });
-        await Promise.all(addTasks);
-
-        return portToAdd;
-    }
-
-    public async removePort(portNumberToRemove: number): Promise<boolean> {
-        let result = true;
-        let removeTasks: Promise<boolean>[] = [];
-        this.hosts.forEach((host) => {
-            removeTasks.push(host.removePort(portNumberToRemove));
+            refreshTasks.push(host.refreshPorts());
         });
 
-        let results = await Promise.all(removeTasks);
-        results.forEach((res) => {
-            result = result && res;
-        });
-
-        return result;
-    }
-
-    public async updatePort(updatedPort: TunnelPort): Promise<TunnelPort> {
-        let updateTasks: Promise<TunnelPort>[] = [];
-        this.hosts.forEach((host) => {
-            updateTasks.push(host.updatePort(updatedPort));
-        });
-
-        await Promise.all(updateTasks);
-        return updatedPort;
+        await Promise.all(refreshTasks);
     }
 
     public dispose(): void {

--- a/ts/src/connections/tunnelClient.ts
+++ b/ts/src/connections/tunnelClient.ts
@@ -60,4 +60,16 @@ export interface TunnelClient extends Disposable {
      * @param cancellation Optional cancellation for the request.
      */
     waitForForwardedPort(forwardedPort: number, cancellation?: CancellationToken): Promise<void>;
+
+    /**
+     * Sends a request to the host to refresh ports that were updated using the management API,
+     * and waits for the refresh to complete.
+     *
+     * After using the management API to add or remove ports, call this method to have a
+     * connected client notify the host to update its cached list of ports. Any added or
+     * removed ports will then propagate back to the set of ports forwarded by the current
+     * client. After the returned task has completed, any newly added ports are usable from
+     * the current client.
+     */
+    refreshPorts(): Promise<void>;
 }

--- a/ts/src/connections/tunnelClientBase.ts
+++ b/ts/src/connections/tunnelClientBase.ts
@@ -226,6 +226,17 @@ export abstract class TunnelClientBase implements TunnelClient {
         e.authenticationPromise = Promise.resolve({});
     }
 
+    public async refreshPorts(): Promise<void> {
+        if (!this.sshSession || this.sshSession.isClosed) {
+            throw new Error('Not connected.');
+        }
+
+        const request = new SessionRequestMessage();
+        request.requestType = 'RefreshPorts';
+        request.wantReply = true;
+        await this.sshSession.request(request);
+    }
+
     private onSshSessionClosed(e: SshSessionClosedEventArgs) {
         this.sshSessionClosedEmitter.fire(this);
     }

--- a/ts/src/connections/tunnelHost.ts
+++ b/ts/src/connections/tunnelHost.ts
@@ -17,20 +17,12 @@ export interface TunnelHost extends Disposable {
     start(tunnel: Tunnel): Promise<void>;
 
     /**
-     * Adds and starts forwarding a port to a tunnel that is currently being hosted through Start
-     * @param portToAdd
+     *
+     * Refreshes ports that were updated using the management API.
+     *
+     * After using the management API to add or remove ports, call this method to have the
+     * host update its cached list of ports. Any added or removed ports will then propagate to
+     * the set of ports forwarded by all connected clients.
      */
-    addPort(portToAdd: TunnelPort): Promise<TunnelPort>;
-
-    /**
-     * Removes a port to a tunnel that is currently being hosted through Start
-     * @param portNumberToRemove
-     */
-    removePort(portNumberToRemove: number): Promise<boolean>;
-
-    /**
-     * Updates a port in a tunnel that is currently being hosted through Start
-     * @param updatedPort
-     */
-    updatePort(updatedPort: TunnelPort): Promise<TunnelPort>;
+    refreshPorts(): Promise<void>;
 }

--- a/ts/src/connections/tunnelHostBase.ts
+++ b/ts/src/connections/tunnelHostBase.ts
@@ -104,14 +104,14 @@ export abstract class TunnelHostBase implements TunnelHost {
                 const key = new SessionPortKey(session.sessionId!, Number(port.portNumber));
                 const forwarder = this.remoteForwarders[key.toString()];
                 if (!forwarder) {
-                    const pfs = session.getService(PortForwardingService) !;
+                    const pfs = session.getService(PortForwardingService)!;
                     forwardPromises.push(this.forwardPort(pfs, port));
                 }
             }
         }
 
         for (let [key, forwarder] of Object.entries(this.remoteForwarders)) {
-            if (!updatedPorts.some((p) => p.portNumber == forwarder.localPort)) {
+            if (!updatedPorts.some((p) => p.portNumber === forwarder.localPort)) {
                 delete this.remoteForwarders[key];
                 forwarder.dispose();
             }

--- a/ts/src/connections/tunnelHostBase.ts
+++ b/ts/src/connections/tunnelHostBase.ts
@@ -88,74 +88,36 @@ export abstract class TunnelHostBase implements TunnelHost {
         }
     }
 
-    public async addPort(portToAdd: TunnelPort): Promise<TunnelPort> {
-        if (!this.tunnel) {
-            throw new Error('Tunnel must be running');
+    public async refreshPorts(): Promise<void> {
+        if (!this.tunnel || !this.managementClient) {
+            return;
         }
 
-        let port = await this.managementClient.createTunnelPort(this.tunnel, portToAdd, undefined);
-        const promises = this.sshSessions.map(async (sshSession) => {
-            if (!sshSession.principal) {
-                // The session is not yet authenticated; all ports will be forwarded after
-                // the session is authenticated.
-                return;
+        const updatedTunnel = await this.managementClient.getTunnel(this.tunnel, undefined);
+        const updatedPorts = updatedTunnel?.ports ?? [];
+        this.tunnel.ports = updatedPorts;
+
+        const forwardPromises: Promise<any>[] = [];
+
+        for (let port of updatedPorts) {
+            for (let session of this.sshSessions.filter((s) => s.isConnected && s.sessionId)) {
+                const key = new SessionPortKey(session.sessionId!, Number(port.portNumber));
+                const forwarder = this.remoteForwarders[key.toString()];
+                if (!forwarder) {
+                    const pfs = session.getService(PortForwardingService) !;
+                    forwardPromises.push(this.forwardPort(pfs, port));
+                }
             }
-
-            let pfs: PortForwardingService | null = sshSession.getService(PortForwardingService);
-            if (!pfs) {
-                throw new Error('PFS must be active to add ports');
-            }
-
-            await this.forwardPort(pfs, port);
-        });
-        await Promise.all(promises);
-
-        return port;
-    }
-
-    public async removePort(portNumberToRemove: number): Promise<boolean> {
-        if (!this.tunnel || !this.tunnel.ports) {
-            throw new Error('Tunnel must be running and have ports to delete');
         }
 
-        let portDeleted = await this.managementClient.deleteTunnelPort(
-            this.tunnel,
-            portNumberToRemove,
-            undefined,
-        );
-
-        this.sshSessions.forEach((sshSession) => {
-            const sessionId = sshSession.sessionId;
-            if (sessionId) {
-                Object.keys(this.remoteForwarders).forEach((key) => {
-                    let entry = this.remoteForwarders[key];
-                    if (entry.localPort === portNumberToRemove) {
-                        // && key.sessionId.equals(sessionId))
-                        let remoteForwarder = this.remoteForwarders[key];
-                        delete this.remoteForwarders[key];
-                        if (remoteForwarder) {
-                            remoteForwarder.dispose();
-                        }
-                    }
-                });
+        for (let [key, forwarder] of Object.entries(this.remoteForwarders)) {
+            if (!updatedPorts.some((p) => p.portNumber == forwarder.localPort)) {
+                delete this.remoteForwarders[key];
+                forwarder.dispose();
             }
-        });
-
-        return portDeleted;
-    }
-
-    public async updatePort(updatedPort: TunnelPort): Promise<TunnelPort> {
-        if (!this.tunnel || !this.tunnel.ports) {
-            throw new Error('Tunnel must be running and have ports to update');
         }
 
-        let port = await this.managementClient.updateTunnelPort(
-            this.tunnel,
-            updatedPort,
-            undefined,
-        );
-
-        return port;
+        await Promise.all(forwardPromises);
     }
 
     protected async forwardPort(pfs: PortForwardingService, port: TunnelPort): Promise<boolean> {
@@ -177,7 +139,7 @@ export abstract class TunnelHostBase implements TunnelHost {
             return false;
         }
 
-        const key = new SessionPortKey(sessionId, Number(forwarder.remotePort));
+        const key = new SessionPortKey(sessionId, Number(forwarder.localPort));
         this.remoteForwarders[key.toString()] = forwarder;
         return true;
     }

--- a/ts/src/connections/tunnelRelayTunnelHost.ts
+++ b/ts/src/connections/tunnelRelayTunnelHost.ts
@@ -191,7 +191,7 @@ export class TunnelRelayTunnelHost extends TunnelHostBase {
         });
         const requestRegistration = session.onRequest((e) => {
             this.onSshSessionRequest(e, session);
-        })
+        });
         const channelOpeningEventRegistration = session.onChannelOpening((e) => {
             this.onSshChannelOpening(e, session);
         });
@@ -242,8 +242,7 @@ export class TunnelRelayTunnelHost extends TunnelHostBase {
 
     private onSshSessionRequest(e: SshRequestEventArgs<SessionRequestMessage>, session: any) {
         if (e.requestType === 'RefreshPorts') {
-            e.responsePromise = (async () =>
-            {
+            e.responsePromise = (async () => {
                 await this.refreshPorts();
                 return new SessionRequestSuccessMessage();
             })();

--- a/ts/src/connections/tunnelRelayTunnelHost.ts
+++ b/ts/src/connections/tunnelRelayTunnelHost.ts
@@ -24,6 +24,9 @@ import {
     PromiseCompletionSource,
     CancellationError,
     ObjectDisposedError,
+    SessionRequestMessage,
+    SshRequestEventArgs,
+    SessionRequestSuccessMessage,
 } from '@vs/vs-ssh';
 import { PortForwardChannelOpenMessage, PortForwardingService } from '@vs/vs-ssh-tcp';
 import { CancellationToken, CancellationTokenSource, Disposable } from 'vscode-jsonrpc';
@@ -186,6 +189,9 @@ export class TunnelRelayTunnelHost extends TunnelHostBase {
         session.onClientAuthenticated(() => {
             this.onSshClientAuthenticated(session);
         });
+        const requestRegistration = session.onRequest((e) => {
+            this.onSshSessionRequest(e, session);
+        })
         const channelOpeningEventRegistration = session.onChannelOpening((e) => {
             this.onSshChannelOpening(e, session);
         });
@@ -200,6 +206,7 @@ export class TunnelRelayTunnelHost extends TunnelHostBase {
             await tcs.promise;
         } finally {
             authenticatingEventRegistration.dispose();
+            requestRegistration.dispose();
             channelOpeningEventRegistration.dispose();
             closedEventRegistration.dispose();
         }
@@ -230,6 +237,16 @@ export class TunnelRelayTunnelHost extends TunnelHostBase {
                     );
                 }
             });
+        }
+    }
+
+    private onSshSessionRequest(e: SshRequestEventArgs<SessionRequestMessage>, session: any) {
+        if (e.requestType === 'RefreshPorts') {
+            e.responsePromise = (async () =>
+            {
+                await this.refreshPorts();
+                return new SessionRequestSuccessMessage();
+            })();
         }
     }
 

--- a/ts/test/tunnels-test/connectTests.ts
+++ b/ts/test/tunnels-test/connectTests.ts
@@ -96,6 +96,9 @@ class MockTunnelClient implements TunnelClient {
     waitForForwardedPort(forwardedPort: number, cancellation?: CancellationToken): Promise<void> {
         throw new Error('Method not implemented.');
     }
+    refreshPorts(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
 
     dispose(): void {
         throw new Error('Method not implemented.');

--- a/ts/test/tunnels-test/tunnelHostAndClientTests.ts
+++ b/ts/test/tunnels-test/tunnelHostAndClientTests.ts
@@ -316,6 +316,7 @@ export class TunnelHostAndClientTests {
         let relayHost = new TunnelRelayTunnelHost(managementClient);
 
         let tunnel = this.createRelayTunnel();
+        await managementClient.createTunnel(tunnel);
         let multiChannelStream = await this.startRelayHost(relayHost, tunnel);
         let clientRelayStream = await multiChannelStream.openStream(
             TunnelRelayTunnelHost.clientStreamChannelType,
@@ -325,7 +326,8 @@ export class TunnelHostAndClientTests {
         let clientCredentials: SshClientCredentials = { username: 'tunnel', password: undefined };
         await clientSshSession.authenticate(clientCredentials);
 
-        await relayHost.addPort({ portNumber: 9985 });
+        await managementClient.createTunnelPort(tunnel, { portNumber: 9985 });
+        await relayHost.refreshPorts();
 
         assert.strictEqual(tunnel.ports!.length, 1);
         const forwardedPort = tunnel.ports![0];
@@ -346,6 +348,7 @@ export class TunnelHostAndClientTests {
         let relayHost = new TunnelRelayTunnelHost(managementClient);
 
         let tunnel = this.createRelayTunnel([9986]);
+        await managementClient.createTunnel(tunnel);
         let multiChannelStream = await this.startRelayHost(relayHost, tunnel);
         let clientRelayStream = await multiChannelStream.openStream(
             TunnelRelayTunnelHost.clientStreamChannelType,
@@ -358,7 +361,8 @@ export class TunnelHostAndClientTests {
         while (Object.keys(relayHost.remoteForwarders).length < 1) {
             await new Promise((r) => setTimeout(r, 2000));
         }
-        await relayHost.removePort(9986);
+        await managementClient.deleteTunnelPort(tunnel, 9985);
+        await relayHost.refreshPorts();
 
         assert.strictEqual(tunnel.ports!.length, 0);
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/basis-planning/issues/450

These changes enable a client with management access to update the set of forwarded ports on an actively hosted tunnel.

 - Add `RefreshPortsAsync()` API to `ITunnelHost` and `ITunnelClient`
 - Implement on the host side by using the management client to get the updated list of ports, and updating SSH port-forwarding state accordingly.
 - Implement on the client side by sending a special SSH request message of type `RefreshPorts` to the host, that simply triggers the above operation.
 - Remove Add/Update/Remove ports APIs from `ITunnelHost`. Any calls to those should be replaced by calls to the equivalent management APIs, followed by `RefreshPortsAsync()`. Test code is updated accordingly.

 **TODO**: (soon) Port changes to other SDK languages (Java, Go, Rust). Merging the C# + TS changes first to unblock partners.

 **TODO**: (later) It would be better if the tunnel service could notify the host immediately whenever changes happen. That would eliminate the need for this "refresh" API. But it would require a lot more server-side plumbing to accomplish.