### PR TITLE
 Add manage:ports access scope

### DIFF
--- a/cs/src/Contracts/TunnelAccessControl.cs
+++ b/cs/src/Contracts/TunnelAccessControl.cs
@@ -78,7 +78,8 @@ namespace Microsoft.VsSaaS.TunnelService.Contracts
         /// <param name="validScopes">Optional subset of scopes to be considered valid;
         /// if omitted then all defined scopes are valid.</param>
         /// <param name="allowMultiple">Whether to allow multiple space-delimited scopes in a
-        /// single item.</param>
+        /// single item. Multiple scopes are supported when requesting a tunnel access token
+        /// with a combination of scopes.</param>
         /// <exception cref="ArgumentException">A scope is not valid.</exception>
         public static void ValidateScopes(
             IEnumerable<string> scopes,

--- a/cs/src/Contracts/TunnelAccessControl.cs
+++ b/cs/src/Contracts/TunnelAccessControl.cs
@@ -77,14 +77,22 @@ namespace Microsoft.VsSaaS.TunnelService.Contracts
         /// <param name="scopes">List of scopes to validate.</param>
         /// <param name="validScopes">Optional subset of scopes to be considered valid;
         /// if omitted then all defined scopes are valid.</param>
+        /// <param name="allowMultiple">Whether to allow multiple space-delimited scopes in a
+        /// single item.</param>
         /// <exception cref="ArgumentException">A scope is not valid.</exception>
         public static void ValidateScopes(
             IEnumerable<string> scopes,
-            IEnumerable<string>? validScopes = null)
+            IEnumerable<string>? validScopes = null,
+            bool allowMultiple = false)
         {
             if (scopes == null)
             {
                 throw new ArgumentNullException(nameof(scopes));
+            }
+
+            if (allowMultiple)
+            {
+                scopes = scopes.SelectMany((s) => s.Split(' '));
             }
 
             foreach (var scope in scopes)

--- a/cs/src/Contracts/TunnelAccessScopes.cs
+++ b/cs/src/Contracts/TunnelAccessScopes.cs
@@ -3,54 +3,62 @@
 // Licensed under the MIT license.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+namespace Microsoft.VsSaaS.TunnelService.Contracts;
 
-namespace Microsoft.VsSaaS.TunnelService.Contracts
+/// <summary>
+/// Defines scopes for tunnel access tokens.
+/// </summary>
+/// <remarks>
+/// A tunnel access token with one or more of these scopes typically also has cluster ID and
+/// tunnel ID claims that limit the access scope to a specific tunnel, and may also have one
+/// or more port claims that further limit the access to particular ports of the tunnel.
+/// </remarks>
+public static class TunnelAccessScopes
 {
     /// <summary>
-    /// Defines scopes for tunnel access tokens.
+    /// Allows creating tunnels. This scope is valid only in policies at the global, domain,
+    /// or organization level; it is not relevant to an already-created tunnel or tunnel port.
+    /// (Creation of ports requires "manage" or "host" access to the tunnel.)
     /// </summary>
-    public static class TunnelAccessScopes
+    public const string Create = "create";
+
+    /// <summary>
+    /// Allows management operations on tunnels and tunnel ports.
+    /// </summary>
+    public const string Manage = "manage";
+
+    /// <summary>
+    /// Allows management operations on all ports of a tunnel, but does not allow updating any
+    /// other tunnel properties or deleting the tunnel.
+    /// </summary>
+    public const string ManagePorts = "manage:ports";
+
+    /// <summary>
+    /// Allows accepting connections on tunnels as a host. Includes access to update tunnel
+    /// endpoints and ports.
+    /// </summary>
+    public const string Host = "host";
+
+    /// <summary>
+    /// Allows inspecting tunnel connection activity and data.
+    /// </summary>
+    public const string Inspect = "inspect";
+
+    /// <summary>
+    /// Allows connecting to tunnels or ports as a client.
+    /// </summary>
+    public const string Connect = "connect";
+
+    /// <summary>
+    /// Array of all access scopes. Primarily used for validation.
+    /// </summary>
+    public static readonly string[] All = new[]
     {
-        /// <summary>
-        /// Allows creating tunnels. This scope is valid only in policies at the global, domain,
-        /// or organization level; it is not relevant to an already-created tunnel or tunnel port.
-        /// (Creation of ports requires "manage" or "host" access to the tunnel.)
-        /// </summary>
-        public const string Create = "create";
-
-        /// <summary>
-        /// Allows management operations on tunnels and tunnel ports.
-        /// </summary>
-        public const string Manage = "manage";
-
-        /// <summary>
-        /// Allows accepting connections on tunnels as a host.
-        /// </summary>
-        public const string Host = "host";
-
-        /// <summary>
-        /// Allows inspecting tunnel connection activity and data.
-        /// </summary>
-        public const string Inspect = "inspect";
-
-        /// <summary>
-        /// Allows connecting to tunnels as a client.
-        /// </summary>
-        public const string Connect = "connect";
-
-        /// <summary>
-        /// Array of all access scopes.
-        /// </summary>
-        public static readonly string[] All = new[]
-        {
-            Create,
-            Manage,
-            Host,
-            Inspect,
-            Connect,
-        };
-    }
+        Create,
+        Manage,
+        ManagePorts,
+        Host,
+        Inspect,
+        Connect,
+    };
 }

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -735,8 +735,27 @@ namespace Microsoft.VsSaaS.TunnelService
             {
                 foreach (var scope in accessTokenScopes)
                 {
-                    if (tunnel.AccessTokens.TryGetValue(scope, out var accessToken) == true &&
-                        !string.IsNullOrEmpty(accessToken))
+                    string? accessToken = null;
+                    foreach (var scopeAndToken in tunnel.AccessTokens)
+                    {
+                        // Each key may be either a single scope or space-delimited list of scopes.
+                        if (scopeAndToken.Key.IndexOf(' ') > 0)
+                        {
+                            var scopes = scopeAndToken.Key.Split(' ');
+                            if (scopes.Contains(scope))
+                            {
+                                accessToken = scopeAndToken.Value;
+                                break;
+                            }
+                        }
+                        else if (scopeAndToken.Key == scope)
+                        {
+                            accessToken = scopeAndToken.Value;
+                            break;
+                        }
+                    }
+                    
+                    if (!string.IsNullOrEmpty(accessToken))
                     {
                         TunnelAccessTokenProperties.ValidateTokenExpiration(accessToken);
                         authHeader = new AuthenticationHeaderValue(

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -47,12 +47,6 @@ namespace Microsoft.VsSaaS.TunnelService
         private static readonly string[] ReadAccessTokenScopes = new[]
         {
             TunnelAccessScopes.Manage,
-            TunnelAccessScopes.Host,
-            TunnelAccessScopes.Connect,
-        };
-        private static readonly string[] ReadPortsAccessTokenScopes = new[]
-        {
-            TunnelAccessScopes.Manage,
             TunnelAccessScopes.ManagePorts,
             TunnelAccessScopes.Host,
             TunnelAccessScopes.Connect,
@@ -991,7 +985,7 @@ namespace Microsoft.VsSaaS.TunnelService
             var result = await this.SendTunnelRequestAsync<TunnelPort[]>(
                 HttpMethod.Get,
                 tunnel,
-                ReadPortsAccessTokenScopes,
+                ReadAccessTokenScopes,
                 PortsApiSubPath,
                 query: null,
                 options,
@@ -1010,7 +1004,7 @@ namespace Microsoft.VsSaaS.TunnelService
             var result = await this.SendTunnelRequestAsync<TunnelPort>(
                 HttpMethod.Get,
                 tunnel,
-                ReadPortsAccessTokenScopes,
+                ReadAccessTokenScopes,
                 path,
                 query: null,
                 options,

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -38,11 +38,22 @@ namespace Microsoft.VsSaaS.TunnelService
             new[] { TunnelAccessScopes.Manage };
         private static readonly string[] HostAccessTokenScope =
             new[] { TunnelAccessScopes.Host };
-        private static readonly string[] HostOrManageAccessTokenScopes =
-            new[] { TunnelAccessScopes.Manage, TunnelAccessScopes.Host };
+        private static readonly string[] ManagePortsAccessTokenScopes = new[]
+        {
+            TunnelAccessScopes.Manage,
+            TunnelAccessScopes.ManagePorts,
+            TunnelAccessScopes.Host,
+        };
         private static readonly string[] ReadAccessTokenScopes = new[]
         {
             TunnelAccessScopes.Manage,
+            TunnelAccessScopes.Host,
+            TunnelAccessScopes.Connect,
+        };
+        private static readonly string[] ReadPortsAccessTokenScopes = new[]
+        {
+            TunnelAccessScopes.Manage,
+            TunnelAccessScopes.ManagePorts,
             TunnelAccessScopes.Host,
             TunnelAccessScopes.Connect,
         };
@@ -980,7 +991,7 @@ namespace Microsoft.VsSaaS.TunnelService
             var result = await this.SendTunnelRequestAsync<TunnelPort[]>(
                 HttpMethod.Get,
                 tunnel,
-                ReadAccessTokenScopes,
+                ReadPortsAccessTokenScopes,
                 PortsApiSubPath,
                 query: null,
                 options,
@@ -999,7 +1010,7 @@ namespace Microsoft.VsSaaS.TunnelService
             var result = await this.SendTunnelRequestAsync<TunnelPort>(
                 HttpMethod.Get,
                 tunnel,
-                ReadAccessTokenScopes,
+                ReadPortsAccessTokenScopes,
                 path,
                 query: null,
                 options,
@@ -1019,7 +1030,7 @@ namespace Microsoft.VsSaaS.TunnelService
             var result = (await this.SendTunnelRequestAsync<TunnelPort, TunnelPort>(
                 HttpMethod.Post,
                 tunnel,
-                HostOrManageAccessTokenScopes,
+                ManagePortsAccessTokenScopes,
                 PortsApiSubPath,
                 query: null,
                 options,
@@ -1060,7 +1071,7 @@ namespace Microsoft.VsSaaS.TunnelService
             var result = (await this.SendTunnelRequestAsync<TunnelPort, TunnelPort>(
                 HttpMethod.Put,
                 tunnel,
-                HostOrManageAccessTokenScopes,
+                ManagePortsAccessTokenScopes,
                 path,
                 query: null,
                 options,
@@ -1098,7 +1109,7 @@ namespace Microsoft.VsSaaS.TunnelService
             var result = await this.SendTunnelRequestAsync<bool>(
                 HttpMethod.Delete,
                 tunnel,
-                HostOrManageAccessTokenScopes,
+                ManagePortsAccessTokenScopes,
                 path,
                 query: null,
                 options,

--- a/cs/src/Management/TunnelRequestOptions.cs
+++ b/cs/src/Management/TunnelRequestOptions.cs
@@ -81,21 +81,18 @@ namespace Microsoft.VsSaaS.TunnelService
         public bool RequireAllTags { get; set; }
 
         /// <summary>
-        /// Gets or sets an optional list of scopes that should be authorized when retrieving a
-        /// tunnel or tunnel port object.
-        /// </summary>
-        /// <remarks>
-        /// For service-to-service calls using forwarded client credentials, the scope(s) should
-        /// match the action the client is requesting, such as "host" or "connect". This enables
-        /// the calling service to ensure the client is specifically authorized for the supplied
-        /// scope(s), rather than just any scopes permitted by the API.
-        /// </remarks>
-        public string[]? Scopes { get; set; }
-
-        /// <summary>
         /// Gets or sets an optional list of token scopes that are requested when retrieving
         /// a tunnel or tunnel port object.
         /// </summary>
+        /// <remarks>
+        /// Each item in the array must be a single scope from <see cref="TunnelAccessScopes"/>
+        /// or a space-delimited combination of multiple scopes. The service issues an access
+        /// token for each scope or combination and returns the token(s) in the
+        /// <see cref="Tunnel.AccessTokens"/> or <see cref="TunnelPort.AccessTokens"/> dictionary.
+        /// If the caller does not have permission to get a token for one or more scopes then a
+        /// token is not returned but the overall request does not fail. Token properties including
+        /// scopes and expiration may be checked using <see cref="TunnelAccessTokenProperties"/>.
+        /// </remarks>
         public string[]? TokenScopes { get; set; }
 
         /// <summary>
@@ -117,15 +114,10 @@ namespace Microsoft.VsSaaS.TunnelService
                 queryOptions["includePorts"] = TrueOption;
             }
 
-            if (Scopes != null)
-            {
-                TunnelAccessControl.ValidateScopes(Scopes);
-                queryOptions["scopes"] = Scopes;
-            }
-
             if (TokenScopes != null)
             {
-                TunnelAccessControl.ValidateScopes(TokenScopes);
+                TunnelAccessControl.ValidateScopes(
+                    TokenScopes, validScopes: null, allowMultiple: true);
                 queryOptions["tokenScopes"] = TokenScopes;
             }
 

--- a/go/tunnels/access_scopes.go
+++ b/go/tunnels/access_scopes.go
@@ -3,22 +3,38 @@
 
 package tunnels
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 var (
 	allScopes = map[TunnelAccessScope]bool{
-		TunnelAccessScopeManage:  true,
-		TunnelAccessScopeHost:    true,
-		TunnelAccessScopeInspect: true,
-		TunnelAccessScopeConnect: true,
+		TunnelAccessScopeManage:      true,
+		TunnelAccessScopeManagePorts: true,
+		TunnelAccessScopeHost:        true,
+		TunnelAccessScopeInspect:     true,
+		TunnelAccessScopeConnect:     true,
 	}
 )
 
-func (s *TunnelAccessScopes) valid(validScopes []TunnelAccessScope) error {
+func (s *TunnelAccessScopes) valid(validScopes []TunnelAccessScope, allowMultiple bool) error {
 	if s == nil {
 		return fmt.Errorf("scopes cannot be null")
 	}
-	for _, scope := range *s {
+
+	var scopes TunnelAccessScopes
+	if allowMultiple {
+		for _, scope := range *s {
+			for _, ss := range strings.Split(string(scope), " ") {
+				scopes = append(scopes, TunnelAccessScope(ss))
+			}
+		}
+	} else {
+		scopes = *s
+	}
+
+	for _, scope := range scopes {
 		if len(scope) == 0 {
 			return fmt.Errorf("scope cannot be null")
 		} else if !allScopes[scope] {
@@ -26,7 +42,7 @@ func (s *TunnelAccessScopes) valid(validScopes []TunnelAccessScope) error {
 		}
 	}
 	if len(validScopes) > 0 {
-		for _, scope := range *s {
+		for _, scope := range scopes {
 			if !scopeContains(validScopes, scope) {
 				return fmt.Errorf("tunnel access scope is invalid for current request: %s", scope)
 			}

--- a/go/tunnels/manager.go
+++ b/go/tunnels/manager.go
@@ -56,8 +56,9 @@ var (
 var (
 	manageAccessTokenScope       = []TunnelAccessScope{TunnelAccessScopeManage}
 	hostAccessTokenScope         = []TunnelAccessScope{TunnelAccessScopeHost}
-	hostOrManageAccessTokenScope = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeHost}
-	readAccessTokenScope         = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeHost, TunnelAccessScopeConnect}
+	managePortsAccessTokenScopes = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeManagePorts, TunnelAccessScopeHost}
+	readAccessTokenScopes        = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeHost, TunnelAccessScopeConnect}
+	readPortsAccessTokenScopes   = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeManagePorts, TunnelAccessScopeHost, TunnelAccessScopeConnect}
 )
 
 // UserAgent contains the name and version of the client.
@@ -124,7 +125,7 @@ func (m *Manager) ListTunnels(
 		queryParams.Add("domain", domain)
 	}
 	url := m.buildUri(clusterID, tunnelsApiPath, options, queryParams.Encode())
-	response, err := m.sendTunnelRequest(ctx, nil, options, http.MethodGet, url, nil, nil, readAccessTokenScope, false)
+	response, err := m.sendTunnelRequest(ctx, nil, options, http.MethodGet, url, nil, nil, readAccessTokenScopes, false)
 	if err != nil {
 		return nil, fmt.Errorf("error sending list tunnel request: %w", err)
 	}
@@ -146,7 +147,7 @@ func (m *Manager) GetTunnel(ctx context.Context, tunnel *Tunnel, options *Tunnel
 		return nil, fmt.Errorf("error creating tunnel url: %w", err)
 	}
 
-	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readAccessTokenScope, true)
+	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readAccessTokenScopes, true)
 	if err != nil {
 		return nil, fmt.Errorf("error sending get tunnel request: %w", err)
 	}
@@ -315,7 +316,7 @@ func (m *Manager) ListTunnelPorts(
 		return nil, fmt.Errorf("error creating tunnel url: %w", err)
 	}
 
-	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readAccessTokenScope, false)
+	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readPortsAccessTokenScopes, false)
 	if err != nil {
 		return nil, fmt.Errorf("error sending list tunnel ports request: %w", err)
 	}
@@ -336,7 +337,7 @@ func (m *Manager) GetTunnelPort(
 		return nil, fmt.Errorf("error creating tunnel url: %w", err)
 	}
 
-	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readAccessTokenScope, true)
+	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readPortsAccessTokenScopes, true)
 	if err != nil {
 		return nil, fmt.Errorf("error sending get tunnel port request: %w", err)
 	}
@@ -364,7 +365,7 @@ func (m *Manager) CreateTunnelPort(
 		return nil, fmt.Errorf("error converting port for request: %w", err)
 	}
 
-	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodPost, url, convertedPort, nil, hostOrManageAccessTokenScope, true)
+	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodPost, url, convertedPort, nil, managePortsAccessTokenScopes, true)
 	if err != nil {
 		return nil, fmt.Errorf("error sending create tunnel port request: %w", err)
 	}
@@ -407,7 +408,7 @@ func (m *Manager) UpdateTunnelPort(
 		return nil, fmt.Errorf("error converting port for request: %w", err)
 	}
 
-	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodPut, url, convertedPort, updateFields, hostOrManageAccessTokenScope, true)
+	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodPut, url, convertedPort, updateFields, managePortsAccessTokenScopes, true)
 	if err != nil {
 		return nil, fmt.Errorf("error sending update tunnel port request: %w", err)
 	}
@@ -443,7 +444,7 @@ func (m *Manager) DeleteTunnelPort(
 		return fmt.Errorf("error creating tunnel url: %w", err)
 	}
 
-	_, err = m.sendTunnelRequest(ctx, tunnel, options, http.MethodDelete, url, nil, nil, hostOrManageAccessTokenScope, true)
+	_, err = m.sendTunnelRequest(ctx, tunnel, options, http.MethodDelete, url, nil, nil, managePortsAccessTokenScopes, true)
 	if err != nil {
 		return fmt.Errorf("error sending get tunnel request: %w", err)
 	}

--- a/go/tunnels/manager.go
+++ b/go/tunnels/manager.go
@@ -57,8 +57,7 @@ var (
 	manageAccessTokenScope       = []TunnelAccessScope{TunnelAccessScopeManage}
 	hostAccessTokenScope         = []TunnelAccessScope{TunnelAccessScopeHost}
 	managePortsAccessTokenScopes = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeManagePorts, TunnelAccessScopeHost}
-	readAccessTokenScopes        = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeHost, TunnelAccessScopeConnect}
-	readPortsAccessTokenScopes   = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeManagePorts, TunnelAccessScopeHost, TunnelAccessScopeConnect}
+	readAccessTokenScopes        = []TunnelAccessScope{TunnelAccessScopeManage, TunnelAccessScopeManagePorts, TunnelAccessScopeHost, TunnelAccessScopeConnect}
 )
 
 // UserAgent contains the name and version of the client.
@@ -316,7 +315,7 @@ func (m *Manager) ListTunnelPorts(
 		return nil, fmt.Errorf("error creating tunnel url: %w", err)
 	}
 
-	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readPortsAccessTokenScopes, false)
+	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readAccessTokenScopes, false)
 	if err != nil {
 		return nil, fmt.Errorf("error sending list tunnel ports request: %w", err)
 	}
@@ -337,7 +336,7 @@ func (m *Manager) GetTunnelPort(
 		return nil, fmt.Errorf("error creating tunnel url: %w", err)
 	}
 
-	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readPortsAccessTokenScopes, true)
+	response, err := m.sendTunnelRequest(ctx, tunnel, options, http.MethodGet, url, nil, nil, readAccessTokenScopes, true)
 	if err != nil {
 		return nil, fmt.Errorf("error sending get tunnel port request: %w", err)
 	}

--- a/go/tunnels/manager_test.go
+++ b/go/tunnels/manager_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	serviceUrl           = "https://localhost:9901/"
+	serviceUrl           = ServiceProperties.ServiceURI
 	ctx                  = context.Background()
 	userAgentManagerTest = []UserAgent{{Name: "Tunnels-Go-SDK-Tests/Manager", Version: PackageVersion}}
 )

--- a/go/tunnels/manager_test.go
+++ b/go/tunnels/manager_test.go
@@ -646,7 +646,7 @@ func TestTunnelEndpoints(t *testing.T) {
 
 	tunnel := &Tunnel{}
 	options := &TunnelRequestOptions{
-		TokenScopes: hostOrManageAccessTokenScopes,
+		TokenScopes: managePortsAccessTokenScopes,
 	}
 	createdTunnel, err := managementClient.CreateTunnel(ctx, tunnel, options)
 	if err != nil {

--- a/go/tunnels/manager_test.go
+++ b/go/tunnels/manager_test.go
@@ -16,19 +16,20 @@ import (
 )
 
 var (
-	serviceUrl           = ServiceProperties.ServiceURI
+	serviceUrl           = "https://localhost:9901/"
 	ctx                  = context.Background()
 	userAgentManagerTest = []UserAgent{{Name: "Tunnels-Go-SDK-Tests/Manager", Version: PackageVersion}}
 )
 
-func getAccessToken() string {
+func getUserToken() string {
+	// Example: "github <gh-token>" or "Bearer <aad-token>"
 	return ""
 }
 
 // These tests do not automatically run in the PR check github action
 // beacuse they require authentication. If you want to run these tests
 // you must first generate a tunnels access token and paste it in the
-// getAccessToken return value.
+// getUserToken return value.
 func TestTunnelCreateDelete(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -40,7 +41,7 @@ func TestTunnelCreateDelete(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -79,7 +80,7 @@ func TestListTunnels(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -138,7 +139,7 @@ func TestTunnelCreateUpdateDelete(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -189,7 +190,7 @@ func TestTunnelCreateUpdateTwiceDelete(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -253,7 +254,7 @@ func TestTunnelCreateGetDelete(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -304,7 +305,7 @@ func TestTunnelAddPort(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -368,7 +369,7 @@ func TestTunnelDeletePort(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -451,13 +452,13 @@ func TestTunnelUpdatePort(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
 	tunnel := &Tunnel{}
-	options := &TunnelRequestOptions{IncludePorts: true, Scopes: []TunnelAccessScope{"manage"}, TokenScopes: []TunnelAccessScope{"manage"}}
+	options := &TunnelRequestOptions{IncludePorts: true, TokenScopes: []TunnelAccessScope{"manage"}}
 	createdTunnel, err := managementClient.CreateTunnel(ctx, tunnel, options)
 	if err != nil {
 		t.Errorf(err.Error())
@@ -551,7 +552,7 @@ func TestTunnelListPorts(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -638,7 +639,7 @@ func TestTunnelEndpoints(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	managementClient, err := NewManager(userAgentManagerTest, getAccessToken, url, nil)
+	managementClient, err := NewManager(userAgentManagerTest, getUserToken, url, nil)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -738,5 +739,24 @@ func TestResourceStatusUnmarshal(t *testing.T) {
 
 	if result1.Current != result2.Current {
 		t.Errorf("%d != %d", result1.Current, result2.Current)
+	}
+}
+
+func TestValidTokenScopes(t *testing.T) {
+	var validScopes = TunnelAccessScopes{ "host", "connect" }
+	var invalidScopes = TunnelAccessScopes{ "invalid", "connect" }
+	var multiScopes = TunnelAccessScopes{ "host connect", "manage" }
+
+	if err := validScopes.valid(nil, false); err != nil {
+		t.Error(err)
+	}
+	if err := invalidScopes.valid(nil, false); err == nil {
+		t.Errorf("Invalid scopes should not be valid")
+	}
+	if err := multiScopes.valid(nil, true); err != nil {
+		t.Error(err)
+	}
+	if err := multiScopes.valid(nil, false); err == nil {
+		t.Errorf("Multiple scopes should not be valid without allowMultiple flag")
 	}
 }

--- a/go/tunnels/manager_test.go
+++ b/go/tunnels/manager_test.go
@@ -646,7 +646,7 @@ func TestTunnelEndpoints(t *testing.T) {
 
 	tunnel := &Tunnel{}
 	options := &TunnelRequestOptions{
-		TokenScopes: hostOrManageAccessTokenScope,
+		TokenScopes: hostOrManageAccessTokenScopes,
 	}
 	createdTunnel, err := managementClient.CreateTunnel(ctx, tunnel, options)
 	if err != nil {

--- a/go/tunnels/request_options.go
+++ b/go/tunnels/request_options.go
@@ -30,9 +30,6 @@ type TunnelRequestOptions struct {
 	// If false, an item is included if any tag matches.
 	RequireAllTags bool
 
-	// List of scopes that are needed for the current request.
-	Scopes TunnelAccessScopes
-
 	// List of token scopes that are requested when retrieving a tunnel or tunnel port object.
 	TokenScopes TunnelAccessScopes
 
@@ -45,16 +42,9 @@ func (options *TunnelRequestOptions) queryString() string {
 	if options.IncludePorts {
 		queryOptions.Set("includePorts", "true")
 	}
-	if options.Scopes != nil {
-		if err := options.Scopes.valid(nil); err == nil {
-			for _, scope := range options.Scopes {
-				queryOptions.Add("scopes", string(scope))
-			}
 
-		}
-	}
 	if options.TokenScopes != nil {
-		if err := options.TokenScopes.valid(nil); err == nil {
+		if err := options.TokenScopes.valid(nil, true); err == nil {
 			for _, scope := range options.TokenScopes {
 				queryOptions.Add("tokenScopes", string(scope))
 			}

--- a/go/tunnels/tunnel_access_scopes.go
+++ b/go/tunnels/tunnel_access_scopes.go
@@ -5,6 +5,11 @@
 package tunnels
 
 // Defines scopes for tunnel access tokens.
+//
+// A tunnel access token with one or more of these scopes typically also has cluster ID
+// and tunnel ID claims that limit the access scope to a specific tunnel, and may also
+// have one or more port claims that further limit the access to particular ports of the
+// tunnel.
 type TunnelAccessScopes []TunnelAccessScope
 type TunnelAccessScope string
 
@@ -12,17 +17,22 @@ const (
 	// Allows creating tunnels. This scope is valid only in policies at the global, domain,
 	// or organization level; it is not relevant to an already-created tunnel or tunnel port.
 	// (Creation of ports requires "manage" or "host" access to the tunnel.)
-	TunnelAccessScopeCreate  TunnelAccessScope = "create"
+	TunnelAccessScopeCreate      TunnelAccessScope = "create"
 
 	// Allows management operations on tunnels and tunnel ports.
-	TunnelAccessScopeManage  TunnelAccessScope = "manage"
+	TunnelAccessScopeManage      TunnelAccessScope = "manage"
 
-	// Allows accepting connections on tunnels as a host.
-	TunnelAccessScopeHost    TunnelAccessScope = "host"
+	// Allows management operations on all ports of a tunnel, but does not allow updating any
+	// other tunnel properties or deleting the tunnel.
+	TunnelAccessScopeManagePorts TunnelAccessScope = "manage:ports"
+
+	// Allows accepting connections on tunnels as a host. Includes access to update tunnel
+	// endpoints and ports.
+	TunnelAccessScopeHost        TunnelAccessScope = "host"
 
 	// Allows inspecting tunnel connection activity and data.
-	TunnelAccessScopeInspect TunnelAccessScope = "inspect"
+	TunnelAccessScopeInspect     TunnelAccessScope = "inspect"
 
-	// Allows connecting to tunnels as a client.
-	TunnelAccessScopeConnect TunnelAccessScope = "connect"
+	// Allows connecting to tunnels or ports as a client.
+	TunnelAccessScopeConnect     TunnelAccessScope = "connect"
 )

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControl.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControl.java
@@ -33,7 +33,7 @@ public class TunnelAccessControl {
     /**
      * Checks that all items in an array of scopes are valid.
      */
-    public static void validateScopes(Collection<String> scopes, Collection<String> validScopes) {
-        TunnelAccessControlStatics.validateScopes(scopes, validScopes);
+    public static void validateScopes(Collection<String> scopes, Collection<String> validScopes, boolean allowMultiple) {
+        TunnelAccessControlStatics.validateScopes(scopes, validScopes, allowMultiple);
     }
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlStatics.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlStatics.java
@@ -5,6 +5,7 @@ package com.microsoft.tunnels.contracts;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import org.apache.maven.shared.utils.StringUtils;
 
@@ -18,7 +19,8 @@ class TunnelAccessControlStatics {
     }
 
     if (allowMultiple) {
-      scopes = scopes.stream().flatMap((s) -> Arrays.stream(s.split(" "))).toList();
+      scopes = scopes.stream().flatMap((s) -> Arrays.stream(s.split(" ")))
+        .collect(Collectors.toList());
     }
 
     var allScopes = Arrays.asList(new String[] {

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlStatics.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlStatics.java
@@ -11,16 +11,23 @@ import org.apache.maven.shared.utils.StringUtils;
 class TunnelAccessControlStatics {
   static void validateScopes(
       Collection<String> scopes,
-      Collection<String> validScopes) {
+      Collection<String> validScopes,
+      boolean allowMultiple) {
     if (scopes == null) {
       throw new IllegalArgumentException("scopes must not be null");
     }
+
+    if (allowMultiple) {
+      scopes = scopes.stream().flatMap((s) -> Arrays.stream(s.split(" "))).toList();
+    }
+
     var allScopes = Arrays.asList(new String[] {
         TunnelAccessScopes.connect,
         TunnelAccessScopes.create,
         TunnelAccessScopes.host,
         TunnelAccessScopes.inspect,
-        TunnelAccessScopes.manage });
+        TunnelAccessScopes.manage,
+        TunnelAccessScopes.managePorts });
     scopes.forEach(scope -> {
       if (StringUtils.isBlank(scope)) {
         throw new IllegalArgumentException("Tunnel access scopes include a null/empty item.");

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessScopes.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessScopes.java
@@ -6,6 +6,11 @@ package com.microsoft.tunnels.contracts;
 
 /**
  * Defines scopes for tunnel access tokens.
+ *
+ * A tunnel access token with one or more of these scopes typically also has cluster ID
+ * and tunnel ID claims that limit the access scope to a specific tunnel, and may also
+ * have one or more port claims that further limit the access to particular ports of the
+ * tunnel.
  */
 public class TunnelAccessScopes {
     /**
@@ -21,7 +26,14 @@ public class TunnelAccessScopes {
     public static final String manage = "manage";
 
     /**
-     * Allows accepting connections on tunnels as a host.
+     * Allows management operations on all ports of a tunnel, but does not allow updating
+     * any other tunnel properties or deleting the tunnel.
+     */
+    public static final String managePorts = "manage:ports";
+
+    /**
+     * Allows accepting connections on tunnels as a host. Includes access to update tunnel
+     * endpoints and ports.
      */
     public static final String host = "host";
 
@@ -31,7 +43,7 @@ public class TunnelAccessScopes {
     public static final String inspect = "inspect";
 
     /**
-     * Allows connecting to tunnels as a client.
+     * Allows connecting to tunnels or ports as a client.
      */
     public static final String connect = "connect";
 }

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -52,18 +52,25 @@ public class TunnelManagementClient implements ITunnelManagementClient {
   private String tunnelAuthenticationScheme = "Tunnel";
 
   // Access Scopes
-  private static String[] HostAccessTokenScope = {
-      TunnelAccessScopes.host
-  };
-  private static String[] HostOrManageAccessTokenScope = {
-      TunnelAccessScopes.host,
-      TunnelAccessScopes.manage,
-  };
   private static String[] ManageAccessTokenScope = {
       TunnelAccessScopes.manage
   };
+  private static String[] HostAccessTokenScope = {
+      TunnelAccessScopes.host
+  };
+  private static String[] ManagePortsAccessTokenScopes = {
+      TunnelAccessScopes.manage,
+      TunnelAccessScopes.managePorts,
+      TunnelAccessScopes.host,
+  };
   private static String[] ReadAccessTokenScopes = {
       TunnelAccessScopes.manage,
+      TunnelAccessScopes.host,
+      TunnelAccessScopes.connect
+  };
+  private static String[] ReadPortsAccessTokenScopes = {
+      TunnelAccessScopes.manage,
+      TunnelAccessScopes.managePorts,
       TunnelAccessScopes.host,
       TunnelAccessScopes.connect
   };
@@ -484,7 +491,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         options,
         HttpMethod.GET,
         uri,
-        ReadAccessTokenScopes,
+        ReadPortsAccessTokenScopes,
         null /* requestObject */,
         responseType);
   }
@@ -502,7 +509,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         options,
         HttpMethod.GET,
         uri,
-        ReadAccessTokenScopes,
+        ReadPortsAccessTokenScopes,
         null,
         responseType);
   }
@@ -526,7 +533,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         options,
         HttpMethod.POST,
         uri,
-        ManageAccessTokenScope,
+        ManagePortsAccessTokenScopes,
         convertTunnelPortForRequest(tunnel, tunnelPort),
         responseType);
 
@@ -605,7 +612,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         options,
         HttpMethod.PUT,
         uri,
-        HostAccessTokenScope,
+        ManagePortsAccessTokenScopes,
         convertTunnelPortForRequest(tunnel, tunnelPort),
         responseType);
 
@@ -642,7 +649,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         options,
         HttpMethod.DELETE,
         uri,
-        HostOrManageAccessTokenScope,
+        ManagePortsAccessTokenScopes,
         null /* requestObject */,
         responseType);
 

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -65,11 +65,6 @@ public class TunnelManagementClient implements ITunnelManagementClient {
   };
   private static String[] ReadAccessTokenScopes = {
       TunnelAccessScopes.manage,
-      TunnelAccessScopes.host,
-      TunnelAccessScopes.connect
-  };
-  private static String[] ReadPortsAccessTokenScopes = {
-      TunnelAccessScopes.manage,
       TunnelAccessScopes.managePorts,
       TunnelAccessScopes.host,
       TunnelAccessScopes.connect
@@ -491,7 +486,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         options,
         HttpMethod.GET,
         uri,
-        ReadPortsAccessTokenScopes,
+        ReadAccessTokenScopes,
         null /* requestObject */,
         responseType);
   }
@@ -509,7 +504,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         options,
         HttpMethod.GET,
         uri,
-        ReadPortsAccessTokenScopes,
+        ReadAccessTokenScopes,
         null,
         responseType);
   }

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
@@ -78,15 +78,17 @@ public class TunnelRequestOptions {
   public boolean requireAllTags;
 
   /**
-   * Gets or sets an optional list of scopes that should be authorized when
-   * retrieving a tunnel or tunnel port object.
-   */
-  public Collection<String> scopes;
-
-  /**
-   * Gets or sets an optional list of token scopes that
-   * are requested when retrieving a tunnel or tunnel port object.
-   */
+    * Gets or sets an optional list of token scopes that are requested when retrieving a
+    * tunnel or tunnel port object.
+    *
+    * Each item in the list must be a single scope from `TunnelAccessScopes` or a space-
+    * delimited combination of multiple scopes. The service issues an access token for
+    * each scope or combination and returns the token(s) in the `Tunnel.accessTokens` or
+    * `TunnelPort.accessTokens` dictionary. If the caller does not have permission to get
+    * a token for one or more scopes then a token is not returned but the overall request
+    * does not fail. Token properties including scopes and expiration may be checked using
+    * `TunnelAccessTokenProperties`.
+    */
   public Collection<String> tokenScopes;
 
   /**
@@ -107,13 +109,8 @@ public class TunnelRequestOptions {
       queryOptions.put("includePorts", Arrays.asList("true"));
     }
 
-    if (this.scopes != null) {
-      TunnelAccessControl.validateScopes(this.scopes, null);
-      queryOptions.put("scopes", this.scopes);
-    }
-
     if (this.tokenScopes != null) {
-      TunnelAccessControl.validateScopes(this.tokenScopes, null);
+      TunnelAccessControl.validateScopes(this.tokenScopes, null, true);
       queryOptions.put("tokenScopes", this.tokenScopes);
     }
 

--- a/java/src/test/java/com/microsoft/tunnels/TunnelContractsTests.java
+++ b/java/src/test/java/com/microsoft/tunnels/TunnelContractsTests.java
@@ -77,13 +77,19 @@ public class TunnelContractsTests {
     var scopes = Arrays.asList("connect", "host");
     var validScopes = Arrays.asList("connect", "create", "inspect", "host", "manage");
     var invalidScopes = Arrays.asList("connect", "invalid");
-    TunnelAccessControl.validateScopes(scopes, null);
-    TunnelAccessControl.validateScopes(validScopes, null);
-    TunnelAccessControl.validateScopes(scopes, validScopes);
-    Exception exception = assertThrows(IllegalArgumentException.class, ()-> {
-      TunnelAccessControl.validateScopes(invalidScopes, validScopes);
+    var multiScopes = Arrays.asList("host connect", "manage");
+    TunnelAccessControl.validateScopes(scopes, null, false);
+    TunnelAccessControl.validateScopes(validScopes, null, false);
+    TunnelAccessControl.validateScopes(scopes, validScopes, false);
+    var exception = assertThrows(IllegalArgumentException.class, ()-> {
+      TunnelAccessControl.validateScopes(invalidScopes, validScopes, false);
     });
     assertTrue(exception.getMessage().equals("Invalid tunnel access scope: invalid"));
+    TunnelAccessControl.validateScopes(multiScopes, null, true);
+    exception = assertThrows(IllegalArgumentException.class, ()-> {
+      TunnelAccessControl.validateScopes(multiScopes, null, false);
+    });
+    assertTrue(exception.getMessage().equals("Invalid tunnel access scope: host connect"));
   }
 
   @Test

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -932,6 +932,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 name = "tunnels"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "opentelemetry",
  "reqwest",

--- a/rs/src/contracts/tunnel_access_scopes.rs
+++ b/rs/src/contracts/tunnel_access_scopes.rs
@@ -3,6 +3,11 @@
 // Generated from ../../../cs/src/Contracts/TunnelAccessScopes.cs
 
 // Defines scopes for tunnel access tokens.
+//
+// A tunnel access token with one or more of these scopes typically also has cluster ID
+// and tunnel ID claims that limit the access scope to a specific tunnel, and may also
+// have one or more port claims that further limit the access to particular ports of the
+// tunnel.
 
 // Allows creating tunnels. This scope is valid only in policies at the global, domain, or
 // organization level; it is not relevant to an already-created tunnel or tunnel port.
@@ -12,11 +17,16 @@ pub const TUNNEL_ACCESS_SCOPES_CREATE: &str = "create";
 // Allows management operations on tunnels and tunnel ports.
 pub const TUNNEL_ACCESS_SCOPES_MANAGE: &str = "manage";
 
-// Allows accepting connections on tunnels as a host.
+// Allows management operations on all ports of a tunnel, but does not allow updating any
+// other tunnel properties or deleting the tunnel.
+pub const TUNNEL_ACCESS_SCOPES_MANAGE_PORTS: &str = "manage:ports";
+
+// Allows accepting connections on tunnels as a host. Includes access to update tunnel
+// endpoints and ports.
 pub const TUNNEL_ACCESS_SCOPES_HOST: &str = "host";
 
 // Allows inspecting tunnel connection activity and data.
 pub const TUNNEL_ACCESS_SCOPES_INSPECT: &str = "inspect";
 
-// Allows connecting to tunnels as a client.
+// Allows connecting to tunnels or ports as a client.
 pub const TUNNEL_ACCESS_SCOPES_CONNECT: &str = "connect";

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -374,9 +374,6 @@ impl TunnelManagementClient {
             if tunnel_opts.include_ports {
                 query.append_pair("includePorts", "true");
             }
-            if !tunnel_opts.scopes.is_empty() {
-                query.append_pair("scopes", &tunnel_opts.scopes.join(","));
-            }
             if !tunnel_opts.token_scopes.is_empty() {
                 query.append_pair("tokenScopes", &tunnel_opts.token_scopes.join(","));
             }

--- a/rs/src/management/tunnel_request_options.rs
+++ b/rs/src/management/tunnel_request_options.rs
@@ -33,10 +33,6 @@ pub struct TunnelRequestOptions {
     /// are requested when retrieving a tunnel or tunnel port object.
     pub token_scopes: Vec<String>,
 
-    /// Gets or sets an optional list of scopes that should be authorized when
-    /// retrieving a tunnel or tunnel port object.
-    pub scopes: Vec<String>,
-
     /// If true on a create or update request then upon a name conflict, attempt to rename the
     /// existing tunnel to null and give the name to the tunnel from the request.
     pub force_rename: bool,
@@ -49,6 +45,5 @@ pub const NO_REQUEST_OPTIONS: &TunnelRequestOptions = &TunnelRequestOptions {
     tags: Vec::new(),
     require_all_tags: false,
     token_scopes: Vec::new(),
-    scopes: Vec::new(),
     force_rename: false,
 };

--- a/ts/src/contracts/tunnelAccessControlStatics.ts
+++ b/ts/src/contracts/tunnelAccessControlStatics.ts
@@ -17,6 +17,7 @@ const allScopes = [
  * @param validScopes Optional subset of scopes to be considered valid;
  * if omitted then all defined scopes are valid.
  * @param allowMultiple Whether to allow multiple space-delimited scopes in a single item.
+ * Multiple scopes are supported when requesting a tunnel access token with a combination of scopes.
  * @throws Error if a scope is not valid.
  */
 export function validateScopes(

--- a/ts/src/contracts/tunnelAccessControlStatics.ts
+++ b/ts/src/contracts/tunnelAccessControlStatics.ts
@@ -5,6 +5,7 @@ import { TunnelAccessScopes } from './tunnelAccessScopes';
 
 const allScopes = [
     TunnelAccessScopes.Manage,
+    TunnelAccessScopes.ManagePorts,
     TunnelAccessScopes.Host,
     TunnelAccessScopes.Inspect,
     TunnelAccessScopes.Connect,
@@ -15,11 +16,20 @@ const allScopes = [
  * @param scopes List of scopes to validate.
  * @param validScopes Optional subset of scopes to be considered valid;
  * if omitted then all defined scopes are valid.
+ * @param allowMultiple Whether to allow multiple space-delimited scopes in a single item.
  * @throws Error if a scope is not valid.
  */
-export function validateScopes(scopes: string[], validScopes?: string[]): void {
+export function validateScopes(
+    scopes: string[],
+    validScopes?: string[],
+    allowMultiple?: boolean,
+): void {
     if (!Array.isArray(scopes)) {
         throw new TypeError('A scopes array was expected.');
+    }
+
+    if (allowMultiple) {
+        scopes = scopes.map((s) => s.split(' ')).reduce((a, b) => a.concat(b), []);
     }
 
     scopes.forEach((scope) => {

--- a/ts/src/contracts/tunnelAccessScopes.ts
+++ b/ts/src/contracts/tunnelAccessScopes.ts
@@ -5,6 +5,11 @@
 
 /**
  * Defines scopes for tunnel access tokens.
+ *
+ * A tunnel access token with one or more of these scopes typically also has cluster ID
+ * and tunnel ID claims that limit the access scope to a specific tunnel, and may also
+ * have one or more port claims that further limit the access to particular ports of the
+ * tunnel.
  */
 export enum TunnelAccessScopes {
     /**
@@ -20,7 +25,14 @@ export enum TunnelAccessScopes {
     Manage = 'manage',
 
     /**
-     * Allows accepting connections on tunnels as a host.
+     * Allows management operations on all ports of a tunnel, but does not allow updating
+     * any other tunnel properties or deleting the tunnel.
+     */
+    ManagePorts = 'manage:ports',
+
+    /**
+     * Allows accepting connections on tunnels as a host. Includes access to update tunnel
+     * endpoints and ports.
      */
     Host = 'host',
 
@@ -30,7 +42,7 @@ export enum TunnelAccessScopes {
     Inspect = 'inspect',
 
     /**
-     * Allows connecting to tunnels as a client.
+     * Allows connecting to tunnels or ports as a client.
      */
     Connect = 'connect',
 }

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -61,9 +61,19 @@ function parseTunnelPortDates(port: TunnelPort | null) {
 
 const manageAccessTokenScope = [TunnelAccessScopes.Manage];
 const hostAccessTokenScope = [TunnelAccessScopes.Host];
-const hostOrManageAccessTokenScopes = [TunnelAccessScopes.Manage, TunnelAccessScopes.Host];
+const managePortsAccessTokenScopes = [
+    TunnelAccessScopes.Manage,
+    TunnelAccessScopes.ManagePorts,
+    TunnelAccessScopes.Host,
+];
 const readAccessTokenScopes = [
     TunnelAccessScopes.Manage,
+    TunnelAccessScopes.Host,
+    TunnelAccessScopes.Connect,
+];
+const readPortsAccessTokenScopes = [
+    TunnelAccessScopes.Manage,
+    TunnelAccessScopes.ManagePorts,
     TunnelAccessScopes.Host,
     TunnelAccessScopes.Connect,
 ];
@@ -311,7 +321,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const results = (await this.sendTunnelRequest<TunnelPort[]>(
             'GET',
             tunnel,
-            readAccessTokenScopes,
+            readPortsAccessTokenScopes,
             portsApiSubPath,
             undefined,
             options,
@@ -329,7 +339,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const result = await this.sendTunnelRequest<TunnelPort>(
             'GET',
             tunnel,
-            readAccessTokenScopes,
+            readPortsAccessTokenScopes,
             path,
             undefined,
             options,
@@ -347,7 +357,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const result = (await this.sendTunnelRequest<TunnelPort>(
             'POST',
             tunnel,
-            hostOrManageAccessTokenScopes,
+            managePortsAccessTokenScopes,
             portsApiSubPath,
             undefined,
             options,
@@ -381,7 +391,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const result = (await this.sendTunnelRequest<TunnelPort>(
             'PUT',
             tunnel,
-            hostOrManageAccessTokenScopes,
+            managePortsAccessTokenScopes,
             path,
             undefined,
             options,
@@ -415,7 +425,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const result = await this.sendTunnelRequest<boolean>(
             'DELETE',
             tunnel,
-            hostOrManageAccessTokenScopes,
+            managePortsAccessTokenScopes,
             path,
             undefined,
             options,

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -68,11 +68,6 @@ const managePortsAccessTokenScopes = [
 ];
 const readAccessTokenScopes = [
     TunnelAccessScopes.Manage,
-    TunnelAccessScopes.Host,
-    TunnelAccessScopes.Connect,
-];
-const readPortsAccessTokenScopes = [
-    TunnelAccessScopes.Manage,
     TunnelAccessScopes.ManagePorts,
     TunnelAccessScopes.Host,
     TunnelAccessScopes.Connect,
@@ -321,7 +316,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const results = (await this.sendTunnelRequest<TunnelPort[]>(
             'GET',
             tunnel,
-            readPortsAccessTokenScopes,
+            readAccessTokenScopes,
             portsApiSubPath,
             undefined,
             options,
@@ -339,7 +334,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const result = await this.sendTunnelRequest<TunnelPort>(
             'GET',
             tunnel,
-            readPortsAccessTokenScopes,
+            readAccessTokenScopes,
             path,
             undefined,
             options,

--- a/ts/src/management/tunnelRequestOptions.ts
+++ b/ts/src/management/tunnelRequestOptions.ts
@@ -53,14 +53,16 @@ export interface TunnelRequestOptions {
     requireAllTags?: boolean;
 
     /**
-     * Gets or sets an optional list of scopes that should be authorized when
-     * retrieving a tunnel or tunnel port object.
-     */
-    scopes?: string[];
-
-    /**
-     * Gets or sets an optional list of token scopes that
-     * are requested when retrieving a tunnel or tunnel port object.
+     * Gets or sets an optional list of token scopes that are requested when retrieving a
+     * tunnel or tunnel port object.
+     *
+     * Each item in the array must be a single scope from `TunnelAccessScopes` or a space-
+     * delimited combination of multiple scopes. The service issues an access token for
+     * each scope or combination and returns the token(s) in the `Tunnel.accessTokens` or
+     * `TunnelPort.accessTokens` dictionary. If the caller does not have permission to get
+     * a token for one or more scopes then a token is not returned but the overall request
+     * does not fail. Token properties including scopes and expiration may be checked using
+     * `TunnelAccessTokenProperties`.
      */
     tokenScopes?: string[];
 

--- a/ts/test/tunnels-test/tunnelManagementTests.ts
+++ b/ts/test/tunnels-test/tunnelManagementTests.ts
@@ -60,10 +60,9 @@ export class TunnelManagementTests {
     @test
     public async listTunnelsIncludePorts() {
         this.nextResponse = [];
-        await this.managementClient.listTunnels(
-            undefined, undefined, { includePorts: true, scopes: [ 'connect' ] });
+        await this.managementClient.listTunnels(undefined, undefined, { includePorts: true });
         assert(this.lastRequest && this.lastRequest.uri);
         assert(this.lastRequest.uri.startsWith('http://global.'));
-        assert(this.lastRequest.uri.includes('includePorts=true&scopes=connect&global=true'));
+        assert(this.lastRequest.uri.includes('includePorts=true&global=true'));
     }
 }


### PR DESCRIPTION
Add SDK support for a new `manage:ports` scope, and for requesting access tokens with a space-delimited combination of scopes, such as `connect manage:ports`.

Note attempts to use the new scope will be rejected by the tunnel service as invalid until the server-side support lands. I'm working on that separately.

Related: https://github.com/microsoft/basis-planning/issues/450