### PR TITLE
Enable Java tests for local development

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,4 +27,4 @@ jobs:
           cache: maven
       - name: Build with Maven
         # don't run ConnectionTest for now.
-        run: mvn -B package --file pom.xml -Dtest=!TunnelManagementClientTests
+        run: mvn -B package --file pom.xml -Dtest=TunnelContractsTests

--- a/java/README.md
+++ b/java/README.md
@@ -5,7 +5,15 @@ These instructions assume you are using vscode for development as SDK is configu
 1. Clone this repo and open the `java` folder in vscode.
 2. Install the recommended extension pack "Extension Pack for Java"
 3. The extension will prompt you to install a JDK. Choose JDK version 11 (LTS).
-4. Once you have the extension and JDK installed, run `mvn test`.
+4. Once you have the extension and JDK installed, run `mvn test` (see next section for test setup).
+
+### Testing
+1. Run `basis user show -v` to get a user access token.
+2. Create a new tunnel and add a port.
+3. Create a new environment variable `TUNNELS_TOKEN` with a string value "Bearer <token>".
+4. Create a new environment variable `TEST_TUNNEL_NAME` with a value containing the name of the tunnel.
+5. Run `basis host` to host the tunnel.
+6. Run the tests.
 
 ### Publishing
 The Tunnels Java SDK is published as a GitHub package through a [GitHub Action](../.github/workflows/java-sdk-release.yml). Since the repo is shared by multiple language SDKs, the Java packages are distinguished with a tag of the form `java-vX.Y.Z`. See [tags](https://github.com/microsoft/dev-tunnels/tags) for examples.

--- a/java/README.md
+++ b/java/README.md
@@ -8,11 +8,11 @@ These instructions assume you are using vscode for development as SDK is configu
 4. Once you have the extension and JDK installed, run `mvn test` (see next section for test setup).
 
 ### Testing
-1. Run `basis user show -v` to get a user access token.
+1. Get a user token using the CLI.
 2. Create a new tunnel and add a port.
 3. Create a new environment variable `TUNNELS_TOKEN` with a string value "Bearer <token>".
 4. Create a new environment variable `TEST_TUNNEL_NAME` with a value containing the name of the tunnel.
-5. Run `basis host` to host the tunnel.
+5. User the CLI to host the tunnel.
 6. Run the tests.
 
 ### Publishing

--- a/java/README.md
+++ b/java/README.md
@@ -11,8 +11,8 @@ These instructions assume you are using vscode for development as SDK is configu
 1. Get a user token using the CLI.
 2. Create a new tunnel and add a port.
 3. Create a new environment variable `TUNNELS_TOKEN` with a string value "Bearer <token>".
-4. Create a new environment variable `TEST_TUNNEL_NAME` with a value containing the name of the tunnel.
-5. User the CLI to host the tunnel.
+4. Create a new environment variable `TEST_TUNNEL` with a value containing the name of the tunnel.
+5. Use the CLI to host the tunnel.
 6. Run the tests.
 
 ### Publishing

--- a/java/src/test/java/com/microsoft/tunnels/TunnelClientTests.java
+++ b/java/src/test/java/com/microsoft/tunnels/TunnelClientTests.java
@@ -1,0 +1,36 @@
+package com.microsoft.tunnels;
+
+import com.microsoft.tunnels.connections.TunnelClient;
+import com.microsoft.tunnels.contracts.Tunnel;
+import com.microsoft.tunnels.contracts.TunnelAccessScopes;
+import com.microsoft.tunnels.management.TunnelRequestOptions;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class TunnelClientTests extends TunnelTest {
+
+  @Test
+  public void connectClient() {
+    // Set up tunnel
+    Tunnel tunnel = new Tunnel();
+    tunnel.name = this.testTunnelName;
+    System.out.println(tunnel.name);
+
+    // Configure tunnel request options
+    var requestOptions = new TunnelRequestOptions();
+    requestOptions.tokenScopes = Arrays.asList(TunnelAccessScopes.connect);
+    requestOptions.includePorts = true;
+
+    // get tunnel
+    var result = this.tunnelManagementClient.getTunnelAsync(tunnel, requestOptions).join();
+
+    // Connect to the tunnel
+    TunnelClient client = new TunnelClient();
+
+    // connect to the tunnel
+    client.connect(result);
+    client.stop();
+  }
+}

--- a/java/src/test/java/com/microsoft/tunnels/TunnelManagementClientTests.java
+++ b/java/src/test/java/com/microsoft/tunnels/TunnelManagementClientTests.java
@@ -15,37 +15,27 @@ import com.microsoft.tunnels.contracts.TunnelAccessScopes;
 import com.microsoft.tunnels.contracts.TunnelPort;
 import com.microsoft.tunnels.contracts.TunnelProtocol;
 import com.microsoft.tunnels.management.HttpResponseException;
-import com.microsoft.tunnels.management.ProductHeaderValue;
-import com.microsoft.tunnels.management.TunnelManagementClient;
 import com.microsoft.tunnels.management.TunnelRequestOptions;
 
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * TunnelManagementClient tests.
  */
-public class TunnelManagementClientTests {
-  private static ProductHeaderValue userAgent = new ProductHeaderValue("connection-test",
-      TunnelManagementClientTests.class.getPackage().getSpecificationVersion());
+public class TunnelManagementClientTests extends TunnelTest {
 
-  private TunnelManagementClient tunnelManagementClient = new TunnelManagementClient(
-      new ProductHeaderValue[] { userAgent }, () -> "");
-
-  @Ignore
   @Test
   public void createTunnel() {
-
     // Set up tunnel access control.
     var tunnelAccessEntry = new TunnelAccessControlEntry();
     tunnelAccessEntry.type = TunnelAccessControlEntryType.Anonymous;
     tunnelAccessEntry.subjects = new String[] {};
     tunnelAccessEntry.scopes = new String[] { "connect" };
     var access = new TunnelAccessControl();
-    access.entries = new TunnelAccessControlEntry[] { new TunnelAccessControlEntry() };
+    access.entries = new TunnelAccessControlEntry[] { tunnelAccessEntry };
 
     // set up the tunnel port.
     var port = new TunnelPort();
@@ -81,7 +71,6 @@ public class TunnelManagementClientTests {
     tunnelManagementClient.deleteTunnelAsync(createdTunnel).join();
   }
 
-  @Ignore
   @Test
   public void getTunnel() {
     Tunnel tunnel = new Tunnel();
@@ -98,7 +87,6 @@ public class TunnelManagementClientTests {
     tunnelManagementClient.deleteTunnelAsync(createdTunnel, options).join();
   }
 
-  @Ignore
   @Test
   public void updateTunnelAsync() {
     Tunnel tunnel = new Tunnel();
@@ -116,7 +104,6 @@ public class TunnelManagementClientTests {
     tunnelManagementClient.deleteTunnelAsync(createdTunnel, options).join();
   }
 
-  @Ignore
   @Test
   public void createTunnelPort() {
     var port = new TunnelPort();

--- a/java/src/test/java/com/microsoft/tunnels/TunnelTest.java
+++ b/java/src/test/java/com/microsoft/tunnels/TunnelTest.java
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package com.microsoft.tunnels;
+
+import com.microsoft.tunnels.management.ProductHeaderValue;
+import com.microsoft.tunnels.management.TunnelManagementClient;
+
+import java.util.function.Supplier;
+
+import org.apache.maven.shared.utils.StringUtils;
+
+/**
+ * Base class for java tunnel tests
+ */
+public abstract class TunnelTest {
+  protected static ProductHeaderValue userAgent = new ProductHeaderValue("connection-test",
+      TunnelManagementClientTests.class.getPackage().getSpecificationVersion());
+
+  // Test tunnel used for local testing of tunnel connections.
+  protected final String testTunnelName = System.getenv("TEST_TUNNEL");
+  // User token for creating tunnels in local tests.
+  protected final String testToken = System.getenv("TUNNELS_TOKEN");
+
+  protected final Supplier<String> userTokenCallback = StringUtils.isNotBlank(testToken)
+      ? () -> testToken
+      : null;
+
+  protected TunnelManagementClient tunnelManagementClient = new TunnelManagementClient(
+      new ProductHeaderValue[] { userAgent },
+      userTokenCallback);
+}


### PR DESCRIPTION
* Reenables Java `TunnelMangementClient` tests locally using an env variable to supply the auth token.
* Adds a `TunnelClient` connection test and readme to set up with a CLI hosted tunnel.