### PR TITLE
rs: implement initial host relay 

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -1261,7 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.34.0-beta.12"
+version = "0.34.0-beta.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a47850d2711f53330077c1ca72f7f326ec1658b68add7dbc22c384731b6adb"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1294,6 +1296,8 @@ dependencies = [
 [[package]]
 name = "russh-cryptovec"
 version = "0.7.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89fd30a2ef98dfa621409d5bc56a2479d5810bf13a5eea3de89d859437b7e2e"
 dependencies = [
  "libc",
  "winapi",
@@ -1301,7 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "russh-keys"
-version = "0.22.0-beta.5"
+version = "0.22.0-beta.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "522f33fe55f03f9a13560533183553552ef12d4383019bac74101e3c9b34f358"
 dependencies = [
  "aes",
  "bcrypt-pbkdf",

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -3,6 +3,47 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.3",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher 0.4.3",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,10 +67,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64ct"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c38c03b9506bd92bf1ef50665a81eda156f615438f7654bffba58907e6149d7"
+dependencies = [
+ "blowfish",
+ "crypto-mac",
+ "pbkdf2 0.8.0",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
+dependencies = [
+ "byteorder",
+ "cipher 0.3.0",
+ "opaque-debug",
+]
 
 [[package]]
 name = "bumpalo"
@@ -38,10 +142,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.3",
+]
 
 [[package]]
 name = "cc"
@@ -56,6 +175,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.3",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +197,25 @@ dependencies = [
  "serde",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -84,6 +233,24 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -106,6 +273,118 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.3",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d14f329cfbaf5d0e06b5e87fff7e265d2673c5ea7d2c27691a2c107db1442a0"
+dependencies = [
+ "cipher 0.4.3",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +400,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -155,25 +444,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.21"
+name = "futures"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -181,29 +486,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.21"
+name = "futures-io"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -215,6 +562,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -241,6 +598,30 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
 
 [[package]]
 name = "http"
@@ -335,6 +716,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +768,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "lock_api"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +809,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -434,6 +850,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,10 +881,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.12.0"
+name = "num_cpus"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -491,6 +935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +952,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -518,8 +972,63 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "thiserror",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
+dependencies = [
+ "crypto-mac",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.3",
+ "hmac",
+ "password-hash",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -567,6 +1076,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,13 +1124,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -608,7 +1163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -617,7 +1181,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.7",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -627,6 +1200,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.7",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -676,6 +1260,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "russh"
+version = "0.34.0-beta.12"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "bitflags",
+ "byteorder",
+ "chacha20",
+ "ctr",
+ "curve25519-dalek",
+ "digest 0.10.3",
+ "flate2",
+ "futures",
+ "generic-array",
+ "hex-literal",
+ "hmac",
+ "log",
+ "num-bigint",
+ "once_cell",
+ "openssl",
+ "poly1305",
+ "rand 0.8.5",
+ "russh-cryptovec",
+ "russh-keys",
+ "sha1",
+ "sha2 0.10.2",
+ "subtle",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.7.0-beta.1"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "russh-keys"
+version = "0.22.0-beta.5"
+dependencies = [
+ "aes",
+ "bcrypt-pbkdf",
+ "bit-vec",
+ "block-padding",
+ "byteorder",
+ "cbc",
+ "ctr",
+ "data-encoding",
+ "dirs",
+ "ed25519-dalek",
+ "futures",
+ "hmac",
+ "inout",
+ "log",
+ "md5",
+ "num-bigint",
+ "num-integer",
+ "openssl",
+ "pbkdf2 0.11.0",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "russh-cryptovec",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.2",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "yasna",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +1349,12 @@ dependencies = [
  "lazy_static",
  "windows-sys",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
@@ -758,10 +1423,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -774,6 +1506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +1520,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -846,16 +1596,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
+ "num_cpus",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -880,6 +1634,31 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -929,18 +1708,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tungstenite"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "tunnels"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "futures",
+ "log",
  "opentelemetry",
+ "rand 0.8.5",
  "reqwest",
+ "russh",
+ "russh-keys",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tungstenite",
  "url",
+ "uuid",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-bidi"
@@ -964,6 +1779,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,10 +1807,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.7",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -990,6 +1842,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1151,4 +2009,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "yasna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+dependencies = [
+ "bit-vec",
+ "num-bigint",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -19,8 +19,8 @@ tokio-tungstenite = { version = "0.17", optional = true }
 futures = { version = "0.3", optional = true }
 tungstenite = { version = "0.17", optional = true }
 uuid = { version = "0.8.2", features = ["v4"], optional = true }
-russh = { path = "../../russh/russh", default-features = false, features = ["openssl", "flate2"], optional = true }
-russh-keys = { path = "../../russh/russh-keys", default-features = false, features = ["openssl"], optional = true }
+russh = { version = "0.34.0-beta.15", default-features = false, features = ["openssl", "flate2"], optional = true }
+russh-keys = { version = "0.22.0-beta.6", default-features = false, features = ["openssl"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["full"] }

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -11,11 +11,39 @@ url = "2"
 opentelemetry = { version = "0.17", features = ["trace"], optional = true }
 serde_json = "1"
 async-trait = "0.1"
+thiserror = "1.0"
+log = "0.4"
+tokio = { version = "1.20", features = ["macros", "io-util", "time"], optional = true }
+tokio-util = { version = "0.7", optional = true }
+tokio-tungstenite = { version = "0.17", optional = true }
+futures = { version = "0.3", optional = true }
+tungstenite = { version = "0.17", optional = true }
+uuid = { version = "0.8.2", features = ["v4"], optional = true }
+russh = { path = "../../russh/russh", default-features = false, features = ["openssl", "flate2"], optional = true }
+russh-keys = { path = "../../russh/russh-keys", default-features = false, features = ["openssl"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.19", features = ["rt", "macros"] }
+tokio = { version = "1.19", features = ["full"] }
+rand = "0.8"
 
 [features]
 default = []
 end_to_end = []
-instrumentation = ["opentelemetry"]
+instrumentation = ["dep:opentelemetry"]
+connections = [
+  "dep:tokio",
+  "dep:tokio-util",
+  "dep:futures",
+  "dep:tokio-tungstenite",
+  "dep:tungstenite",
+  "dep:uuid",
+  "dep:russh",
+  "dep:russh-keys",
+]
+vendored-openssl = [
+  "reqwest/native-tls-vendored",
+  "tokio-tungstenite?/native-tls-vendored",
+  "tungstenite?/native-tls-vendored",
+  "russh?/vendored-openssl",
+  "russh-keys?/vendored-openssl"
+]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -19,11 +19,8 @@ tokio-tungstenite = { version = "0.17", optional = true }
 futures = { version = "0.3", optional = true }
 tungstenite = { version = "0.17", optional = true }
 uuid = { version = "0.8.2", features = ["v4"], optional = true }
-# temporary until https://github.com/warp-tech/russh/issues/42:
-# russh = { version = "0.34.0-beta.16", default-features = false, features = ["openssl", "flate2"], optional = true }
-# russh-keys = { version = "0.22.0-beta.6", default-features = false, features = ["openssl"], optional = true }
-russh = { git = "https://github.com/microsoft/vscode-russh", branch = "own", default-features = false, features = ["openssl", "flate2"], optional = true }
-russh-keys = { git = "https://github.com/microsoft/vscode-russh", branch = "own", default-features = false, features = ["openssl"], optional = true }
+russh = { version = "0.34.0-beta.16", default-features = false, features = ["openssl", "flate2"], optional = true }
+russh-keys = { version = "0.22.0-beta.7", default-features = false, features = ["openssl"], optional = true }
 
 
 [dev-dependencies]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -19,8 +19,12 @@ tokio-tungstenite = { version = "0.17", optional = true }
 futures = { version = "0.3", optional = true }
 tungstenite = { version = "0.17", optional = true }
 uuid = { version = "0.8.2", features = ["v4"], optional = true }
-russh = { version = "0.34.0-beta.16", default-features = false, features = ["openssl", "flate2"], optional = true }
-russh-keys = { version = "0.22.0-beta.6", default-features = false, features = ["openssl"], optional = true }
+# temporary until https://github.com/warp-tech/russh/issues/42:
+# russh = { version = "0.34.0-beta.16", default-features = false, features = ["openssl", "flate2"], optional = true }
+# russh-keys = { version = "0.22.0-beta.6", default-features = false, features = ["openssl"], optional = true }
+russh = { git = "https://github.com/microsoft/vscode-russh", branch = "own", default-features = false, features = ["openssl", "flate2"], optional = true }
+russh-keys = { git = "https://github.com/microsoft/vscode-russh", branch = "own", default-features = false, features = ["openssl"], optional = true }
+
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["full"] }

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -19,7 +19,7 @@ tokio-tungstenite = { version = "0.17", optional = true }
 futures = { version = "0.3", optional = true }
 tungstenite = { version = "0.17", optional = true }
 uuid = { version = "0.8.2", features = ["v4"], optional = true }
-russh = { version = "0.34.0-beta.15", default-features = false, features = ["openssl", "flate2"], optional = true }
+russh = { version = "0.34.0-beta.16", default-features = false, features = ["openssl", "flate2"], optional = true }
 russh-keys = { version = "0.22.0-beta.6", default-features = false, features = ["openssl"], optional = true }
 
 [dev-dependencies]

--- a/rs/src/connections/errors.rs
+++ b/rs/src/connections/errors.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use thiserror::Error;
+
+/// Type of error returned from tunnel operations.
+#[derive(Debug, Error)]
+pub enum TunnelError {
+    #[error("{reason}: {error}")]
+    HttpError {
+        error: crate::management::HttpError,
+        reason: &'static str,
+    },
+
+    #[error("the tunnel relay was disconnected: {0}")]
+    TunnelRelayDisconnected(#[from] russh::Error),
+
+    #[error("the tunnel host relay endpoint URI is missing")]
+    MissingHostEndpoint,
+
+    #[error("invalid host relay uri: {0}")]
+    InvalidHostEndpoint(String),
+
+    #[error("websocket error: {0}")]
+    WebSocketError(#[from] tungstenite::Error),
+
+    #[error("port {0} already exists in the relay")]
+    PortAlreadyExists(u32),
+}

--- a/rs/src/connections/host_relay.rs
+++ b/rs/src/connections/host_relay.rs
@@ -1,0 +1,1052 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::{collections::HashMap, io, pin::Pin, sync::Arc, task::Poll, time::Duration};
+
+use crate::{
+    contracts::{TunnelConnectionMode, TunnelEndpoint, TunnelPort, TunnelRelayTunnelEndpoint},
+    management::{
+        Authorization, HttpError, TunnelLocator, TunnelManagementClient, TunnelRequestOptions,
+        NO_REQUEST_OPTIONS,
+    },
+};
+use futures::{FutureExt, TryFutureExt};
+use russh::{server::Server as ServerTrait, CryptoVec};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    net::TcpStream,
+    sync::{mpsc, oneshot, watch},
+    task::JoinHandle,
+};
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use uuid::Uuid;
+
+use super::{
+    errors::TunnelError,
+    ws::{build_websocket_request, AsyncRWWebSocket},
+};
+
+type PortMap = HashMap<u32, mpsc::UnboundedSender<ForwardedPortConnection>>;
+
+pub struct HostRelay {
+    locator: TunnelLocator,
+    host_id: Uuid,
+    ports_tx: watch::Sender<PortMap>,
+    ports_rx: watch::Receiver<PortMap>,
+    mgmt: TunnelManagementClient,
+}
+
+/// Hello friend. You're probably here because you want to change how tunnel
+/// connections work! Here's how it works.
+///
+/// ## Overall Communication
+///
+/// Tunneling communicates via SSH over websockets. Data is sent fairly opaquely in
+/// binary websocket messages. We use Tungstenite for the websocket, and then
+/// wrap it into an AsyncRead/AsyncWrite type that we can give to the websocket
+/// library, russh.
+///
+/// We then connect over SSH. Today, Tunneling doesn't require additional auth in
+/// the SSH connection, and also has a somewhat non-standard "none" value for
+/// its key exchange. This prevents many off-the-shelf SSH implementations from
+/// working. Once a client connects to the other end of the tunnel, it'll
+/// open a new Channel from the server (of type "client-ssh-session-stream").
+///
+/// The stream of data over this channel is actually an SSH client connection.
+/// So, for each client, we create an SSH server instance, and do some more
+/// work to make that channel AsyncRead/AsyncWrite as well. (Note that this
+/// client actually does do a key exchange and it data is encrypted.) Once
+/// established, the host (this program) requests the client to forward the
+/// ports that it via `tcpip-forward` requests. Clients then open
+/// `forwarded-tcpip` channels for each new connection.
+///
+/// ```text
+///        ┌───────────┐     ┌───────┐      ┌───────┐
+///        │Host (this)│     │Service│      │Client │
+///        └─────┬─────┘     └───┬───┘      └───┬───┘
+///              │ Connect as    │              │
+///              ├─SSH client────▶              │
+///              │               │  Connect to  │
+///              │               ◀──service ws──┤
+///              │   Create new  │              │
+///              ◀───SSH tunnel──┤              │
+///              │               │              │
+///              │    SSH server handshake.     │
+///              ├────(Service just proxies ────▶
+///              │      traffic through)        │
+///              │               │              │
+///              ├────tcpip-forward for ports───▶
+///              │               │              │
+///              │               │              ◀───asked to
+///              │               │              │   connect
+///              ◀────create forwarded-tcpip ───┤
+///      make    │            channel           │
+/// local tcp ◀──┤               │              │
+/// connection   │               │              │
+///              ◀ ─ ─ ─ ─forward traffic─ ─ ─ ─▶
+///              │               │              │
+///              │               │              │
+///              ▼               ▼              ▼
+/// ```
+///
+/// ## How this Package Works
+///
+/// The HostRelay allows the consumer to `connect()` to a tunnel. It's legal
+/// to call this in parallel (though not generally useful...) The host keeps
+/// a map of the forwarded ports in a tokio watch channel, which allows
+/// connected channels to update them in realtime. Each port also has a channel
+/// on which incoming connections can be received.
+///
+/// When the client creates a new channel for a client, that's sent back on
+/// a channel, where it's wrapepd in the "AsyncRWChannel" to provide
+/// AsyncRead/Write traits, and then spawned in its own Tokio task.
+///
+/// It watches the ports list, and when new forwarded channels are made, it
+/// wraps those in a ForwardedPortConnection struct, and sends those to the
+/// channel on the port record.
+///
+/// Ports are handled by a client calling `add_port()` or `add_port_raw()`,
+/// which either forward to a local TCP connection or return the
+/// ForwardedPortConnection directly, respectively.
+
+/// The HostRelay can host connections via the tunneling service. After
+/// creating it, you will generally want to run `connect()` to create a new
+/// a new connection.
+///
+/// Note that, while ports can be added and remove dynamically from running
+/// tunnels via the appropriate methods on the HostRelay, no ports will be
+/// hosted until those methods are called.
+#[allow(dead_code)]
+impl HostRelay {
+    pub fn new(locator: TunnelLocator, mgmt: TunnelManagementClient) -> Self {
+        let host_id = Uuid::new_v4();
+        let (ports_tx, ports_rx) = watch::channel(HashMap::new());
+        HostRelay {
+            host_id,
+            locator,
+            ports_tx,
+            ports_rx,
+            mgmt,
+        }
+    }
+
+    /// Creates a connection and returns a handle to the tunnel relay. When
+    /// created, the tunnel will forward all ports currently on the tunnel.
+    /// The returned handle is a future that completes when the tunnel closes.
+    /// For example:
+    ///
+    /// ```ignore
+    /// let handle = relay.connect("host_token").await?;
+    ///
+    /// tokio::spawn(async move || {
+    ///     loop {
+    ///       tokio::select! {
+    ///         port = add_port.recv() => handle.add_port(port).await?;
+    ///         handle => break,
+    ///       }
+    ///     }
+    /// });
+    /// ```
+    ///
+    /// The handle may be dropped in order to disconnect from the relay, and
+    /// will be closed if connection to the relay fails. Consumers should
+    /// reconnect if this happens, and they can reconnect using the same
+    /// HostRelay.
+    pub async fn connect(&mut self, host_token: &str) -> Result<RelayHandle, TunnelError> {
+        let (cnx, endpoint) = self.create_websocket(host_token).await?;
+        let cnx = AsyncRWWebSocket::new(super::ws::AsyncRWWebSocketOptions {
+            websocket: cnx,
+            ping_interval: Duration::from_secs(60),
+            ping_timeout: Duration::from_secs(10),
+        });
+
+        let (client_session, mut rx) = HostRelay::make_ssh_client(cnx)
+            .await
+            .map_err(TunnelError::TunnelRelayDisconnected)?;
+        let client_session = Arc::new(client_session);
+        let client_session_ret = client_session.clone();
+
+        let mut channels = HashMap::new();
+        let ports_rx = self.ports_rx.clone();
+        let join = tokio::spawn(async move {
+            let mut server = HostRelay::make_ssh_server();
+            loop {
+                tokio::select! {
+                    Some(op) = rx.recv() => match op {
+                        ChannelOp::Open(id) => {
+                            let (rw, sender) = AsyncRWChannel::new(id, client_session.clone());
+                            server.run_stream(rw, ports_rx.clone());
+                            // do we need to store the JoinHandle for any reason?
+                            channels.insert(id, sender);
+                            log::info!("Opened new client on channel {}", id);
+                        },
+                        ChannelOp::Close(id) => {
+                            channels.remove(&id);
+                        },
+                        ChannelOp::Data(id, data) => {
+                            if let Some(ch) = channels.get(&id) {
+                                if ch.send(data).is_err() { // rx was dropped
+                                    channels.remove(&id);
+                                }
+                            }
+                        },
+                    },
+                    else => break,
+                }
+            }
+
+            client_session
+                .disconnect(russh::Disconnect::ByApplication, "going away", "en")
+                .await
+                .ok();
+
+            Ok(())
+        });
+
+        Ok(RelayHandle {
+            endpoint,
+            join,
+            session: client_session_ret,
+        })
+    }
+
+    /// Unregisters relay from the tunnel's list of hosts.
+    pub async fn unregister(&self) -> Result<bool, TunnelError> {
+        self.mgmt
+            .delete_tunnel_endpoints(
+                &self.locator,
+                &self.host_id.to_string(),
+                None,
+                NO_REQUEST_OPTIONS,
+            )
+            .await
+            .map_err(|e| TunnelError::HttpError {
+                error: e,
+                reason: "could not unregister relay",
+            })
+    }
+
+    /// Adds a new port to the relay and returns a receiver for connections
+    /// that are made to that port. This is a "low level" type that you can use
+    /// if you want to deal with forwarding manually, but the `add_port` method
+    /// is appropriate and simpler for most use cases.
+    ///
+    /// Calling this method multiple times with the same port will result in
+    /// an error. Dropping the receiver **will not** remove the port, you must
+    /// call `remove_port()` to do that.
+    pub async fn add_port_raw(
+        &self,
+        port_to_add: &TunnelPort,
+    ) -> Result<mpsc::UnboundedReceiver<ForwardedPortConnection>, TunnelError> {
+        let n = port_to_add.port_number as u32;
+        if self.ports_tx.borrow().get(&n).is_some() {
+            return Err(TunnelError::PortAlreadyExists(n));
+        }
+
+        let tunnel_port = self
+            .mgmt
+            .create_tunnel_port(&self.locator, port_to_add, NO_REQUEST_OPTIONS)
+            .await;
+
+        // Allow 200's and 409 statuses. Return an error on anything else.
+        match tunnel_port {
+            Ok(_) => {}
+            Err(HttpError::ResponseError(e)) if e.status_code == 409 => {}
+            Err(e) => {
+                return Err(TunnelError::HttpError {
+                    error: e,
+                    reason: "failed to add port to tunnel",
+                })
+            }
+        }
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.ports_tx.send_modify(|v| {
+            v.insert(n, tx);
+        });
+
+        Ok(rx)
+    }
+
+    /// Adds a new port to the tunnel and forwards TCP/IP connections made
+    /// over that port to the local machine. Calling this method multiple times
+    /// with the same port will result in an error.
+    pub async fn add_port(&self, port_to_add: &TunnelPort) -> Result<(), TunnelError> {
+        let rx = self.add_port_raw(port_to_add).await?;
+
+        tokio::spawn(forward_port_to_tcp(
+            format!("127.0.0.1:{}", port_to_add.port_number),
+            rx,
+        ));
+
+        Ok(())
+    }
+
+    /// Removes a port from the tunnel connection. Any channel returned from
+    /// `add_port_raw`, and any connections made within `add_port`, will close
+    /// shortly after this is called.
+    pub async fn remove_port(&self, port_number: u16) -> Result<(), TunnelError> {
+        self.mgmt
+            .delete_tunnel_port(&self.locator, port_number, NO_REQUEST_OPTIONS)
+            .await
+            .map_err(|e| TunnelError::HttpError {
+                error: e,
+                reason: "failed to remove port from tunnel",
+            })?;
+
+        self.ports_tx.send_modify(|v| {
+            v.remove(&(port_number as u32));
+        });
+
+        Ok(())
+    }
+
+    fn make_ssh_server() -> Server {
+        let c = russh::server::Config {
+            connection_timeout: None,
+            auth_rejection_time: std::time::Duration::from_secs(5),
+            keys: vec![russh_keys::key::KeyPair::generate_rsa(
+                2048,
+                russh_keys::key::SignatureHash::SHA2_512,
+            )
+            .expect("expected to generate rsa keypair")],
+            ..Default::default()
+        };
+
+        let config = Arc::new(c);
+        Server { config }
+    }
+
+    async fn make_ssh_client(
+        rw: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    ) -> Result<
+        (
+            russh::client::Handle<Client>,
+            mpsc::UnboundedReceiver<ChannelOp>,
+        ),
+        russh::Error,
+    > {
+        let config = russh::client::Config {
+            anonymous: true,
+            preferred: russh::Preferred {
+                kex: &[russh::kex::NONE],
+                key: &[russh_keys::key::NONE],
+                cipher: &[russh::cipher::NONE],
+                mac: russh::Preferred::DEFAULT.mac,
+                compression: russh::Preferred::COMPRESSED.compression,
+            },
+            ..Default::default()
+        };
+
+        let config = Arc::new(config);
+        let (client, rx) = Client::new();
+        let session = russh::client::connect_stream(config, rw, client).await?;
+
+        Ok((session, rx))
+    }
+
+    async fn create_websocket(
+        &self,
+        host_token: &str,
+    ) -> Result<
+        (
+            WebSocketStream<MaybeTlsStream<TcpStream>>,
+            TunnelRelayTunnelEndpoint,
+        ),
+        TunnelError,
+    > {
+        let endpoint = self
+            .mgmt
+            .update_tunnel_relay_endpoints(
+                &self.locator,
+                &TunnelRelayTunnelEndpoint {
+                    base: TunnelEndpoint {
+                        connection_mode: TunnelConnectionMode::TunnelRelay,
+                        host_id: self.host_id.to_string(),
+                        host_public_keys: vec![],
+                        port_uri_format: None,
+                        port_ssh_command_format: None,
+                    },
+                    client_relay_uri: None,
+                    host_relay_uri: None,
+                },
+                &TunnelRequestOptions {
+                    authorization: Some(Authorization::Tunnel(host_token.to_string())),
+                    ..TunnelRequestOptions::default()
+                },
+            )
+            .await
+            .map_err(|e| TunnelError::HttpError {
+                error: e,
+                reason: "failed to update tunnel endpoint for hosting",
+            })?;
+
+        let url = endpoint
+            .host_relay_uri
+            .as_deref()
+            .ok_or(TunnelError::MissingHostEndpoint)?;
+
+        let req = build_websocket_request(
+            url,
+            &[
+                ("Sec-WebSocket-Protocol", "tunnel-relay-host"),
+                ("Authorization", &format!("tunnel {}", host_token)),
+                ("User-Agent", self.mgmt.user_agent.to_str().unwrap()),
+            ],
+        )?;
+
+        let (cnx, _) = connect_async(req)
+            .await
+            .map_err(TunnelError::WebSocketError)?;
+
+        Ok((cnx, endpoint))
+    }
+}
+
+/// Type returned in a channel from `add_forwarded_port_raw`, implementing
+/// `AsyncRead` and `AsyncWrite`.
+pub struct ForwardedPortConnection {
+    port: u32,
+    channel: russh::ChannelId,
+    handle: russh::server::Handle,
+    receiver: mpsc::Receiver<Vec<u8>>,
+}
+
+impl ForwardedPortConnection {
+    /// Sends data on the connection.
+    pub async fn send(&mut self, d: &[u8]) -> Result<(), ()> {
+        self.handle
+            .data(self.channel, CryptoVec::from_slice(d))
+            .map_err(|_| ())
+            .await
+    }
+
+    /// Receives data from the connection, returning None when it's closed.
+    pub async fn recv(&mut self) -> Option<Vec<u8>> {
+        self.receiver.recv().await
+    }
+
+    /// Closes the forwarded connection.
+    pub async fn close(self) {
+        self.handle.close(self.channel).await.ok();
+    }
+
+    /// Returns an AsyncRead/AsyncWrite implementation for the connection.
+    pub fn into_rw(self) -> ForwardedPortRW {
+        let (w, r) = self.into_split();
+        ForwardedPortRW(r, w)
+    }
+
+    /// Returns a split AsyncRead/AsyncWrite half for the connection.
+    pub fn into_split(self) -> (ForwardedPortWriter, ForwardedPortReader) {
+        (
+            ForwardedPortWriter {
+                channel: self.channel,
+                handle: self.handle,
+                is_write_fut_valid: false,
+                write_fut: tokio_util::sync::ReusableBoxFuture::new(make_server_write_fut(None)),
+            },
+            ForwardedPortReader {
+                receiver: self.receiver,
+                readbuf: super::io::ReadBuffer::default(),
+            },
+        )
+    }
+}
+
+/// AsyncWrite implementation that can be obtained from the ForwardedPortConnection.
+pub struct ForwardedPortWriter {
+    channel: russh::ChannelId,
+    handle: russh::server::Handle,
+    is_write_fut_valid: bool,
+    write_fut: tokio_util::sync::ReusableBoxFuture<'static, Result<(), russh::CryptoVec>>,
+}
+
+/// Makes a future that writes to the russh handle. This general approach was
+/// taken from https://docs.rs/tokio-util/0.7.3/tokio_util/sync/struct.PollSender.html
+/// This is just like make_client_write_fut, but for clients (they don't share a trait...)
+async fn make_server_write_fut(
+    data: Option<(russh::server::Handle, russh::ChannelId, Vec<u8>)>,
+) -> Result<(), russh::CryptoVec> {
+    match data {
+        Some((client, id, data)) => client.data(id, CryptoVec::from(data)).await,
+        None => unreachable!("this future should not be pollable in this state"),
+    }
+}
+
+impl AsyncWrite for ForwardedPortWriter {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        if !self.is_write_fut_valid {
+            let handle = self.handle.clone();
+            let id = self.channel;
+            self.write_fut
+                .set(make_server_write_fut(Some((handle, id, buf.to_vec()))));
+            self.is_write_fut_valid = true;
+        }
+
+        self.poll_flush(cx).map(|r| r.map(|_| buf.len()))
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        if !self.is_write_fut_valid {
+            return Poll::Ready(Ok(()));
+        }
+
+        match self.write_fut.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(_)) => {
+                self.is_write_fut_valid = false;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(_)) => {
+                self.is_write_fut_valid = false;
+                Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "EOF")))
+            }
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// AsyncRead implementation that can be obtained from the ForwardedPortConnection.
+pub struct ForwardedPortReader {
+    receiver: mpsc::Receiver<Vec<u8>>,
+    readbuf: super::io::ReadBuffer,
+}
+
+impl AsyncRead for ForwardedPortReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if let Some(v) = self.readbuf.take_data() {
+            return self.readbuf.put_data(buf, &v);
+        }
+
+        match self.receiver.poll_recv(cx) {
+            Poll::Ready(Some(msg)) => self.readbuf.put_data(buf, &msg),
+            Poll::Ready(None) => Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "EOF"))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub struct ForwardedPortRW(ForwardedPortReader, ForwardedPortWriter);
+
+impl AsyncRead for ForwardedPortRW {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for ForwardedPortRW {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        Pin::new(&mut self.1).poll_write(cx, buf)
+    }
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.1).poll_flush(cx)
+    }
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.1).poll_shutdown(cx)
+    }
+}
+
+#[derive(Clone)]
+struct Server {
+    config: Arc<russh::server::Config>,
+}
+
+impl Server {
+    pub fn run_stream(
+        &mut self,
+        rw: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        mut ports: watch::Receiver<PortMap>,
+    ) -> JoinHandle<Result<(), russh::Error>> {
+        let mut server_session = self.new_client(None);
+        let mut server_connection_rx = server_session.take_rx().expect("expected to have tx");
+        let authed_tx = server_session.take_authed().expect("expected to have tx");
+
+        let config = self.config.clone();
+        tokio::spawn(async move {
+            let session = match russh::server::run_stream(config, rw, server_session).await {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("error handshaking session: {}", e);
+                    return Err(e);
+                }
+            };
+
+            if authed_tx.await.is_err() {
+                log::debug!("connection closed before auth");
+                return Ok(()); // session closed
+            }
+
+            let mut known_ports: PortMap = HashMap::new();
+            tokio::pin!(session);
+
+            loop {
+                tokio::select! {
+                    r = &mut session => return r,
+                    cnx = server_connection_rx.recv() => match cnx {
+                        Some(cnx) => {
+                            if let Some(p) = known_ports.get(&cnx.port) {
+                                p.send(cnx).ok(); // ignore error, could have dropped in the meantime
+                            }
+                        },
+                        None => {
+                            log::debug!("no more connections, ending");
+                            return Ok(());
+                        },
+                    },
+                    _ = ports.changed() => {
+                        let new_ports = ports.borrow().clone();
+                        for port in new_ports.keys() {
+                            if !known_ports.contains_key(port) {
+                                session.handle().forward_tcpip("127.0.0.1".to_string(), *port).await.ok();
+                            }
+                        }
+                        for port in known_ports.keys() {
+                            if !new_ports.contains_key(port) {
+                                session.handle().cancel_forward_tcpip("127.0.0.1".to_string(), *port).await.ok();
+                            }
+                        }
+
+                        known_ports = new_ports;
+                    },
+                }
+            }
+        })
+    }
+}
+
+/// Connects connections that are sent to the receiver to TCP services locally.
+/// Runs until the receiver is closed (usually via `delete_port()`).
+async fn forward_port_to_tcp(
+    addr: impl tokio::net::ToSocketAddrs + std::fmt::Display,
+    mut rx: mpsc::UnboundedReceiver<ForwardedPortConnection>,
+) {
+    while let Some(mut conn) = rx.recv().await {
+        let mut stream = match TcpStream::connect(&addr).await {
+            Ok(s) => s,
+            Err(e) => {
+                log::info!("Error connecting forwarding to {}, {}", addr, e);
+                conn.close().await;
+                continue;
+            }
+        };
+
+        log::debug!("Forwarded port to {}", addr);
+
+        tokio::spawn(async move {
+            let mut read_buf = [0u8; 1024 * 64];
+            loop {
+                tokio::select! {
+                    n = stream.read(&mut read_buf) => match n {
+                        Ok(0) => {
+                            log::debug!("EOF from TCP stream, ending");
+                            break;
+                        },
+                        Ok(n) => {
+                            if (conn.send(&read_buf[..n]).await).is_err() {
+                                log::debug!("channel was closed, ending forwarded port");
+                                break;
+                            }
+                        },
+                        Err(e) => {
+                            log::debug!("error from TCP stream, ending: {}", e);
+                            break;
+                        }
+                    },
+                    m = conn.recv() => match m {
+                        Some(data) => {
+                            if let Err(e) = stream.write_all(&data).await {
+                                log::debug!("error writing data to channel, ending: {}", e);
+                                break;
+                            }
+                        },
+                        None => {
+                            log::debug!("EOF from channel, ending");
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+impl ServerTrait for Server {
+    type Handler = ServerHandle;
+    fn new_client(&mut self, _: Option<std::net::SocketAddr>) -> ServerHandle {
+        ServerHandle::new()
+    }
+}
+
+struct ServerHandle {
+    authed_tx: Option<oneshot::Sender<()>>,
+    authed_rx: Option<oneshot::Receiver<()>>,
+    cnx_tx: mpsc::UnboundedSender<ForwardedPortConnection>,
+    cnx_rx: Option<mpsc::UnboundedReceiver<ForwardedPortConnection>>,
+    channel_senders: HashMap<russh::ChannelId, mpsc::Sender<Vec<u8>>>,
+}
+
+impl ServerHandle {
+    pub fn new() -> Self {
+        let (authed_tx, authed_rx) = oneshot::channel();
+        let (cnx_tx, cnx_rx) = mpsc::unbounded_channel();
+        Self {
+            authed_rx: Some(authed_rx),
+            authed_tx: Some(authed_tx),
+            cnx_rx: Some(cnx_rx),
+            cnx_tx,
+            channel_senders: HashMap::new(),
+        }
+    }
+
+    /// Takes the receiver from a newly-created handle.
+    pub fn take_rx(&mut self) -> Option<mpsc::UnboundedReceiver<ForwardedPortConnection>> {
+        self.cnx_rx.take()
+    }
+
+    /// Takes the receiver from a newly-created handle.
+    pub fn take_authed(&mut self) -> Option<oneshot::Receiver<()>> {
+        self.authed_rx.take()
+    }
+}
+
+impl russh::server::Handler for ServerHandle {
+    type Error = russh::Error;
+    type FutureAuth = Pin<
+        Box<
+            dyn core::future::Future<Output = Result<(Self, russh::server::Auth), Self::Error>>
+                + Send,
+        >,
+    >;
+    type FutureUnit = Pin<
+        Box<
+            dyn core::future::Future<Output = Result<(Self, russh::server::Session), Self::Error>>
+                + Send,
+        >,
+    >;
+    type FutureBool = Pin<
+        Box<
+            dyn core::future::Future<
+                    Output = Result<(Self, russh::server::Session, bool), Self::Error>,
+                > + Send,
+        >,
+    >;
+
+    fn finished_auth(self, auth: russh::server::Auth) -> Self::FutureAuth {
+        async { Ok((self, auth)) }.boxed()
+    }
+
+    fn finished_bool(self, b: bool, s: russh::server::Session) -> Self::FutureBool {
+        async move { Ok((self, s, b)) }.boxed()
+    }
+
+    fn finished(self, s: russh::server::Session) -> Self::FutureUnit {
+        async { Ok((self, s)) }.boxed()
+    }
+
+    fn auth_succeeded(mut self, session: russh::server::Session) -> Self::FutureUnit {
+        if let Some(tx) = self.authed_tx.take() {
+            tx.send(()).ok();
+        }
+
+        self.finished(session)
+    }
+
+    /// Connecting clients will use "none" auth on their channels.
+    fn auth_none(self, _: &str) -> Self::FutureAuth {
+        self.finished_auth(russh::server::Auth::Accept)
+    }
+
+    fn channel_open_forwarded_tcpip(
+        mut self,
+        channel: russh::ChannelId,
+        _host_to_connect: &str,
+        port_to_connect: u32,
+        _originator_address: &str,
+        _originator_port: u32,
+        session: russh::server::Session,
+    ) -> Self::FutureBool {
+        let (sender, receiver) = mpsc::channel(10);
+        let txd = self.cnx_tx.send(ForwardedPortConnection {
+            port: port_to_connect,
+            channel,
+            handle: session.handle(),
+            receiver,
+        });
+        if txd.is_ok() {
+            self.channel_senders.insert(channel, sender);
+        }
+        self.finished_bool(true, session)
+    }
+
+    fn data(
+        mut self,
+        channel: russh::ChannelId,
+        data: &[u8],
+        session: russh::server::Session,
+    ) -> Self::FutureUnit {
+        let data_vec = data.to_vec();
+        async move {
+            if let Some(sender) = self.channel_senders.get(&channel) {
+                if sender.send(data_vec).await.is_err() {
+                    self.channel_senders.remove(&channel);
+                }
+            }
+            Ok((self, session))
+        }
+        .boxed()
+    }
+}
+
+/// Type sent from the Handler back to the processing queue. This can be a
+/// channel starting or stopping, or data on a channel.
+#[derive(Debug)]
+enum ChannelOp {
+    Open(russh::ChannelId),
+    Close(russh::ChannelId),
+    Data(russh::ChannelId, Vec<u8>),
+}
+
+/// The Client implements the russh handler for the main SSH session on which
+/// connections will come in via channels.
+struct Client {
+    sender: mpsc::UnboundedSender<ChannelOp>,
+}
+
+impl Client {
+    pub fn new() -> (Self, mpsc::UnboundedReceiver<ChannelOp>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Client { sender: tx }, rx)
+    }
+}
+
+impl russh::client::Handler for Client {
+    type Error = russh::Error;
+    type FutureUnit = futures::future::Ready<Result<(Self, russh::client::Session), russh::Error>>;
+    type FutureBool = futures::future::Ready<Result<(Self, bool), russh::Error>>;
+
+    fn finished_bool(self, b: bool) -> Self::FutureBool {
+        futures::future::ready(Ok((self, b)))
+    }
+    fn finished(self, session: russh::client::Session) -> Self::FutureUnit {
+        futures::future::ready(Ok((self, session)))
+    }
+
+    fn check_server_key(self, _server_public_key: &russh_keys::key::PublicKey) -> Self::FutureBool {
+        self.finished_bool(true)
+    }
+
+    fn server_channel_handle_unknown(
+        &self,
+        channel: russh::ChannelId,
+        channel_type: &[u8],
+    ) -> bool {
+        if channel_type == b"client-ssh-session-stream" {
+            self.sender.send(ChannelOp::Open(channel)).ok();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn channel_close(
+        self,
+        channel: russh::ChannelId,
+        session: russh::client::Session,
+    ) -> Self::FutureUnit {
+        self.sender.send(ChannelOp::Close(channel)).ok();
+        self.finished(session)
+    }
+
+    fn data(
+        self,
+        channel: russh::ChannelId,
+        data: &[u8],
+        session: russh::client::Session,
+    ) -> Self::FutureUnit {
+        self.sender
+            .send(ChannelOp::Data(channel, data.to_vec()))
+            .ok();
+        self.finished(session)
+    }
+}
+
+/// AsyncRead/AsyncWrite for converting SSH Channels into AsyncRead/AsyncWrite.
+struct AsyncRWChannel {
+    id: russh::ChannelId,
+    session: Arc<russh::client::Handle<Client>>,
+    incoming: mpsc::UnboundedReceiver<Vec<u8>>,
+
+    readbuf: super::io::ReadBuffer,
+
+    is_write_fut_valid: bool,
+    write_fut: tokio_util::sync::ReusableBoxFuture<'static, Result<(), russh::CryptoVec>>,
+}
+
+impl AsyncRWChannel {
+    pub fn new(
+        id: russh::ChannelId,
+        session: Arc<russh::client::Handle<Client>>,
+    ) -> (Self, mpsc::UnboundedSender<Vec<u8>>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            AsyncRWChannel {
+                id,
+                session,
+                incoming: rx,
+                readbuf: super::io::ReadBuffer::default(),
+                is_write_fut_valid: false,
+                write_fut: tokio_util::sync::ReusableBoxFuture::new(make_client_write_fut(None)),
+            },
+            tx,
+        )
+    }
+}
+
+/// Makes a future that writes to the russh handle. This general approach was
+/// taken from https://docs.rs/tokio-util/0.7.3/tokio_util/sync/struct.PollSender.html
+/// This is just like make_server_write_fut, but for clients (they don't share a trait...)
+async fn make_client_write_fut(
+    data: Option<(
+        Arc<russh::client::Handle<Client>>,
+        russh::ChannelId,
+        Vec<u8>,
+    )>,
+) -> Result<(), russh::CryptoVec> {
+    match data {
+        Some((client, id, data)) => client.data(id, CryptoVec::from(data)).await,
+        None => unreachable!("this future should not be pollable in this state"),
+    }
+}
+
+impl AsyncWrite for AsyncRWChannel {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        if !self.is_write_fut_valid {
+            let session = self.session.clone();
+            let id = self.id;
+            self.write_fut
+                .set(make_client_write_fut(Some((session, id, buf.to_vec()))));
+            self.is_write_fut_valid = true;
+        }
+
+        self.poll_flush(cx).map(|r| r.map(|_| buf.len()))
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        if !self.is_write_fut_valid {
+            return Poll::Ready(Ok(()));
+        }
+
+        match self.write_fut.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(_)) => {
+                self.is_write_fut_valid = false;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(_)) => {
+                self.is_write_fut_valid = false;
+                Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "EOF")))
+            }
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncRead for AsyncRWChannel {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if let Some(v) = self.readbuf.take_data() {
+            return self.readbuf.put_data(buf, &v);
+        }
+
+        match self.incoming.poll_recv(cx) {
+            Poll::Ready(Some(msg)) => self.readbuf.put_data(buf, &msg),
+            Poll::Ready(None) => Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "EOF"))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub struct RelayHandle {
+    endpoint: TunnelRelayTunnelEndpoint,
+    session: Arc<russh::client::Handle<Client>>,
+    join: JoinHandle<Result<(), russh::Error>>,
+}
+
+impl RelayHandle {
+    /// Gets the endpoint this relay is connected to.
+    pub fn endpoint(&self) -> &TunnelRelayTunnelEndpoint {
+        &self.endpoint
+    }
+
+    /// Closes the tunnel and waits for all associated tasks to end.
+    pub async fn close(self) -> Result<(), TunnelError> {
+        let result = self
+            .session
+            .disconnect(russh::Disconnect::ByApplication, "disconnect", "en")
+            .await;
+        self.join.await.ok();
+        result.map_err(TunnelError::TunnelRelayDisconnected)
+    }
+}
+
+impl std::future::Future for RelayHandle {
+    type Output = Result<(), TunnelError>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match std::future::Future::poll(Pin::new(&mut self.join), cx) {
+            Poll::Ready(r) => Poll::Ready(match r {
+                Ok(Ok(_)) => Ok(()),
+                Ok(Err(e)) => Err(TunnelError::TunnelRelayDisconnected(e)),
+                Err(_) => Ok(()),
+            }),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/rs/src/connections/io.rs
+++ b/rs/src/connections/io.rs
@@ -32,7 +32,7 @@ impl ReadBuffer {
             target.put_slice(&bytes[start..]);
             self.0 = None;
         } else {
-            let end = target.remaining();
+            let end = start + target.remaining();
             target.put_slice(&bytes[start..end]);
             self.0 = Some((bytes, end));
         }

--- a/rs/src/connections/io.rs
+++ b/rs/src/connections/io.rs
@@ -29,11 +29,12 @@ impl ReadBuffer {
         }
 
         if target.remaining() >= bytes.len() - start {
-            target.put_slice(&bytes);
+            target.put_slice(&bytes[start..]);
             self.0 = None;
         } else {
-            target.put_slice(&bytes[start..start + target.remaining()]);
-            self.0 = Some((bytes, start + target.remaining()));
+            let end = target.remaining();
+            target.put_slice(&bytes[start..end]);
+            self.0 = Some((bytes, end));
         }
 
         Poll::Ready(Ok(()))

--- a/rs/src/connections/io.rs
+++ b/rs/src/connections/io.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::task::Poll;
+
+/// Helper used when converting Future interfaces to poll-based interfaces.
+/// Stores excess data that can be reused on future polls.
+#[derive(Default)]
+pub(crate) struct ReadBuffer(Option<Vec<u8>>);
+
+impl ReadBuffer {
+    /// Removes any data stored in the read buffer
+    pub fn take_data(&mut self) -> Option<Vec<u8>> {
+        self.0.take()
+    }
+
+    /// Writes as many bytes as possible to the readbuf, stashing any extra.
+    pub fn put_data(
+        &mut self,
+        target: &mut tokio::io::ReadBuf<'_>,
+        bytes: &[u8],
+    ) -> Poll<std::io::Result<()>> {
+        if bytes.is_empty() {
+            self.0 = None;
+            // should not return Ok(), since if nothing is written to the target
+            // it signals EOF. Instead wait for more data from the source.
+            return Poll::Pending;
+        }
+
+        if target.remaining() >= bytes.len() {
+            self.0 = None;
+            target.put_slice(bytes);
+        } else {
+            self.0 = Some(bytes[target.remaining()..].to_vec());
+            target.put_slice(&bytes[..target.remaining()]);
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}

--- a/rs/src/connections/mod.rs
+++ b/rs/src/connections/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+mod errors;
+mod io;
+mod host_relay;
+mod ws;
+
+pub use host_relay::*;

--- a/rs/src/connections/mod.rs
+++ b/rs/src/connections/mod.rs
@@ -3,7 +3,7 @@
 
 mod errors;
 mod io;
-mod host_relay;
+mod relay_tunnel_host;
 mod ws;
 
-pub use host_relay::*;
+pub use relay_tunnel_host::*;

--- a/rs/src/connections/ws.rs
+++ b/rs/src/connections/ws.rs
@@ -1,0 +1,330 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+use std::{io, pin::Pin, task::Poll, time::Duration};
+
+use futures::{Future, Sink, Stream};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    time::{sleep, Instant, Sleep},
+};
+use tokio_tungstenite::WebSocketStream;
+
+use super::errors::TunnelError;
+
+/// AsyncRead/AsyncWrite wrapper for a WebSocketStream.
+pub(crate) struct AsyncRWWebSocket<S> {
+    websocket: WebSocketStream<S>,
+    readbuf: super::io::ReadBuffer,
+    ping_timer: Pin<Box<Sleep>>,
+    ping_state: PingState,
+    ping_interval: Duration,
+    ping_timeout: Duration,
+}
+
+enum PingState {
+    WillPing,
+    SendingPing,
+    WaitingForPong,
+}
+
+pub(crate) struct AsyncRWWebSocketOptions<S> {
+    pub websocket: WebSocketStream<S>,
+    pub ping_interval: Duration,
+    pub ping_timeout: Duration,
+}
+
+impl<S> AsyncRWWebSocket<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    pub fn new(opts: AsyncRWWebSocketOptions<S>) -> Self {
+        AsyncRWWebSocket {
+            websocket: opts.websocket,
+            readbuf: super::io::ReadBuffer::default(),
+            ping_timer: Box::pin(sleep(opts.ping_interval)),
+            ping_state: PingState::WillPing,
+            ping_interval: opts.ping_interval,
+            ping_timeout: opts.ping_timeout,
+        }
+    }
+
+    fn get_ws(&mut self) -> Pin<&mut WebSocketStream<S>> {
+        Pin::new(&mut self.websocket)
+    }
+
+    fn poll_send_ping(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> Option<Poll<std::io::Result<()>>> {
+        match self.get_ws().poll_flush(cx) {
+            Poll::Ready(Ok(_)) => {
+                let deadline = Instant::now() + self.ping_timeout;
+                self.ping_timer.as_mut().reset(deadline);
+                self.ping_state = PingState::WaitingForPong;
+                log::debug!("sent liveness ping");
+                None
+            }
+            Poll::Ready(Err(e)) => Some(Poll::Ready(Err(tung_to_io_error(e)))),
+            Poll::Pending => Some(Poll::Pending),
+        }
+    }
+}
+
+fn tung_to_io_error(e: tungstenite::Error) -> io::Error {
+    match e {
+        tungstenite::Error::Io(e) => e,
+        _ => io::Error::new(io::ErrorKind::Other, e.to_string()),
+    }
+}
+
+impl<S> AsyncWrite for AsyncRWWebSocket<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let sm = self.get_mut();
+
+        match sm.get_ws().poll_ready(cx) {
+            Poll::Ready(Ok(())) => {
+                sm.get_ws()
+                    .start_send(tungstenite::Message::Binary(buf.to_vec()))
+                    .map_err(tung_to_io_error)?;
+                Poll::Ready(Ok(buf.len()))
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(tung_to_io_error(e))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        self.get_mut()
+            .get_ws()
+            .poll_flush(cx)
+            .map_err(tung_to_io_error)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        self.get_mut()
+            .get_ws()
+            .poll_close(cx)
+            .map_err(tung_to_io_error)
+    }
+}
+
+impl<S> AsyncRead for AsyncRWWebSocket<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if let Some(v) = self.readbuf.take_data() {
+            return self.readbuf.put_data(buf, &v);
+        }
+
+        // The following blocks implement the state machine for liveness checks
+        // via a websocket ping/pong. There is a "sleep" on the struct, which
+        // is bumped every time we get a new message, along with a "state".
+        //
+        // - When sleep times out the first time (state=WillPing), we poll the
+        //   websocket for readiness, and then enqueue a ping message.
+        // - When sending that ping (state=SendingPing), we poll_flush the socket
+        //   until that gets sent, reset the timer, and then move to WaitForPong.
+        // - The next time the timer times out, if we're still state=WaitForPong
+        //   state (i.e. the state was not updated in the below read loop) then
+        //   we signal EOF to the caller.
+
+        if let PingState::SendingPing = self.ping_state {
+            if let Some(ret) = self.poll_send_ping(cx) {
+                return ret;
+            }
+        } else if Pin::new(&mut self.ping_timer).poll(cx).is_ready() {
+            match self.ping_state {
+                PingState::WaitingForPong => {
+                    log::info!("websocket pong timed out, closing");
+                    return Poll::Ready(Ok(()));
+                }
+                PingState::WillPing => match self.get_ws().poll_ready(cx) {
+                    Poll::Ready(Ok(_)) => {
+                        if let Err(e) = self.get_ws().start_send(tungstenite::Message::Ping(vec![]))
+                        {
+                            return Poll::Ready(Err(tung_to_io_error(e)));
+                        }
+                        self.ping_state = PingState::SendingPing;
+                        if let Some(ret) = self.poll_send_ping(cx) {
+                            return ret;
+                        }
+                    }
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(tung_to_io_error(e))),
+                    Poll::Pending => return Poll::Pending,
+                },
+                PingState::SendingPing => unreachable!(),
+            }
+        }
+
+        // That's the end of ping/pong. Now the standard read loop:
+        loop {
+            match self.get_ws().poll_next(cx) {
+                Poll::Ready(Some(Ok(msg))) => {
+                    // bump the timeout to avoid unnecessary work if messages
+                    // are still flowing.
+                    let deadline = Instant::now() + self.ping_interval;
+                    self.ping_timer.as_mut().reset(deadline);
+
+                    match msg {
+                        tungstenite::Message::Text(text) => {
+                            return self.readbuf.put_data(buf, text.as_bytes());
+                        }
+                        tungstenite::Message::Binary(bin) => {
+                            return self.readbuf.put_data(buf, bin.as_slice());
+                        }
+                        tungstenite::Message::Close(_) => return Poll::Ready(Ok(())),
+                        tungstenite::Message::Pong(_) => {
+                            log::debug!("received liveness pong");
+                            self.ping_state = PingState::WillPing;
+                        }
+                        // Note: tungstenite handles replying to pings internally,
+                        // so we don't need to handle that here.
+                        _ => { /* read next */ }
+                    }
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    log::info!("error reading websocket: {}", e);
+                    return Poll::Ready(Err(tung_to_io_error(e)));
+                }
+                Poll::Ready(None) => return Poll::Ready(Ok(())),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+/// Creates a websocket request with additional headers. This is annoyingly
+/// complicated. https://github.com/snapview/tungstenite-rs/issues/107
+pub(crate) fn build_websocket_request(
+    url: &str,
+    extra_headers: &[(&str, &str)],
+) -> Result<tungstenite::handshake::client::Request, TunnelError> {
+    let url =
+        reqwest::Url::try_from(url).map_err(|e| TunnelError::InvalidHostEndpoint(e.to_string()))?;
+    let host = url
+        .host()
+        .ok_or_else(|| TunnelError::InvalidHostEndpoint("missing host".to_string()))?;
+
+    let mut req = tungstenite::handshake::client::Request::builder()
+        .method("GET")
+        .header("Host", host.to_string())
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header(
+            "Sec-WebSocket-Key",
+            tungstenite::handshake::client::generate_key(),
+        );
+
+    for (key, value) in extra_headers {
+        req = req.header(*key, *value);
+    }
+
+    req.uri(url.as_str())
+        .body(())
+        .map_err(|e| TunnelError::InvalidHostEndpoint(e.to_string()))
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use futures::{StreamExt, TryStreamExt};
+    use rand::RngCore;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+    };
+    use tokio_tungstenite::connect_async;
+
+    use super::{build_websocket_request, AsyncRWWebSocket, AsyncRWWebSocketOptions};
+
+    #[tokio::test]
+    async fn test_websocket_stream() {
+        let echo_server = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("expect to listen");
+
+        let req = build_websocket_request(
+            &format!("ws://{}", echo_server.local_addr().unwrap()),
+            &[("User-Agent", "test client")],
+        )
+        .expect("expected to make req");
+
+        tokio::spawn(async move {
+            let (cnx, _) = echo_server.accept().await.expect("expect client");
+            accept_echo_server_connection(cnx).await;
+        });
+
+        let input_len = 1024 * 1024;
+        let mut input = Vec::new();
+        input.reserve(input_len);
+        for i in 0..input_len {
+            input.push(i as u8);
+        }
+
+        let (cnx, _) = connect_async(req).await.expect("expected to connect");
+        let (mut read, mut write) =
+            tokio::io::split(AsyncRWWebSocket::new(AsyncRWWebSocketOptions {
+                ping_interval: Duration::from_secs(60),
+                ping_timeout: Duration::from_secs(1),
+                websocket: cnx,
+            }));
+
+        let input_dup = input.clone();
+        tokio::spawn(async move {
+            let mut i = 0;
+            while i < input_len {
+                let next = std::cmp::min(
+                    input_len,
+                    i + (rand::thread_rng().next_u32() % 100000) as usize,
+                );
+                write
+                    .write_all(&input_dup[i..next])
+                    .await
+                    .expect("expected to write");
+                i = next;
+            }
+        });
+
+        let mut output = Vec::new();
+        output.resize(input_len, 0);
+        read.read_exact(&mut output)
+            .await
+            .expect("expected to read");
+
+        assert_eq!(input, output);
+    }
+
+    async fn accept_echo_server_connection(stream: TcpStream) {
+        let ws_stream = tokio_tungstenite::accept_async(stream)
+            .await
+            .expect("Error during the websocket handshake occurred");
+
+        let (write, read) = ws_stream.split();
+        // We should not forward messages other than text or binary.
+        read.try_filter(|msg| futures::future::ready(msg.is_text() || msg.is_binary()))
+            .forward(write)
+            .await
+            .ok();
+    }
+}

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod contracts;
 pub mod management;
+
+#[cfg(feature = "connections")]
+pub mod connections;

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -11,8 +11,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use url::Url;
 
 use crate::contracts::{
-    env_production, Tunnel, TunnelRelayTunnelEndpoint, TunnelConnectionMode, TunnelEndpoint, TunnelPort,
-    TunnelServiceProperties,
+    env_production, Tunnel, TunnelConnectionMode, TunnelEndpoint, TunnelPort,
+    TunnelRelayTunnelEndpoint, TunnelServiceProperties,
 };
 
 use super::{
@@ -33,6 +33,17 @@ const ENDPOINTS_API_SUB_PATH: &str = "endpoints";
 const PORTS_API_SUB_PATH: &str = "ports";
 
 impl TunnelManagementClient {
+    /// Returns a builder that creates a new client, starting with the current
+    /// client's options.
+    pub fn build(&self) -> TunnelClientBuilder {
+        TunnelClientBuilder {
+            authorization: self.authorization.clone(),
+            client: Some(self.client.clone()),
+            user_agent: self.user_agent.clone(),
+            environment: self.environment.clone(),
+        }
+    }
+
     /// Lists tunnels owned by the user.
     pub async fn list_all_tunnels(
         &self,
@@ -161,7 +172,8 @@ impl TunnelManagementClient {
         let request = self
             .make_tunnel_request(Method::DELETE, url, options)
             .await?;
-        self.execute_no_response("delete_tunnel_endpoints", request).await
+        self.execute_no_response("delete_tunnel_endpoints", request)
+            .await
     }
 
     /// List a tunnel's ports.
@@ -233,7 +245,8 @@ impl TunnelManagementClient {
         let request = self
             .make_tunnel_request(Method::DELETE, url, options)
             .await?;
-        self.execute_no_response("delete_tunnel_port", request).await
+        self.execute_no_response("delete_tunnel_port", request)
+            .await
     }
 
     /// Sends the request and deserializes a JSON response
@@ -262,7 +275,7 @@ impl TunnelManagementClient {
         res
     }
 
-    /// Executes a request in which 200 status codes indicate success and 
+    /// Executes a request in which 200 status codes indicate success and
     /// 404 indicates an unsuccessful deletion but is not an error.
     async fn execute_no_response(&self, _: &'static str, request: Request) -> HttpResult<bool> {
         let url_clone = request.url().clone();
@@ -271,7 +284,7 @@ impl TunnelManagementClient {
             .execute(request)
             .await
             .map_err(HttpError::ConnectionError)?;
-        
+
         if res.status().is_success() {
             Ok(true)
         } else if res.status().as_u16() == 404 {
@@ -430,7 +443,7 @@ where
 }
 
 pub struct TunnelClientBuilder {
-    authorization: Box<dyn AuthorizationProvider>,
+    authorization: Arc<Box<dyn AuthorizationProvider>>,
     client: Option<Client>,
     user_agent: HeaderValue,
     environment: TunnelServiceProperties,
@@ -440,7 +453,9 @@ pub struct TunnelClientBuilder {
 /// to get the client instance (or cast automatically).
 pub fn new_tunnel_management(user_agent: &str) -> TunnelClientBuilder {
     TunnelClientBuilder {
-        authorization: Box::new(super::StaticAuthorizationProvider(Authorization::Anonymous)),
+        authorization: Arc::new(Box::new(super::StaticAuthorizationProvider(
+            Authorization::Anonymous,
+        ))),
         client: None,
         user_agent: HeaderValue::from_str(user_agent).unwrap(),
         environment: env_production(),
@@ -449,7 +464,7 @@ pub fn new_tunnel_management(user_agent: &str) -> TunnelClientBuilder {
 
 impl TunnelClientBuilder {
     pub fn authorization(&mut self, authorization: Authorization) -> &mut Self {
-        self.authorization = Box::new(super::StaticAuthorizationProvider(authorization));
+        self.authorization = Arc::new(Box::new(super::StaticAuthorizationProvider(authorization)));
         self
     }
 
@@ -457,7 +472,7 @@ impl TunnelClientBuilder {
         &mut self,
         provider: impl AuthorizationProvider + 'static,
     ) -> &mut Self {
-        self.authorization = Box::new(provider);
+        self.authorization = Arc::new(Box::new(provider));
         self
     }
 
@@ -475,7 +490,7 @@ impl TunnelClientBuilder {
 impl From<TunnelClientBuilder> for TunnelManagementClient {
     fn from(builder: TunnelClientBuilder) -> Self {
         TunnelManagementClient {
-            authorization: Arc::new(builder.authorization),
+            authorization: builder.authorization,
             client: builder.client.unwrap_or_else(Client::new),
             user_agent: builder.user_agent,
             environment: builder.environment,

--- a/rs/src/management/tunnel_locator.rs
+++ b/rs/src/management/tunnel_locator.rs
@@ -1,6 +1,6 @@
 use crate::contracts::Tunnel;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TunnelLocator {
     /// Tunnel by its unique name.
     Name(String),


### PR DESCRIPTION
This implement a host relay. It does not yet implement reconnections,
although with that added in consumer code this has been working fairly
well for me, and I've been using this for my day-to-date work.
The relay is opt-in under the `connections` feature flag.

This PR is marked as draft until russh publishes their next version,
at which time I'll update the Cargo.toml and this'll be ready to go.