### PR TITLE
Add ssh gateway public key to tunnel endpoint

### DIFF
--- a/cs/src/Contracts/TunnelEndpoint.cs
+++ b/cs/src/Contracts/TunnelEndpoint.cs
@@ -83,6 +83,13 @@ public abstract class TunnelEndpoint
     public string? TunnelSshCommand { get; set; }
 
     /// <summary>
+    /// Gets or sets the Ssh gateway public key which should be added to the authorized_keys
+    /// file so that tunnel service can connect to the shared ssh server.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SshGatewayPublicKey { get; set; }
+
+    /// <summary>
     /// Token included in <see cref="PortUriFormat"/> and <see cref="PortSshCommandFormat"/>
     ///  that is to be replaced by a specified port number.
     /// </summary>

--- a/go/tunnels/tunnel_endpoint.go
+++ b/go/tunnels/tunnel_endpoint.go
@@ -48,6 +48,10 @@ type TunnelEndpoint struct {
 	// of the tunnel.
 	TunnelSshCommand     string `json:"tunnelSshCommand,omitempty"`
 
+	// Gets or sets the Ssh gateway public key which should be added to the authorized_keys
+	// file so that tunnel service can connect to the shared ssh server.
+	SshGatewayPublicKey  string `json:"sshGatewayPublicKey,omitempty"`
+
 	LocalNetworkTunnelEndpoint
 	TunnelRelayTunnelEndpoint
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelEndpoint.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelEndpoint.java
@@ -76,6 +76,13 @@ public class TunnelEndpoint {
     public String tunnelSshCommand;
 
     /**
+     * Gets or sets the Ssh gateway public key which should be added to the
+     * authorized_keys file so that tunnel service can connect to the shared ssh server.
+     */
+    @Expose
+    public String sshGatewayPublicKey;
+
+    /**
      * Token included in {@link TunnelEndpoint#portUriFormat} and {@link
      * TunnelEndpoint#portSshCommandFormat} that is to be replaced by a specified port
      * number.

--- a/rs/src/contracts/tunnel_endpoint.rs
+++ b/rs/src/contracts/tunnel_endpoint.rs
@@ -52,6 +52,10 @@ pub struct TunnelEndpoint {
     // Gets or sets the Ssh command where the Ssh client can connect to the default ssh
     // port of the tunnel.
     pub tunnel_ssh_command: Option<String>,
+
+    // Gets or sets the Ssh gateway public key which should be added to the
+    // authorized_keys file so that tunnel service can connect to the shared ssh server.
+    pub ssh_gateway_public_key: Option<String>,
 }
 
 // Token included in `TunnelEndpoint.PortUriFormat` and

--- a/ts/src/contracts/tunnelEndpoint.ts
+++ b/ts/src/contracts/tunnelEndpoint.ts
@@ -65,6 +65,12 @@ export interface TunnelEndpoint {
      * port of the tunnel.
      */
     tunnelSshCommand?: string;
+
+    /**
+     * Gets or sets the Ssh gateway public key which should be added to the
+     * authorized_keys file so that tunnel service can connect to the shared ssh server.
+     */
+    sshGatewayPublicKey?: string;
 }
 
 /**


### PR DESCRIPTION
Add ssh gateway public key to tunnel endpoint which will be used in CLI to show it user to add the public key to authorized_keys file.