### PR TITLE
Add Java refresh ports tests

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -9,10 +9,9 @@ These instructions assume you are using vscode for development as SDK is configu
 
 ### Testing
 1. Get a user token using the CLI command: `user show --verbose`
-2. Create a new tunnel and add a port.
-3. Create a new environment variable `TEST_TUNNEL_TOKEN` with a string value "Bearer <token>".
-4. Create a new environment variable `TEST_TUNNEL_NAME` with a value containing the name of the tunnel.
-5. Optionally: set `TEST_TUNNEL_VERBOSE=1` to enable verbose console logging during tests.
+2. Create a new environment variable `TEST_TUNNEL_TOKEN` with a string value "Bearer <token>".
+3. Create a new environment variable `TEST_TUNNEL_NAME` with a value containing the name of the tunnel.
+4. Optionally: set `TEST_TUNNEL_VERBOSE=1` to enable verbose console logging during tests.
 5. Use the CLI to host the tunnel.
 6. Run the tests with `mvn test`, or run a single test with `mvn test -Dtest=TunnelClientTests#connectClient`
 

--- a/java/src/test/java/com/microsoft/tunnels/TunnelClientTests.java
+++ b/java/src/test/java/com/microsoft/tunnels/TunnelClientTests.java
@@ -1,38 +1,100 @@
 package com.microsoft.tunnels;
 
+import com.microsoft.tunnels.connections.ForwardedPort;
+import com.microsoft.tunnels.connections.ForwardedPortEventListener;
 import com.microsoft.tunnels.connections.TunnelClient;
 import com.microsoft.tunnels.connections.TunnelRelayTunnelClient;
 import com.microsoft.tunnels.contracts.Tunnel;
-import com.microsoft.tunnels.contracts.TunnelAccessScopes;
-import com.microsoft.tunnels.management.TunnelRequestOptions;
+import com.microsoft.tunnels.contracts.TunnelPort;
+import com.microsoft.tunnels.management.HttpResponseException;
 
-import java.util.Arrays;
-
+import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TunnelClientTests extends TunnelTest {
+  private static Tunnel testTunnel;
+
+  @BeforeClass
+  public static void initializeTestTunnel() {
+    testTunnel = getTestTunnel();
+  }
 
   @Test
   public void connectClient() {
-    // Set up tunnel
-    Tunnel tunnel = new Tunnel();
-    tunnel.name = this.testTunnelName;
-    System.out.println(tunnel.name);
-
-    // Configure tunnel request options
-    var requestOptions = new TunnelRequestOptions();
-    requestOptions.tokenScopes = Arrays.asList(TunnelAccessScopes.connect);
-    requestOptions.includePorts = true;
-
-    // get tunnel
-    var result = this.tunnelManagementClient.getTunnelAsync(tunnel, requestOptions).join();
-
-    // Connect to the tunnel
     TunnelClient client = new TunnelRelayTunnelClient();
 
     // connect to the tunnel
-    client.connectAsync(result).join();
-    logger.info("Connected.");
-    client.stop();
+    client.connectAsync(testTunnel).thenRun(() -> {
+      logger.info("TunnelRelayTunnel client connected successfully.");
+      client.stop();
+    }).join();
+  }
+
+  @Test
+  public void addAndRemovePorts() {
+    var testPort = new TunnelPort();
+    testPort.portNumber = 5000;
+    testPort.protocol = "https";
+    TunnelRelayTunnelClient client = new TunnelRelayTunnelClient();
+
+    client.getForwardedPorts().addListener(new ForwardedPortEventListener() {
+      @Override
+      public void onForwardedPortAdded(ForwardedPort port) {
+        logger.info("Port added - local: " + port.getLocalPort()
+            + " remote: " + port.getRemotePort());
+        Assert.assertEquals(testPort.portNumber, port.getRemotePort());
+      }
+
+      @Override
+      public void onForwardedPortRemoved(ForwardedPort port) {
+        logger.info("Port removed - local: " + port.getLocalPort()
+            + " remote: " + port.getRemotePort());
+        Assert.assertEquals(testPort.portNumber, port.getRemotePort());
+      }
+    });
+
+    // Add a new port via the tunnelManagementClient and verify that the client
+    // does not pick it up.
+    Runnable updateTunnelPort = () -> {
+      Assert.assertEquals("Expected no ports to be forwarded yet.",
+          0, client.getForwardedPorts().size());
+      logger.info("Adding port " + testPort.portNumber + " to test tunnel " +
+          testTunnelName);
+      tunnelManagementClient.createTunnelPortAsync(testTunnel, testPort,
+          null).thenRun(() -> {
+            Assert.assertEquals("Expected forwarded ports to not be updated.",
+                0, client.getForwardedPorts().size());
+          });
+    };
+
+    // Verify that calling refreshPorts on the client adds new ports to the
+    // collection.
+    Runnable refreshTunnelPorts = () -> {
+      logger.info("Refreshing ports of test tunnel " + testTunnelName);
+      client.refreshPortsAsync().thenRun(() -> {
+        Assert.assertEquals("Expected port " + testPort.portNumber
+            + " to be added to the forwarded ports collection.",
+            1, client.getForwardedPorts().size());
+      });
+    };
+
+    try {
+      client.connectAsync(testTunnel)
+          .thenRun(updateTunnelPort)
+          .thenRun(refreshTunnelPorts)
+          .thenRun(refreshTunnelPorts) // calling refresh a second time shouldn't affect anything.
+          .join();
+    } finally {
+      try {
+        // Delete the port and verify that the correct port is removed from the collection.
+        logger.info("Deleting port " + testPort.portNumber + " of test tunnel " + testTunnelName);
+        tunnelManagementClient.deleteTunnelPortAsync(testTunnel, testPort.portNumber, null)
+          .thenRun(refreshTunnelPorts)
+          .join();
+      } finally {
+        client.stop();
+      }
+    }
   }
 }

--- a/java/src/test/java/com/microsoft/tunnels/TunnelTest.java
+++ b/java/src/test/java/com/microsoft/tunnels/TunnelTest.java
@@ -3,9 +3,13 @@
 
 package com.microsoft.tunnels;
 
+import com.microsoft.tunnels.contracts.Tunnel;
+import com.microsoft.tunnels.contracts.TunnelAccessScopes;
 import com.microsoft.tunnels.management.ProductHeaderValue;
 import com.microsoft.tunnels.management.TunnelManagementClient;
+import com.microsoft.tunnels.management.TunnelRequestOptions;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
@@ -21,15 +25,16 @@ public abstract class TunnelTest {
       TunnelManagementClientTests.class.getPackage().getSpecificationVersion());
 
   // Test tunnel used for local testing of tunnel connections.
-  protected final String testTunnelName = System.getenv("TEST_TUNNEL_NAME");
+  protected static final String testTunnelName = System.getenv("TEST_TUNNEL_NAME");
   // User token for creating tunnels in local tests.
-  protected final String testToken = System.getenv("TEST_TUNNEL_TOKEN");
+  protected static final String testToken = System.getenv("TEST_TUNNEL_TOKEN");
 
-  protected final Supplier<CompletableFuture<String>> userTokenCallback = StringUtils.isNotBlank(testToken)
-      ? () -> CompletableFuture.completedFuture(testToken)
-      : null;
+  protected static final Supplier<CompletableFuture<String>> userTokenCallback = StringUtils
+      .isNotBlank(testToken)
+          ? () -> CompletableFuture.completedFuture(testToken)
+          : null;
 
-  protected TunnelManagementClient tunnelManagementClient = new TunnelManagementClient(
+  protected static TunnelManagementClient tunnelManagementClient = new TunnelManagementClient(
       new ProductHeaderValue[] { userAgent },
       userTokenCallback);
 
@@ -42,10 +47,12 @@ public abstract class TunnelTest {
   }
 
   /**
-   * Enables FINE logging for all components (including HTTP, SSL, SSH). VERY verbose.
+   * Enables FINE logging for all components (including HTTP, SSL, SSH). VERY
+   * verbose.
    */
   private static void enableVerboseLogging() {
-    // SLF4J logging is routed to java.util.logging via the reference to the slf4j-jdk14 package.
+    // SLF4J logging is routed to java.util.logging via the reference to the
+    // slf4j-jdk14 package.
     var rootLogger = java.util.logging.Logger.getLogger("");
     rootLogger.setLevel(java.util.logging.Level.FINE);
 
@@ -53,5 +60,20 @@ public abstract class TunnelTest {
     for (var logHandler : rootLogger.getHandlers()) {
       logHandler.setLevel(java.util.logging.Level.ALL);
     }
+  }
+
+  protected static Tunnel getTestTunnel() {
+    // Set up tunnel
+    Tunnel tunnel = new Tunnel();
+    tunnel.name = testTunnelName;
+
+    // Configure tunnel request options
+    var requestOptions = new TunnelRequestOptions();
+    requestOptions.tokenScopes = Arrays.asList(TunnelAccessScopes.connect);
+    requestOptions.includePorts = true;
+
+    // get tunnel
+    var result = tunnelManagementClient.getTunnelAsync(tunnel, requestOptions).join();
+    return result;
   }
 }


### PR DESCRIPTION
* Respond to `tcpip-forward` request with success if the requested port is already in the forwarded ports collection. 
* Add test for adding and removing ports.