### PR TITLE
Add AdditionalQueryParameters and include ssh gateway public key in UpdateTunnelEndpoint

### DIFF
--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -113,11 +113,19 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
             HostId = this.hostId,
             HostPublicKeys = hostPublicKeys,
         };
+        List<KeyValuePair<string, string>>? additionalQueryParams = null;
+        if (Tunnel.Ports != null && Tunnel.Ports.Any((p) => p.Protocol == TunnelProtocol.Ssh))
+        {
+            additionalQueryParams = new () {new KeyValuePair<string, string>("includeSshGatewayPublicKey", "true")};
+        }
 
         endpoint = (TunnelRelayTunnelEndpoint)await ManagementClient!.UpdateTunnelEndpointAsync(
             Tunnel,
             endpoint,
-            options: null,
+            options: new TunnelRequestOptions()
+            {
+                AdditionalQueryParameters = additionalQueryParams,
+            },
             cancellation);
 
         Requires.Argument(

--- a/cs/src/Management/TunnelRequestOptions.cs
+++ b/cs/src/Management/TunnelRequestOptions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VsSaaS.TunnelService
         public IEnumerable<KeyValuePair<string, string>>? AdditionalHeaders { get; set; }
 
         /// <summary>
-        /// Gets or sets additional headers to be included in the request.
+        /// Gets or sets additional query parameters to be included in the request.
         /// </summary>
         public IEnumerable<KeyValuePair<string, string>>? AdditionalQueryParameters { get; set; }
 

--- a/cs/src/Management/TunnelRequestOptions.cs
+++ b/cs/src/Management/TunnelRequestOptions.cs
@@ -43,6 +43,11 @@ namespace Microsoft.VsSaaS.TunnelService
         public IEnumerable<KeyValuePair<string, string>>? AdditionalHeaders { get; set; }
 
         /// <summary>
+        /// Gets or sets additional headers to be included in the request.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string>>? AdditionalQueryParameters { get; set; }
+
+        /// <summary>
         /// Gets or sets a value that indicates whether HTTP redirect responses will be
         /// automatically followed.
         /// </summary>
@@ -132,6 +137,14 @@ namespace Microsoft.VsSaaS.TunnelService
                 if (RequireAllTags)
                 {
                     queryOptions["allTags"] = TrueOption;
+                }
+            }
+
+            if (AdditionalQueryParameters != null)
+            {
+                foreach (var queryParam in AdditionalQueryParameters)
+                {
+                    queryOptions.Add(queryParam.Key, new string[] {queryParam.Value});
                 }
             }
 

--- a/go/tunnels/request_options.go
+++ b/go/tunnels/request_options.go
@@ -15,6 +15,9 @@ type TunnelRequestOptions struct {
 	// Additional headers to be included in the request.
 	AdditionalHeaders map[string]string
 
+	// Additional qurey parameters to be included in the request.
+	AdditionalQueryParameters map[string]string
+
 	// Indicates whether HTTP redirect responses will be automatically followed.
 	FollowRedirects bool
 
@@ -60,6 +63,12 @@ func (options *TunnelRequestOptions) queryString() string {
 
 		if options.RequireAllTags {
 			queryOptions.Set("allTags", "true")
+		}
+	}
+
+	if options.AdditionalQueryParameters {
+		for paramName, paramValue := range m.AdditionalQueryParameters {
+			queryOptions.Add(paramName, paramValue)
 		}
 	}
 

--- a/go/tunnels/request_options.go
+++ b/go/tunnels/request_options.go
@@ -66,8 +66,8 @@ func (options *TunnelRequestOptions) queryString() string {
 		}
 	}
 
-	if options.AdditionalQueryParameters {
-		for paramName, paramValue := range m.AdditionalQueryParameters {
+	if options.AdditionalQueryParameters != null {
+		for paramName, paramValue := range options.AdditionalQueryParameters {
 			queryOptions.Add(paramName, paramValue)
 		}
 	}

--- a/go/tunnels/request_options.go
+++ b/go/tunnels/request_options.go
@@ -66,7 +66,7 @@ func (options *TunnelRequestOptions) queryString() string {
 		}
 	}
 
-	if options.AdditionalQueryParameters != null {
+	if options.AdditionalQueryParameters != nil {
 		for paramName, paramValue := range options.AdditionalQueryParameters {
 			queryOptions.Add(paramName, paramValue)
 		}

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -211,6 +211,12 @@ public class TunnelManagementClient implements ITunnelManagementClient {
         requestBuilder.header(AUTH_HEADER, authHeaderValue);
       }
 
+      if (options != null && options.additionalHeaders != null) {
+        options.additionalHeaders.forEach(
+          (key, value) -> requestBuilder.header(key, value)
+        );
+      }
+
       Gson gson = TunnelContracts.getGson();
       var requestJson = gson.toJson(requestObject);
       var bodyPublisher = requestMethod == HttpMethod.POST || requestMethod == HttpMethod.PUT

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
@@ -36,6 +36,11 @@ public class TunnelRequestOptions {
   public HashMap<String, String> additionalHeaders;
 
   /**
+   * Gets or sets additional query parameters to be included in the request.
+   */
+  public HashMap<String, String> additionalQueryParameters;
+
+  /**
    * <p>
    * Gets or sets a value that indicates whether HTTP redirect responses will be
    * automatically followed.
@@ -123,6 +128,12 @@ public class TunnelRequestOptions {
       if (this.requireAllTags) {
         queryOptions.put("allTags", Arrays.asList("true"));
       }
+    }
+
+    if (this.additionalQueryParameters != null) {
+      this.additionalQueryParameters.forEach(
+        (key, value) -> queryOptions.put(key, Arrays.asList(value))
+      );
     }
 
     Stream<String> encodedParameters = queryOptions.entrySet().stream().map(o -> {

--- a/ts/src/connections/tunnelRelayTunnelHost.ts
+++ b/ts/src/connections/tunnelRelayTunnelHost.ts
@@ -5,6 +5,7 @@ import {
     Tunnel,
     TunnelAccessScopes,
     TunnelConnectionMode,
+    TunnelProtocol,
     TunnelRelayTunnelEndpoint,
 } from '@vs/tunnels-contracts';
 import { TunnelManagementClient } from '@vs/tunnels-management';
@@ -102,8 +103,14 @@ export class TunnelRelayTunnelHost extends tunnelRelaySessionClass(
             hostPublicKeys: this.hostPublicKeys,
             connectionMode: TunnelConnectionMode.TunnelRelay,
         };
+        let additionalQueryParameters = undefined;
+        if (tunnel.ports != null && tunnel.ports.find((v) => v.protocol == TunnelProtocol.Ssh)) {
+            additionalQueryParameters = {"includeSshGatewayPublicKey": "true"}; 
+        }
 
-        endpoint = await this.managementClient!.updateTunnelEndpoint(tunnel, endpoint);
+        endpoint = await this.managementClient!.updateTunnelEndpoint(tunnel, endpoint, {
+            additionalQueryParameters: additionalQueryParameters,
+        });
         return endpoint.hostRelayUri!;
     }
 

--- a/ts/src/connections/tunnelRelayTunnelHost.ts
+++ b/ts/src/connections/tunnelRelayTunnelHost.ts
@@ -104,8 +104,8 @@ export class TunnelRelayTunnelHost extends tunnelRelaySessionClass(
             connectionMode: TunnelConnectionMode.TunnelRelay,
         };
         let additionalQueryParameters = undefined;
-        if (tunnel.ports != null && tunnel.ports.find((v) => v.protocol == TunnelProtocol.Ssh)) {
-            additionalQueryParameters = {"includeSshGatewayPublicKey": "true"}; 
+        if (tunnel.ports != null && tunnel.ports.find((v) => v.protocol === TunnelProtocol.Ssh)) {
+            additionalQueryParameters = { includeSshGatewayPublicKey: "true" }; 
         }
 
         endpoint = await this.managementClient!.updateTunnelEndpoint(tunnel, endpoint, {

--- a/ts/src/connections/tunnelRelayTunnelHost.ts
+++ b/ts/src/connections/tunnelRelayTunnelHost.ts
@@ -105,7 +105,7 @@ export class TunnelRelayTunnelHost extends tunnelRelaySessionClass(
         };
         let additionalQueryParameters = undefined;
         if (tunnel.ports != null && tunnel.ports.find((v) => v.protocol === TunnelProtocol.Ssh)) {
-            additionalQueryParameters = { includeSshGatewayPublicKey: 'true' }; 
+            additionalQueryParameters = { includeSshGatewayPublicKey: 'true' };
         }
 
         endpoint = await this.managementClient!.updateTunnelEndpoint(tunnel, endpoint, {

--- a/ts/src/connections/tunnelRelayTunnelHost.ts
+++ b/ts/src/connections/tunnelRelayTunnelHost.ts
@@ -105,7 +105,7 @@ export class TunnelRelayTunnelHost extends tunnelRelaySessionClass(
         };
         let additionalQueryParameters = undefined;
         if (tunnel.ports != null && tunnel.ports.find((v) => v.protocol === TunnelProtocol.Ssh)) {
-            additionalQueryParameters = { includeSshGatewayPublicKey: "true" }; 
+            additionalQueryParameters = { includeSshGatewayPublicKey: 'true' }; 
         }
 
         endpoint = await this.managementClient!.updateTunnelEndpoint(tunnel, endpoint, {

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -606,19 +606,13 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             tunnelPath = `${tunnelsApiPath}/${tunnel.name}`;
         }
 
-        let additionalQuery = '';
         if (options?.additionalQueryParameters) {
             for (let [paramName, paramValue] of Object.entries(options.additionalQueryParameters)) {
-                additionalQuery = `${paramName}=${paramValue}`;
-            }
-        }
-
-        if (additionalQuery) {
-            if (query) {
-                query += additionalQuery;
-            } else {
-                additionalQuery = additionalQuery.substring(1);
-                query = additionalQuery;
+                if (query) {
+                    query += `&${paramName}=${paramValue}`;
+                } else {
+                    query = `${paramName}=${paramValue}`;
+                }
             }
         }
 

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -606,13 +606,13 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             tunnelPath = `${tunnelsApiPath}/${tunnel.name}`;
         }
 
-        var additionalQuery = '';
+        let additionalQuery = '';
         if (options?.additionalQueryParameters) {
             for (let [paramName, paramValue] of Object.entries(options.additionalQueryParameters)) {
                 additionalQuery = `${paramName}=${paramValue}`;
             }
         }
-        
+
         if (additionalQuery) {
             if (query) {
                 query += additionalQuery;

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -606,6 +606,22 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             tunnelPath = `${tunnelsApiPath}/${tunnel.name}`;
         }
 
+        var additionalQuery = '';
+        if (options?.additionalQueryParameters) {
+            for (let [paramName, paramValue] of Object.entries(options.additionalQueryParameters)) {
+                additionalQuery = `${paramName}=${paramValue}`;
+            }
+        }
+        
+        if (additionalQuery) {
+            if (query) {
+                query += additionalQuery;
+            } else {
+                additionalQuery = additionalQuery.substring(1);
+                query = additionalQuery;
+            }
+        }
+
         return this.buildUri(tunnel.clusterId, tunnelPath + (path ? path : ''), query, options);
     }
 

--- a/ts/src/management/tunnelRequestOptions.ts
+++ b/ts/src/management/tunnelRequestOptions.ts
@@ -19,6 +19,12 @@ export interface TunnelRequestOptions {
      */
     additionalHeaders?: { [header: string]: string };
 
+
+    /**
+     * Gets or sets additional query parameters to be included in the request.
+     */
+     additionalQueryParameters?: { [name: string]: string };
+
     /**
      * Gets or sets a value that indicates whether HTTP redirect responses will be
      * automatically followed.

--- a/ts/src/management/tunnelRequestOptions.ts
+++ b/ts/src/management/tunnelRequestOptions.ts
@@ -19,11 +19,10 @@ export interface TunnelRequestOptions {
      */
     additionalHeaders?: { [header: string]: string };
 
-
     /**
      * Gets or sets additional query parameters to be included in the request.
      */
-     additionalQueryParameters?: { [name: string]: string };
+    additionalQueryParameters?: { [name: string]: string };
 
     /**
      * Gets or sets a value that indicates whether HTTP redirect responses will be


### PR DESCRIPTION
Add AdditionalQueryParameters for users of SDK to send additional query parameters.
Send additional parameter to include ssh gateway public key when calling UpdateTunnelEndpoint api if there is atleast one ssh port.