### PR TITLE
Add http request rate to tunnel status

### DIFF
--- a/cs/src/Contracts/TunnelStatus.cs
+++ b/cs/src/Contracts/TunnelStatus.cs
@@ -96,7 +96,8 @@ public class TunnelStatus
     public RateStatus? ApiUpdateRate { get; set; }
 
     /// <summary>
-    /// Gets or sets the current value and limit for the rate of http requests to the tunnel.
+    /// Gets or sets the current value and limit for the rate of http requests to the tunnel
+    /// when web forwarding.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RateStatus? HttpRequestRate { get; set; }

--- a/cs/src/Contracts/TunnelStatus.cs
+++ b/cs/src/Contracts/TunnelStatus.cs
@@ -94,4 +94,10 @@ public class TunnelStatus
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RateStatus? ApiUpdateRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current value and limit for the rate of http requests to the tunnel.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public RateStatus? HttpRequestRate { get; set; }
 }

--- a/go/tunnels/tunnel_status.go
+++ b/go/tunnels/tunnel_status.go
@@ -59,4 +59,7 @@ type TunnelStatus struct {
 	// Gets or sets the current value and limit for the rate of management API update
 	// operations for the tunnel or tunnel ports.
 	ApiUpdateRate            *RateStatus `json:"apiUpdateRate,omitempty"`
+
+	// Gets or sets the current value and limit for the rate of http requests to the tunnel.
+	HttpRequestRate          *RateStatus `json:"httpRequestRate,omitempty"`
 }

--- a/go/tunnels/tunnel_status.go
+++ b/go/tunnels/tunnel_status.go
@@ -60,6 +60,7 @@ type TunnelStatus struct {
 	// operations for the tunnel or tunnel ports.
 	ApiUpdateRate            *RateStatus `json:"apiUpdateRate,omitempty"`
 
-	// Gets or sets the current value and limit for the rate of http requests to the tunnel.
+	// Gets or sets the current value and limit for the rate of http requests to the tunnel
+	// when web forwarding.
 	HttpRequestRate          *RateStatus `json:"httpRequestRate,omitempty"`
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelStatus.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelStatus.java
@@ -87,4 +87,11 @@ public class TunnelStatus {
      */
     @Expose
     public RateStatus apiUpdateRate;
+
+    /**
+     * Gets or sets the current value and limit for the rate of http requests to the
+     * tunnel.
+     */
+    @Expose
+    public RateStatus httpRequestRate;
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelStatus.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelStatus.java
@@ -90,7 +90,7 @@ public class TunnelStatus {
 
     /**
      * Gets or sets the current value and limit for the rate of http requests to the
-     * tunnel.
+     * tunnel when web forwarding.
      */
     @Expose
     public RateStatus httpRequestRate;

--- a/rs/src/contracts/tunnel_status.rs
+++ b/rs/src/contracts/tunnel_status.rs
@@ -59,4 +59,8 @@ pub struct TunnelStatus {
     // Gets or sets the current value and limit for the rate of management API update
     // operations for the tunnel or tunnel ports.
     pub api_update_rate: Option<RateStatus>,
+
+    // Gets or sets the current value and limit for the rate of http requests to the
+    // tunnel.
+    pub http_request_rate: Option<RateStatus>,
 }

--- a/rs/src/contracts/tunnel_status.rs
+++ b/rs/src/contracts/tunnel_status.rs
@@ -61,6 +61,6 @@ pub struct TunnelStatus {
     pub api_update_rate: Option<RateStatus>,
 
     // Gets or sets the current value and limit for the rate of http requests to the
-    // tunnel.
+    // tunnel when web forwarding.
     pub http_request_rate: Option<RateStatus>,
 }

--- a/ts/src/contracts/tunnelStatus.ts
+++ b/ts/src/contracts/tunnelStatus.ts
@@ -77,4 +77,10 @@ export interface TunnelStatus {
      * operations for the tunnel or tunnel ports.
      */
     apiUpdateRate?: RateStatus;
+
+    /**
+     * Gets or sets the current value and limit for the rate of http requests to the
+     * tunnel.
+     */
+    httpRequestRate?: RateStatus;
 }

--- a/ts/src/contracts/tunnelStatus.ts
+++ b/ts/src/contracts/tunnelStatus.ts
@@ -80,7 +80,7 @@ export interface TunnelStatus {
 
     /**
      * Gets or sets the current value and limit for the rate of http requests to the
-     * tunnel.
+     * tunnel when web forwarding.
      */
     httpRequestRate?: RateStatus;
 }


### PR DESCRIPTION
This adds the http request rate to the tunnel status. This will be used to http request rate limiting in the service