### PR TITLE
Update rate status contract reset time

### DIFF
--- a/cs/src/Contracts/RateStatus.cs
+++ b/cs/src/Contracts/RateStatus.cs
@@ -26,5 +26,5 @@ public class RateStatus : ResourceStatus
     /// Gets or sets the unix time when this status will be reset.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public uint? ResetTime { get; set; }
+    public long? ResetTime { get; set; }
 }

--- a/cs/src/Contracts/RateStatus.cs
+++ b/cs/src/Contracts/RateStatus.cs
@@ -23,9 +23,8 @@ public class RateStatus : ResourceStatus
     public uint? PeriodSeconds { get; set; }
 
     /// <summary>
-    /// Gets or sets the number of seconds until the current measurement period ends and the
-    /// current rate value resets.
+    /// Gets or sets the unix time when this status will be reset.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public uint? ResetSeconds { get; set; }
+    public uint? ResetTime { get; set; }
 }

--- a/go/tunnels/resource_status.go
+++ b/go/tunnels/resource_status.go
@@ -29,5 +29,5 @@ type RateStatus struct {
 	PeriodSeconds uint32 `json:"periodSeconds,omitempty"`
 
 	// Gets or sets the unix time when this status will be reset.
-	ResetTime     uint32 `json:"resetTime,omitempty"`
+	ResetTime     int64 `json:"resetTime,omitempty"`
 }

--- a/go/tunnels/resource_status.go
+++ b/go/tunnels/resource_status.go
@@ -28,7 +28,6 @@ type RateStatus struct {
 	// estimate, since the actual duration may vary by the calendar.
 	PeriodSeconds uint32 `json:"periodSeconds,omitempty"`
 
-	// Gets or sets the number of seconds until the current measurement period ends and the
-	// current rate value resets.
-	ResetSeconds  uint32 `json:"resetSeconds,omitempty"`
+	// Gets or sets the unix time when this status will be reset.
+	ResetTime     uint32 `json:"resetTime,omitempty"`
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/RateStatus.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/RateStatus.java
@@ -22,9 +22,8 @@ public class RateStatus extends ResourceStatus {
     public int periodSeconds;
 
     /**
-     * Gets or sets the number of seconds until the current measurement period ends and
-     * the current rate value resets.
+     * Gets or sets the unix time when this status will be reset.
      */
     @Expose
-    public int resetSeconds;
+    public int resetTime;
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/RateStatus.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/RateStatus.java
@@ -25,5 +25,5 @@ public class RateStatus extends ResourceStatus {
      * Gets or sets the unix time when this status will be reset.
      */
     @Expose
-    public int resetTime;
+    public long resetTime;
 }

--- a/rs/src/contracts/rate_status.rs
+++ b/rs/src/contracts/rate_status.rs
@@ -20,7 +20,6 @@ pub struct RateStatus {
     // an estimate, since the actual duration may vary by the calendar.
     pub period_seconds: Option<u32>,
 
-    // Gets or sets the number of seconds until the current measurement period ends and
-    // the current rate value resets.
-    pub reset_seconds: Option<u32>,
+    // Gets or sets the unix time when this status will be reset.
+    pub reset_time: Option<u32>,
 }

--- a/rs/src/contracts/rate_status.rs
+++ b/rs/src/contracts/rate_status.rs
@@ -21,5 +21,5 @@ pub struct RateStatus {
     pub period_seconds: Option<u32>,
 
     // Gets or sets the unix time when this status will be reset.
-    pub reset_time: Option<u32>,
+    pub reset_time: Option<i64>,
 }

--- a/ts/src/contracts/rateStatus.ts
+++ b/ts/src/contracts/rateStatus.ts
@@ -20,8 +20,7 @@ export interface RateStatus extends ResourceStatus {
     periodSeconds?: number;
 
     /**
-     * Gets or sets the number of seconds until the current measurement period ends and
-     * the current rate value resets.
+     * Gets or sets the unix time when this status will be reset.
      */
-    resetSeconds?: number;
+    resetTime?: number;
 }


### PR DESCRIPTION
This changes the resetSeconds field to resetTime. This should allow for more efficient tracking of when the current value should be reset to 0 as we can just check this value against the current time. This should not change anything as the ResetSeconds field appears to not be used anywhere in the service outside the mapper. This will allow the relay pods to reset status on their own 