### PR TITLE
(TS) don't check remote forwarders on forwarded-tcpip request

### DIFF
--- a/ts/test/tunnels-test/tunnelHostAndClientTests.ts
+++ b/ts/test/tunnels-test/tunnelHostAndClientTests.ts
@@ -534,7 +534,7 @@ export class TunnelHostAndClientTests {
     }
 
     @test
-    public async connectRelayHostThenConnectRelayClientToForwardedPortStream() {
+    public async ConnectRelayHostThenConnectRelayClientToDifferentPort_Fails() {
         let managementClient = new MockTunnelManagementClient();
         managementClient.hostRelayUri = this.mockHostRelayUri;
         let relayHost = new TunnelRelayTunnelHost(managementClient);

--- a/ts/test/tunnels-test/tunnelHostAndClientTests.ts
+++ b/ts/test/tunnels-test/tunnelHostAndClientTests.ts
@@ -534,6 +534,36 @@ export class TunnelHostAndClientTests {
     }
 
     @test
+    public async connectRelayHostThenConnectRelayClientToForwardedPortStream() {
+        let managementClient = new MockTunnelManagementClient();
+        managementClient.hostRelayUri = this.mockHostRelayUri;
+        let relayHost = new TunnelRelayTunnelHost(managementClient);
+
+        let testPort = 9886;
+        let differentPort = 9887;
+
+        let tunnel = this.createRelayTunnel([testPort]);
+        await managementClient.createTunnel(tunnel);
+        let multiChannelStream = await this.startRelayHost(relayHost, tunnel);
+        let clientRelayStream = await multiChannelStream.openStream(
+            TunnelRelayTunnelHost.clientStreamChannelType,
+        );
+
+        let clientSshSession = this.createSshClientSession();
+        let pfs = clientSshSession.activateService(PortForwardingService);
+        await clientSshSession.connect(new NodeStream(clientRelayStream));
+
+        let clientCredentials: SshClientCredentials = { username: 'tunnel', password: undefined };
+        await clientSshSession.authenticate(clientCredentials);
+        
+        await pfs.waitForForwardedPort(testPort);
+        await assert.rejects(pfs.connectToForwardedPort(differentPort));
+
+        clientSshSession.dispose();
+        multiChannelStream.dispose();
+    }
+
+    @test
     public async connectRelayHostAddPort() {
         let managementClient = new MockTunnelManagementClient();
         managementClient.hostRelayUri = this.mockHostRelayUri;


### PR DESCRIPTION
The service E2E tests are currently running on an older version of the TS SDK (`1.0.7280`, and latest is `1.0.7298`), and updating the package fails the tests. Changes in the newer packages are causing us to check the hosts `remoteForwarders` for a local port instead of a remote port on `forwarded-tcpip` requests here:
https://github.com/microsoft/dev-tunnels/blob/c02ac44d6262a2775420904a5690d60ae8cfc6b9/ts/src/connections/tunnelHostBase.ts#L120

Updating the TypeScript SDK with the corresponding C# change from this PR fixes the E2E tests:
https://github.com/microsoft/dev-tunnels/pull/116

Also added a TS version of one of the tests from the other PR, though I don't think it actually tests the behavior in question.

