### PR TITLE
Fix port tags and description updates

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -1166,6 +1166,8 @@ namespace Microsoft.DevTunnels.Management
             {
                 PortNumber = tunnelPort.PortNumber,
                 Protocol = tunnelPort.Protocol,
+                Description = tunnelPort.Description,
+                Tags = tunnelPort.Tags,
                 Options = tunnelPort.Options,
                 AccessControl = tunnelPort.AccessControl == null ? null : new TunnelAccessControl(
                     tunnelPort.AccessControl.Where((ace) => !ace.IsInherited)),

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -127,9 +127,12 @@ func (tunnelPort *TunnelPort) requestObject(tunnel *Tunnel) (*TunnelPort, error)
 		return nil, fmt.Errorf("tunnel port tunnel ID does not match tunnel")
 	}
 	convertedPort := &TunnelPort{
-		PortNumber: tunnelPort.PortNumber,
-		Protocol:   tunnelPort.Protocol,
-		Options:    tunnelPort.Options,
+		PortNumber:  tunnelPort.PortNumber,
+		Protocol:    tunnelPort.Protocol,
+		Description: tunnelPort.Description,
+		Tags:        tunnelPort.Tags,
+		SshUser:     tunnelPort.SshUser,
+		Options:     tunnelPort.Options,
 	}
 	if tunnelPort.AccessControl != nil {
 		var newEntries []TunnelAccessControlEntry

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -607,6 +607,9 @@ public class TunnelManagementClient implements ITunnelManagementClient {
     var converted = new TunnelPort();
     converted.portNumber = tunnelPort.portNumber;
     converted.protocol = tunnelPort.protocol;
+    converted.description = tunnelPort.description;
+    converted.tags = tunnelPort.tags;
+    converted.sshUser = tunnelPort.sshUser;
     converted.options = tunnelPort.options;
     if (tunnelPort.accessControl != null && tunnelPort.accessControl.entries != null) {
       List<TunnelAccessControlEntry> entries = Arrays.asList(tunnel.accessControl.entries);

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -709,6 +709,9 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         return {
             portNumber: tunnelPort.portNumber,
             protocol: tunnelPort.protocol,
+            description: tunnelPort.description,
+            tags: tunnelPort.tags,
+            sshUser: tunnelPort.sshUser,
             options: tunnelPort.options,
             accessControl: !tunnelPort.accessControl
                 ? undefined


### PR DESCRIPTION
Port description and tags were not getting updated due to some missing assignments in the management client.