### PR TITLE
Add TunnelRequestOptions.HttpRequestOptions for C# SDK

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -447,6 +447,8 @@ namespace Microsoft.DevTunnels.Management
                 FollowRedirectsHttpHandler.SetFollowRedirectsEnabledForRequest(request, false);
             }
 
+            options?.SetRequestOptions(request);
+
             var response = await this.httpClient.SendAsync(request, cancellation);
             var result = await ConvertResponseAsync<TResult>(
                 method,

--- a/cs/test/TunnelsSDK.Test/TunnelManagementClientTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelManagementClientTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.DevTunnels.Contracts;
+using Microsoft.DevTunnels.Management;
+using Xunit;
+
+namespace Microsoft.DevTunnels.Test;
+public class TunnelManagementClientTests
+{
+    private const string TunnelId = "tnnl0001";
+    private const string ClusterId = "usw2";
+
+    private readonly CancellationToken timeout = System.Diagnostics.Debugger.IsAttached ? default : new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token;
+    private readonly ProductInfoHeaderValue userAgent = TunnelUserAgent.GetUserAgent(typeof(TunnelManagementClientTests).Assembly);
+    private readonly Uri tunnelServiceUri = new Uri("https://localhost:3000/");
+    private readonly Tunnel tunnel = new Tunnel
+    {
+        TunnelId = TunnelId,
+        ClusterId = ClusterId,
+    };
+
+    [Fact]
+    public async Task TunnelRequestOptions_SetRequestOption()
+    {
+        var options = new TunnelRequestOptions()
+        {
+            HttpRequestOptions = new Dictionary<string, object>
+            {
+                { "foo", "bar" },
+                { "bazz", 100 },
+            }
+        };
+
+        var handler = new MockHttpMessageHandler(
+            (message, ct) => 
+            {
+                Assert.True(message.Options.TryGetValue(new HttpRequestOptionsKey<string>("foo"), out string strValue) && strValue == "bar");
+                Assert.True(message.Options.TryGetValue(new HttpRequestOptionsKey<int>("bazz"), out int intValue) && intValue == 100);
+                return GetTunnelResponseAsync();
+            });
+
+        var client = new TunnelManagementClient(this.userAgent, null, this.tunnelServiceUri, handler);
+        var tunnel = await client.GetTunnelAsync(this.tunnel, options, this.timeout);
+        Assert.NotNull(tunnel);
+        Assert.Equal(TunnelId, tunnel.TunnelId);
+        Assert.Equal(ClusterId, tunnel.ClusterId);
+    }
+
+    private Task<HttpResponseMessage> GetTunnelResponseAsync()
+    {
+        var result = new HttpResponseMessage(HttpStatusCode.OK);
+        result.Content = JsonContent.Create(this.tunnel);
+        return Task.FromResult(result);
+    }
+
+    private sealed class MockHttpMessageHandler : DelegatingHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
+
+        public MockHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) 
+            : base(new HttpClientHandler
+            {
+                AllowAutoRedirect = false,
+                UseDefaultCredentials = false,
+            })
+        {
+            this.handler = Requires.NotNull(handler, nameof(handler));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            this.handler(request, cancellationToken);
+    }
+}
+


### PR DESCRIPTION
The use case is to pass custom options to a DelegatingHttpHandler that TunnelManagementClient may be using.