### PR TITLE
Add header to skip antiphishing page 

### DIFF
--- a/cs/src/Contracts/TunnelHeaderNames.cs
+++ b/cs/src/Contracts/TunnelHeaderNames.cs
@@ -27,4 +27,9 @@ public static class TunnelHeaderNames
     /// Github Ssh public key which can be used to validate if it belongs to tunnel's owner.
     /// </summary>
     public const string XGithubSshKey = "X-Github-Ssh-Key";
+
+    /// <summary>
+    /// Header that will skip the antiphishing page when connection to a tunnel through web forwarding.
+    /// </summary>
+    public const string XTunnelSkipPhishing = "X-Tunnel-Skip-Phishing-Page";
 }

--- a/go/tunnels/tunnel_header_names.go
+++ b/go/tunnels/tunnel_header_names.go
@@ -21,4 +21,8 @@ const (
 
 	// Github Ssh public key which can be used to validate if it belongs to tunnel's owner.
 	TunnelHeaderNameXGithubSshKey        TunnelHeaderName = "X-Github-Ssh-Key"
+
+	// Header that will skip the antiphishing page when connection to a tunnel through web
+	// forwarding.
+	TunnelHeaderNameXTunnelSkipPhishing  TunnelHeaderName = "X-Tunnel-Skip-Phishing-Page"
 )

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelHeaderNames.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelHeaderNames.java
@@ -27,4 +27,10 @@ public class TunnelHeaderNames {
      * owner.
      */
     public static final String xGithubSshKey = "X-Github-Ssh-Key";
+
+    /**
+     * Header that will skip the antiphishing page when connection to a tunnel through web
+     * forwarding.
+     */
+    public static final String xTunnelSkipPhishing = "X-Tunnel-Skip-Phishing-Page";
 }

--- a/rs/src/contracts/tunnel_header_names.rs
+++ b/rs/src/contracts/tunnel_header_names.rs
@@ -15,3 +15,7 @@ pub const TUNNEL_HEADER_NAMES_X_REQUEST_ID: &str = "X-Request-ID";
 
 // Github Ssh public key which can be used to validate if it belongs to tunnel's owner.
 pub const TUNNEL_HEADER_NAMES_X_GITHUB_SSH_KEY: &str = "X-Github-Ssh-Key";
+
+// Header that will skip the antiphishing page when connection to a tunnel through web
+// forwarding.
+pub const TUNNEL_HEADER_NAMES_X_TUNNEL_SKIP_PHISHING: &str = "X-Tunnel-Skip-Phishing-Page";

--- a/ts/src/contracts/tunnelHeaderNames.ts
+++ b/ts/src/contracts/tunnelHeaderNames.ts
@@ -26,4 +26,10 @@ export enum TunnelHeaderNames {
      * owner.
      */
     XGithubSshKey = 'X-Github-Ssh-Key',
+
+    /**
+     * Header that will skip the antiphishing page when connection to a tunnel through web
+     * forwarding.
+     */
+    XTunnelSkipPhishing = 'X-Tunnel-Skip-Phishing-Page',
 }


### PR DESCRIPTION
This adds a header that can be sent with requests that will cause the service to return the skipPhishing cookie and skip the antiphishing page during webforwarding