### PR TITLE
Add HostHeader tunnel option

### DIFF
--- a/cs/src/Contracts/TunnelOptions.cs
+++ b/cs/src/Contracts/TunnelOptions.cs
@@ -27,11 +27,41 @@ namespace Microsoft.DevTunnels.Contracts
 
         /// <summary>
         /// Gets or sets a value for `Host` header rewriting to use in web-forwarding of this tunnel or port.
-        /// By default, with this property null or empty, web-forwarding uses "localhost" to rewrite the `Host` header.
-        /// Web-fowarding will use this property instead if it is not null or empty, .
+        /// By default, with this property null or empty, web-forwarding uses "localhost" to rewrite the header.
+        /// Web-fowarding will use this property instead if it is not null or empty.
         /// Port-level option, if set, takes precedence over this option on the tunnel level.
+        /// The option is ignored if IsHostHeaderUnchanged is true.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? HostHeader { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether `Host` header is rewritten or the header value stays intact.
+        /// By default, if false, web-forwarding rewrites the host header with the value from HostHeader property or "localhost".
+        /// If true, the host header will be whatever the tunnel's web-forwarding host is, e.g. tunnel-name-8080.devtunnels.ms.
+        /// Port-level option, if set, takes precedence over this option on the tunnel level.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool IsHostHeaderUnchanged { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value for `Origin` header rewriting to use in web-forwarding of this tunnel or port.
+        /// By default, with this property null or empty, web-forwarding uses "http(s)://localhost" to rewrite the header.
+        /// Web-fowarding will use this property instead if it is not null or empty.
+        /// Port-level option, if set, takes precedence over this option on the tunnel level.
+        /// The option is ignored if IsOriginHeaderUnchanged is true.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? OriginHeader { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether `Origin` header is rewritten or the header value stays intact.
+        /// By default, if false, web-forwarding rewrites the origin header with the value from OriginHeader property or 
+        /// "http(s)://localhost".
+        /// If true, the Origin header will be whatever the tunnel's web-forwarding Origin is, e.g. https://tunnel-name-8080.devtunnels.ms.
+        /// Port-level option, if set, takes precedence over this option on the tunnel level.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool IsOriginHeaderUnchanged { get; set; }        
     }
 }

--- a/cs/src/Contracts/TunnelOptions.cs
+++ b/cs/src/Contracts/TunnelOptions.cs
@@ -24,5 +24,14 @@ namespace Microsoft.DevTunnels.Contracts
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool IsGloballyAvailable { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value for `Host` header rewriting to use in web-forwarding of this tunnel or port.
+        /// By default, with this property null or empty, web-forwarding uses "localhost" to rewrite the `Host` header.
+        /// Web-fowarding will use this property instead if it is not null or empty, .
+        /// Port-level option, if set, takes precedence over this option on the tunnel level.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? HostHeader { get; set; }
     }
 }

--- a/go/tunnels/tunnel_options.go
+++ b/go/tunnels/tunnel_options.go
@@ -9,12 +9,35 @@ type TunnelOptions struct {
 	// Gets or sets a value indicating whether web-forwarding of this tunnel can run on any
 	// cluster (region) without redirecting to the home cluster. This is only applicable if
 	// the tunnel has a name and web-forwarding uses it.
-	IsGloballyAvailable bool `json:"isGloballyAvailable,omitempty"`
+	IsGloballyAvailable     bool `json:"isGloballyAvailable,omitempty"`
 
 	// Gets or sets a value for `Host` header rewriting to use in web-forwarding of this
 	// tunnel or port. By default, with this property null or empty, web-forwarding uses
-	// "localhost" to rewrite the `Host` header. Web-fowarding will use this property instead
-	// if it is not null or empty, . Port-level option, if set, takes precedence over this
-	// option on the tunnel level.
-	HostHeader          string `json:"hostHeader,omitempty"`
+	// "localhost" to rewrite the header. Web-fowarding will use this property instead if it
+	// is not null or empty. Port-level option, if set, takes precedence over this option on
+	// the tunnel level. The option is ignored if IsHostHeaderUnchanged is true.
+	HostHeader              string `json:"hostHeader,omitempty"`
+
+	// Gets or sets a value indicating whether `Host` header is rewritten or the header value
+	// stays intact. By default, if false, web-forwarding rewrites the host header with the
+	// value from HostHeader property or "localhost". If true, the host header will be
+	// whatever the tunnel's web-forwarding host is, e.g. tunnel-name-8080.devtunnels.ms.
+	// Port-level option, if set, takes precedence over this option on the tunnel level.
+	IsHostHeaderUnchanged   bool `json:"isHostHeaderUnchanged,omitempty"`
+
+	// Gets or sets a value for `Origin` header rewriting to use in web-forwarding of this
+	// tunnel or port. By default, with this property null or empty, web-forwarding uses
+	// "http(s)://localhost" to rewrite the header. Web-fowarding will use this property
+	// instead if it is not null or empty. Port-level option, if set, takes precedence over
+	// this option on the tunnel level. The option is ignored if IsOriginHeaderUnchanged is
+	// true.
+	OriginHeader            string `json:"originHeader,omitempty"`
+
+	// Gets or sets a value indicating whether `Origin` header is rewritten or the header
+	// value stays intact. By default, if false, web-forwarding rewrites the origin header
+	// with the value from OriginHeader property or  "http(s)://localhost". If true, the
+	// Origin header will be whatever the tunnel's web-forwarding Origin is, e.g.
+	// https://tunnel-name-8080.devtunnels.ms. Port-level option, if set, takes precedence
+	// over this option on the tunnel level.
+	IsOriginHeaderUnchanged bool `json:"isOriginHeaderUnchanged,omitempty"`
 }

--- a/go/tunnels/tunnel_options.go
+++ b/go/tunnels/tunnel_options.go
@@ -10,4 +10,11 @@ type TunnelOptions struct {
 	// cluster (region) without redirecting to the home cluster. This is only applicable if
 	// the tunnel has a name and web-forwarding uses it.
 	IsGloballyAvailable bool `json:"isGloballyAvailable,omitempty"`
+
+	// Gets or sets a value for `Host` header rewriting to use in web-forwarding of this
+	// tunnel or port. By default, with this property null or empty, web-forwarding uses
+	// "localhost" to rewrite the `Host` header. Web-fowarding will use this property instead
+	// if it is not null or empty, . Port-level option, if set, takes precedence over this
+	// option on the tunnel level.
+	HostHeader          string `json:"hostHeader,omitempty"`
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelOptions.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelOptions.java
@@ -21,10 +21,43 @@ public class TunnelOptions {
     /**
      * Gets or sets a value for `Host` header rewriting to use in web-forwarding of this
      * tunnel or port. By default, with this property null or empty, web-forwarding uses
-     * "localhost" to rewrite the `Host` header. Web-fowarding will use this property
-     * instead if it is not null or empty, . Port-level option, if set, takes precedence
-     * over this option on the tunnel level.
+     * "localhost" to rewrite the header. Web-fowarding will use this property instead if
+     * it is not null or empty. Port-level option, if set, takes precedence over this
+     * option on the tunnel level. The option is ignored if IsHostHeaderUnchanged is true.
      */
     @Expose
     public String hostHeader;
+
+    /**
+     * Gets or sets a value indicating whether `Host` header is rewritten or the header
+     * value stays intact. By default, if false, web-forwarding rewrites the host header
+     * with the value from HostHeader property or "localhost". If true, the host header
+     * will be whatever the tunnel's web-forwarding host is, e.g.
+     * tunnel-name-8080.devtunnels.ms. Port-level option, if set, takes precedence over
+     * this option on the tunnel level.
+     */
+    @Expose
+    public boolean isHostHeaderUnchanged;
+
+    /**
+     * Gets or sets a value for `Origin` header rewriting to use in web-forwarding of this
+     * tunnel or port. By default, with this property null or empty, web-forwarding uses
+     * "http(s)://localhost" to rewrite the header. Web-fowarding will use this property
+     * instead if it is not null or empty. Port-level option, if set, takes precedence
+     * over this option on the tunnel level. The option is ignored if
+     * IsOriginHeaderUnchanged is true.
+     */
+    @Expose
+    public String originHeader;
+
+    /**
+     * Gets or sets a value indicating whether `Origin` header is rewritten or the header
+     * value stays intact. By default, if false, web-forwarding rewrites the origin header
+     * with the value from OriginHeader property or  "http(s)://localhost". If true, the
+     * Origin header will be whatever the tunnel's web-forwarding Origin is, e.g.
+     * https://tunnel-name-8080.devtunnels.ms. Port-level option, if set, takes precedence
+     * over this option on the tunnel level.
+     */
+    @Expose
+    public boolean isOriginHeaderUnchanged;
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelOptions.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelOptions.java
@@ -17,4 +17,14 @@ public class TunnelOptions {
      */
     @Expose
     public boolean isGloballyAvailable;
+
+    /**
+     * Gets or sets a value for `Host` header rewriting to use in web-forwarding of this
+     * tunnel or port. By default, with this property null or empty, web-forwarding uses
+     * "localhost" to rewrite the `Host` header. Web-fowarding will use this property
+     * instead if it is not null or empty, . Port-level option, if set, takes precedence
+     * over this option on the tunnel level.
+     */
+    @Expose
+    public String hostHeader;
 }

--- a/rs/src/contracts/tunnel_options.rs
+++ b/rs/src/contracts/tunnel_options.rs
@@ -13,4 +13,12 @@ pub struct TunnelOptions {
     // applicable if the tunnel has a name and web-forwarding uses it.
     #[serde(default)]
     pub is_globally_available: bool,
+
+    // Gets or sets a value for `Host` header rewriting to use in web-forwarding of this
+    // tunnel or port. By default, with this property null or empty, web-forwarding uses
+    // "localhost" to rewrite the `Host` header. Web-fowarding will use this property
+    // instead if it is not null or empty, . Port-level option, if set, takes precedence
+    // over this option on the tunnel level.
+    #[serde(default)]
+    pub host_header: Option<String>,
 }

--- a/rs/src/contracts/tunnel_options.rs
+++ b/rs/src/contracts/tunnel_options.rs
@@ -16,9 +16,36 @@ pub struct TunnelOptions {
 
     // Gets or sets a value for `Host` header rewriting to use in web-forwarding of this
     // tunnel or port. By default, with this property null or empty, web-forwarding uses
-    // "localhost" to rewrite the `Host` header. Web-fowarding will use this property
-    // instead if it is not null or empty, . Port-level option, if set, takes precedence
-    // over this option on the tunnel level.
+    // "localhost" to rewrite the header. Web-fowarding will use this property instead if
+    // it is not null or empty. Port-level option, if set, takes precedence over this
+    // option on the tunnel level. The option is ignored if IsHostHeaderUnchanged is true.
     #[serde(default)]
     pub host_header: Option<String>,
+
+    // Gets or sets a value indicating whether `Host` header is rewritten or the header
+    // value stays intact. By default, if false, web-forwarding rewrites the host header
+    // with the value from HostHeader property or "localhost". If true, the host header
+    // will be whatever the tunnel's web-forwarding host is, e.g.
+    // tunnel-name-8080.devtunnels.ms. Port-level option, if set, takes precedence over
+    // this option on the tunnel level.
+    #[serde(default)]
+    pub is_host_header_unchanged: bool,
+
+    // Gets or sets a value for `Origin` header rewriting to use in web-forwarding of this
+    // tunnel or port. By default, with this property null or empty, web-forwarding uses
+    // "http(s)://localhost" to rewrite the header. Web-fowarding will use this property
+    // instead if it is not null or empty. Port-level option, if set, takes precedence
+    // over this option on the tunnel level. The option is ignored if
+    // IsOriginHeaderUnchanged is true.
+    #[serde(default)]
+    pub origin_header: Option<String>,
+
+    // Gets or sets a value indicating whether `Origin` header is rewritten or the header
+    // value stays intact. By default, if false, web-forwarding rewrites the origin header
+    // with the value from OriginHeader property or  "http(s)://localhost". If true, the
+    // Origin header will be whatever the tunnel's web-forwarding Origin is, e.g.
+    // https://tunnel-name-8080.devtunnels.ms. Port-level option, if set, takes precedence
+    // over this option on the tunnel level.
+    #[serde(default)]
+    pub is_origin_header_unchanged: bool,
 }

--- a/ts/src/contracts/tunnelOptions.ts
+++ b/ts/src/contracts/tunnelOptions.ts
@@ -17,9 +17,39 @@ export interface TunnelOptions {
     /**
      * Gets or sets a value for `Host` header rewriting to use in web-forwarding of this
      * tunnel or port. By default, with this property null or empty, web-forwarding uses
-     * "localhost" to rewrite the `Host` header. Web-fowarding will use this property
-     * instead if it is not null or empty, . Port-level option, if set, takes precedence
-     * over this option on the tunnel level.
+     * "localhost" to rewrite the header. Web-fowarding will use this property instead if
+     * it is not null or empty. Port-level option, if set, takes precedence over this
+     * option on the tunnel level. The option is ignored if IsHostHeaderUnchanged is true.
      */
     hostHeader?: string;
+
+    /**
+     * Gets or sets a value indicating whether `Host` header is rewritten or the header
+     * value stays intact. By default, if false, web-forwarding rewrites the host header
+     * with the value from HostHeader property or "localhost". If true, the host header
+     * will be whatever the tunnel's web-forwarding host is, e.g.
+     * tunnel-name-8080.devtunnels.ms. Port-level option, if set, takes precedence over
+     * this option on the tunnel level.
+     */
+    isHostHeaderUnchanged?: boolean;
+
+    /**
+     * Gets or sets a value for `Origin` header rewriting to use in web-forwarding of this
+     * tunnel or port. By default, with this property null or empty, web-forwarding uses
+     * "http(s)://localhost" to rewrite the header. Web-fowarding will use this property
+     * instead if it is not null or empty. Port-level option, if set, takes precedence
+     * over this option on the tunnel level. The option is ignored if
+     * IsOriginHeaderUnchanged is true.
+     */
+    originHeader?: string;
+
+    /**
+     * Gets or sets a value indicating whether `Origin` header is rewritten or the header
+     * value stays intact. By default, if false, web-forwarding rewrites the origin header
+     * with the value from OriginHeader property or  "http(s)://localhost". If true, the
+     * Origin header will be whatever the tunnel's web-forwarding Origin is, e.g.
+     * https://tunnel-name-8080.devtunnels.ms. Port-level option, if set, takes precedence
+     * over this option on the tunnel level.
+     */
+    isOriginHeaderUnchanged?: boolean;
 }

--- a/ts/src/contracts/tunnelOptions.ts
+++ b/ts/src/contracts/tunnelOptions.ts
@@ -13,4 +13,13 @@ export interface TunnelOptions {
      * applicable if the tunnel has a name and web-forwarding uses it.
      */
     isGloballyAvailable?: boolean;
+
+    /**
+     * Gets or sets a value for `Host` header rewriting to use in web-forwarding of this
+     * tunnel or port. By default, with this property null or empty, web-forwarding uses
+     * "localhost" to rewrite the `Host` header. Web-fowarding will use this property
+     * instead if it is not null or empty, . Port-level option, if set, takes precedence
+     * over this option on the tunnel level.
+     */
+    hostHeader?: string;
 }


### PR DESCRIPTION
To let tunnels change the `Host` request header in web-forwarding, we need to pass this header to the service.