### PR TITLE
Enable CodeQL in CI build

### DIFF
--- a/.pipelines/cs-ci-build.yaml
+++ b/.pipelines/cs-ci-build.yaml
@@ -16,6 +16,7 @@ variables:
   TeamName: "Visual Studio"
   enableSigning: true
   signType: real
+  Codeql.Enabled: true
 
 steps:
 

--- a/.pipelines/typescript-build-and-publish.yaml
+++ b/.pipelines/typescript-build-and-publish.yaml
@@ -12,6 +12,9 @@ trigger:
 
 pr: none
 
+variables:
+  Codeql.Enabled: true
+
 steps:
 - template: typescript-build-steps.yaml
 


### PR DESCRIPTION
Enable CodeQL in CI builds

See https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#enabling-codeql-3000 for details.