### PR TITLE
Report more bandwidth details in tunnel status

### DIFF
--- a/cs/src/Contracts/RateStatus.cs
+++ b/cs/src/Contracts/RateStatus.cs
@@ -27,4 +27,47 @@ public class RateStatus : ResourceStatus
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? ResetTime { get; set; }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        var count = base.ToString();
+        if (PeriodSeconds == null)
+        {
+            return count;
+        }
+
+        if (PeriodSeconds.Value == 1)
+        {
+            return count + "/s";
+        }
+        else if (PeriodSeconds.Value == 60)
+        {
+            return count + "/m";
+        }
+        else if (PeriodSeconds.Value == 3600)
+        {
+            return count + "/h";
+        }
+        else if (PeriodSeconds.Value == (24*3600))
+        {
+            return count + "/d";
+        }
+        else if ((PeriodSeconds.Value % (24*3600)) == 0)
+        {
+            return $"{count}/{(PeriodSeconds.Value / (24*3600))}d";
+        }
+        else if (PeriodSeconds.Value % 3600 == 0)
+        {
+            return $"{count}/{PeriodSeconds.Value / 3600}h";
+        }
+        else if (PeriodSeconds.Value % 60 == 0)
+        {
+            return $"{count}/{PeriodSeconds.Value / 60}m";
+        }
+        else
+        {
+            return $"{count}/{PeriodSeconds.Value}s";
+        }
+    }
 }

--- a/cs/src/Contracts/ResourceStatus.cs
+++ b/cs/src/Contracts/ResourceStatus.cs
@@ -44,6 +44,12 @@ public class ResourceStatus
     /// <param name="status"></param>
     public static implicit operator ulong(ResourceStatus status) => status.Current;
 
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return Current.ToString();
+    }
+
     /// <summary>
     /// JSON converter that allows for compatibility with a simple number value
     /// when the resource status does not include a limit.

--- a/cs/src/Contracts/TunnelStatus.cs
+++ b/cs/src/Contracts/TunnelStatus.cs
@@ -71,15 +71,56 @@ public class TunnelStatus
     public RateStatus? ClientConnectionRate { get; set; }
 
     /// <summary>
-    /// Gets or sets the current value and limit for the rate of bytes transferred
-    /// via the tunnel.
+    /// Gets or sets the current value and limit for the rate of bytes being received by the tunnel
+    /// host and uploaded by tunnel clients.
     /// </summary>
     /// <remarks>
-    /// This includes both sending and receiving. All types of tunnel and port connections
-    /// contribute to this rate.
+    /// All types of tunnel and port connections, from potentially multiple clients, can
+    /// contribute to this rate. The reported rate may differ slightly from the rate measurable
+    /// by applications, due to protocol overhead. Data rate status reporting is delayed by a few
+    /// seconds, so this value is a snapshot of the data transfer rate from a few seconds earlier.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public RateStatus? DataTransferRate { get; set; }
+    public RateStatus? UploadRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current value and limit for the rate of bytes being sent by the tunnel
+    /// host and downloaded by tunnel clients.
+    /// </summary>
+    /// <remarks>
+    /// All types of tunnel and port connections, from potentially multiple clients, can
+    /// contribute to this rate. The reported rate may differ slightly from the rate measurable
+    /// by applications, due to protocol overhead. Data rate status reporting is delayed by a few
+    /// seconds, so this value is a snapshot of the data transfer rate from a few seconds earlier.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public RateStatus? DownloadRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of bytes received by the tunnel host and uploaded by tunnel
+    /// clients, over the lifetime of the tunnel.
+    /// </summary>
+    /// <remarks>
+    /// All types of tunnel and port connections, from potentially multiple clients, can
+    /// contribute to this total. The reported value may differ slightly from the value measurable
+    /// by applications, due to protocol overhead. Data transfer status reporting is delayed by
+    /// a few seconds.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ulong? UploadTotal { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of bytes sent by the tunnel host and downloaded by tunnel
+    /// clients, over the lifetime of the tunnel.
+    /// </summary>
+    /// <remarks>
+    /// All types of tunnel and port connections, from potentially multiple clients, can
+    /// contribute to this total. The reported value may differ slightly from the value measurable
+    /// by applications, due to protocol overhead. Data transfer status reporting is delayed by
+    /// a few seconds.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ulong? DownloadTotal { get; set; }
 
     /// <summary>
     /// Gets or sets the current value and limit for the rate of management API read operations 

--- a/go/tunnels/tunnel_status.go
+++ b/go/tunnels/tunnel_status.go
@@ -45,12 +45,43 @@ type TunnelStatus struct {
 	// See `TunnelPortStatus` for status of per-port client connections.
 	ClientConnectionRate     *RateStatus `json:"clientConnectionRate,omitempty"`
 
-	// Gets or sets the current value and limit for the rate of bytes transferred via the
-	// tunnel.
+	// Gets or sets the current value and limit for the rate of bytes being received by the
+	// tunnel host and uploaded by tunnel clients.
 	//
-	// This includes both sending and receiving. All types of tunnel and port connections
-	// contribute to this rate.
-	DataTransferRate         *RateStatus `json:"dataTransferRate,omitempty"`
+	// All types of tunnel and port connections, from potentially multiple clients, can
+	// contribute to this rate. The reported rate may differ slightly from the rate
+	// measurable by applications, due to protocol overhead. Data rate status reporting is
+	// delayed by a few seconds, so this value is a snapshot of the data transfer rate from a
+	// few seconds earlier.
+	UploadRate               *RateStatus `json:"uploadRate,omitempty"`
+
+	// Gets or sets the current value and limit for the rate of bytes being sent by the
+	// tunnel host and downloaded by tunnel clients.
+	//
+	// All types of tunnel and port connections, from potentially multiple clients, can
+	// contribute to this rate. The reported rate may differ slightly from the rate
+	// measurable by applications, due to protocol overhead. Data rate status reporting is
+	// delayed by a few seconds, so this value is a snapshot of the data transfer rate from a
+	// few seconds earlier.
+	DownloadRate             *RateStatus `json:"downloadRate,omitempty"`
+
+	// Gets or sets the total number of bytes received by the tunnel host and uploaded by
+	// tunnel clients, over the lifetime of the tunnel.
+	//
+	// All types of tunnel and port connections, from potentially multiple clients, can
+	// contribute to this total. The reported value may differ slightly from the value
+	// measurable by applications, due to protocol overhead. Data transfer status reporting
+	// is delayed by a few seconds.
+	UploadTotal              uint64 `json:"uploadTotal,omitempty"`
+
+	// Gets or sets the total number of bytes sent by the tunnel host and downloaded by
+	// tunnel clients, over the lifetime of the tunnel.
+	//
+	// All types of tunnel and port connections, from potentially multiple clients, can
+	// contribute to this total. The reported value may differ slightly from the value
+	// measurable by applications, due to protocol overhead. Data transfer status reporting
+	// is delayed by a few seconds.
+	DownloadTotal            uint64 `json:"downloadTotal,omitempty"`
 
 	// Gets or sets the current value and limit for the rate of management API read
 	// operations  for the tunnel or tunnel ports.

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelStatus.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelStatus.java
@@ -65,14 +65,54 @@ public class TunnelStatus {
     public RateStatus clientConnectionRate;
 
     /**
-     * Gets or sets the current value and limit for the rate of bytes transferred via the
-     * tunnel.
+     * Gets or sets the current value and limit for the rate of bytes being received by
+     * the tunnel host and uploaded by tunnel clients.
      *
-     * This includes both sending and receiving. All types of tunnel and port connections
-     * contribute to this rate.
+     * All types of tunnel and port connections, from potentially multiple clients, can
+     * contribute to this rate. The reported rate may differ slightly from the rate
+     * measurable by applications, due to protocol overhead. Data rate status reporting is
+     * delayed by a few seconds, so this value is a snapshot of the data transfer rate
+     * from a few seconds earlier.
      */
     @Expose
-    public RateStatus dataTransferRate;
+    public RateStatus uploadRate;
+
+    /**
+     * Gets or sets the current value and limit for the rate of bytes being sent by the
+     * tunnel host and downloaded by tunnel clients.
+     *
+     * All types of tunnel and port connections, from potentially multiple clients, can
+     * contribute to this rate. The reported rate may differ slightly from the rate
+     * measurable by applications, due to protocol overhead. Data rate status reporting is
+     * delayed by a few seconds, so this value is a snapshot of the data transfer rate
+     * from a few seconds earlier.
+     */
+    @Expose
+    public RateStatus downloadRate;
+
+    /**
+     * Gets or sets the total number of bytes received by the tunnel host and uploaded by
+     * tunnel clients, over the lifetime of the tunnel.
+     *
+     * All types of tunnel and port connections, from potentially multiple clients, can
+     * contribute to this total. The reported value may differ slightly from the value
+     * measurable by applications, due to protocol overhead. Data transfer status
+     * reporting is delayed by a few seconds.
+     */
+    @Expose
+    public long uploadTotal;
+
+    /**
+     * Gets or sets the total number of bytes sent by the tunnel host and downloaded by
+     * tunnel clients, over the lifetime of the tunnel.
+     *
+     * All types of tunnel and port connections, from potentially multiple clients, can
+     * contribute to this total. The reported value may differ slightly from the value
+     * measurable by applications, due to protocol overhead. Data transfer status
+     * reporting is delayed by a few seconds.
+     */
+    @Expose
+    public long downloadTotal;
 
     /**
      * Gets or sets the current value and limit for the rate of management API read

--- a/rs/src/contracts/tunnel_status.rs
+++ b/rs/src/contracts/tunnel_status.rs
@@ -45,12 +45,43 @@ pub struct TunnelStatus {
     // clients. See `TunnelPortStatus` for status of per-port client connections.
     pub client_connection_rate: Option<RateStatus>,
 
-    // Gets or sets the current value and limit for the rate of bytes transferred via the
-    // tunnel.
+    // Gets or sets the current value and limit for the rate of bytes being received by
+    // the tunnel host and uploaded by tunnel clients.
     //
-    // This includes both sending and receiving. All types of tunnel and port connections
-    // contribute to this rate.
-    pub data_transfer_rate: Option<RateStatus>,
+    // All types of tunnel and port connections, from potentially multiple clients, can
+    // contribute to this rate. The reported rate may differ slightly from the rate
+    // measurable by applications, due to protocol overhead. Data rate status reporting is
+    // delayed by a few seconds, so this value is a snapshot of the data transfer rate
+    // from a few seconds earlier.
+    pub upload_rate: Option<RateStatus>,
+
+    // Gets or sets the current value and limit for the rate of bytes being sent by the
+    // tunnel host and downloaded by tunnel clients.
+    //
+    // All types of tunnel and port connections, from potentially multiple clients, can
+    // contribute to this rate. The reported rate may differ slightly from the rate
+    // measurable by applications, due to protocol overhead. Data rate status reporting is
+    // delayed by a few seconds, so this value is a snapshot of the data transfer rate
+    // from a few seconds earlier.
+    pub download_rate: Option<RateStatus>,
+
+    // Gets or sets the total number of bytes received by the tunnel host and uploaded by
+    // tunnel clients, over the lifetime of the tunnel.
+    //
+    // All types of tunnel and port connections, from potentially multiple clients, can
+    // contribute to this total. The reported value may differ slightly from the value
+    // measurable by applications, due to protocol overhead. Data transfer status
+    // reporting is delayed by a few seconds.
+    pub upload_total: Option<u64>,
+
+    // Gets or sets the total number of bytes sent by the tunnel host and downloaded by
+    // tunnel clients, over the lifetime of the tunnel.
+    //
+    // All types of tunnel and port connections, from potentially multiple clients, can
+    // contribute to this total. The reported value may differ slightly from the value
+    // measurable by applications, due to protocol overhead. Data transfer status
+    // reporting is delayed by a few seconds.
+    pub download_total: Option<u64>,
 
     // Gets or sets the current value and limit for the rate of management API read
     // operations  for the tunnel or tunnel ports.

--- a/ts/src/contracts/tunnelStatus.ts
+++ b/ts/src/contracts/tunnelStatus.ts
@@ -58,13 +58,50 @@ export interface TunnelStatus {
     clientConnectionRate?: RateStatus;
 
     /**
-     * Gets or sets the current value and limit for the rate of bytes transferred via the
-     * tunnel.
+     * Gets or sets the current value and limit for the rate of bytes being received by
+     * the tunnel host and uploaded by tunnel clients.
      *
-     * This includes both sending and receiving. All types of tunnel and port connections
-     * contribute to this rate.
+     * All types of tunnel and port connections, from potentially multiple clients, can
+     * contribute to this rate. The reported rate may differ slightly from the rate
+     * measurable by applications, due to protocol overhead. Data rate status reporting is
+     * delayed by a few seconds, so this value is a snapshot of the data transfer rate
+     * from a few seconds earlier.
      */
-    dataTransferRate?: RateStatus;
+    uploadRate?: RateStatus;
+
+    /**
+     * Gets or sets the current value and limit for the rate of bytes being sent by the
+     * tunnel host and downloaded by tunnel clients.
+     *
+     * All types of tunnel and port connections, from potentially multiple clients, can
+     * contribute to this rate. The reported rate may differ slightly from the rate
+     * measurable by applications, due to protocol overhead. Data rate status reporting is
+     * delayed by a few seconds, so this value is a snapshot of the data transfer rate
+     * from a few seconds earlier.
+     */
+    downloadRate?: RateStatus;
+
+    /**
+     * Gets or sets the total number of bytes received by the tunnel host and uploaded by
+     * tunnel clients, over the lifetime of the tunnel.
+     *
+     * All types of tunnel and port connections, from potentially multiple clients, can
+     * contribute to this total. The reported value may differ slightly from the value
+     * measurable by applications, due to protocol overhead. Data transfer status
+     * reporting is delayed by a few seconds.
+     */
+    uploadTotal?: number;
+
+    /**
+     * Gets or sets the total number of bytes sent by the tunnel host and downloaded by
+     * tunnel clients, over the lifetime of the tunnel.
+     *
+     * All types of tunnel and port connections, from potentially multiple clients, can
+     * contribute to this total. The reported value may differ slightly from the value
+     * measurable by applications, due to protocol overhead. Data transfer status
+     * reporting is delayed by a few seconds.
+     */
+    downloadTotal?: number;
 
     /**
      * Gets or sets the current value and limit for the rate of management API read


### PR DESCRIPTION
 - Extend `TunnelStatus` properties to track `UploadRate`, `UploadTotal`, `DownloadRate`, `DownloadTotal`.
 - Add `ToString()` methods in C# `ResourceStatus` and `RateStatus` classes.