### PR TITLE
Add Limit Param to List Operation

### DIFF
--- a/cs/src/Management/TunnelRequestOptions.cs
+++ b/cs/src/Management/TunnelRequestOptions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DevTunnels.Management
         /// <summary>
         /// Limits the number of tunnels returned when searching or listing tunnels.
         /// </summary>
-        public uint Limit { get; set; }
+        public uint? Limit { get; set; }
 
         /// <summary>
         /// Converts tunnel request options to a query string for HTTP requests to the
@@ -152,9 +152,9 @@ namespace Microsoft.DevTunnels.Management
                 }
             }
 
-            if (Limit > 0)
+            if (Limit != null)
             {
-                queryOptions["limit"] = new[] { Limit.ToString() };
+                queryOptions["limit"] = new[] { Limit!.Value.ToString() };
             }
 
             if (AdditionalQueryParameters != null)

--- a/cs/src/Management/TunnelRequestOptions.cs
+++ b/cs/src/Management/TunnelRequestOptions.cs
@@ -114,6 +114,11 @@ namespace Microsoft.DevTunnels.Management
         public bool ForceRename { get; set; }
 
         /// <summary>
+        /// Limits the number of tunnels returned when searching or listing tunnels.
+        /// </summary>
+        public uint Limit { get; set; }
+
+        /// <summary>
         /// Converts tunnel request options to a query string for HTTP requests to the
         /// tunnel management API.
         /// </summary>
@@ -145,6 +150,11 @@ namespace Microsoft.DevTunnels.Management
                 {
                     queryOptions["allTags"] = TrueOption;
                 }
+            }
+
+            if (Limit > 0)
+            {
+                queryOptions["limit"] = new[] { Limit.ToString() };
             }
 
             if (AdditionalQueryParameters != null)

--- a/go/tunnels/request_options.go
+++ b/go/tunnels/request_options.go
@@ -4,6 +4,7 @@
 package tunnels
 
 import (
+	"fmt"
 	"net/url"
 )
 
@@ -38,6 +39,9 @@ type TunnelRequestOptions struct {
 
 	// If there is another tunnel with the name requested in updateTunnel, try to acquire the name from the other tunnel.
 	ForceRename bool
+
+	// Limits the number of tunnels returned when searching or listing tunnels.
+	Limit uint
 }
 
 func (options *TunnelRequestOptions) queryString() string {
@@ -70,6 +74,10 @@ func (options *TunnelRequestOptions) queryString() string {
 		for paramName, paramValue := range options.AdditionalQueryParameters {
 			queryOptions.Add(paramName, paramValue)
 		}
+	}
+
+	if options.Limit > 0 {
+		queryOptions.Set("limit", fmt.Sprint(options.Limit))
 	}
 
 	return queryOptions.Encode()

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelRequestOptions.java
@@ -102,6 +102,11 @@ public class TunnelRequestOptions {
    */
   public boolean forceRename;
 
+  /**
+   * Limits the number of tunnels returned when searching or listing tunnels.
+   */
+  public Integer limit;
+
 
   /**
    * Converts tunnel request options to a query string for HTTP requests to the
@@ -128,6 +133,10 @@ public class TunnelRequestOptions {
       if (this.requireAllTags) {
         queryOptions.put("allTags", Arrays.asList("true"));
       }
+    }
+
+    if (this.limit != null) {
+      queryOptions.put("limit", Arrays.asList(this.limit.toString()));
     }
 
     if (this.additionalQueryParameters != null) {

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -399,6 +399,9 @@ impl TunnelManagementClient {
                     query.append_pair("allTags", "true");
                 }
             }
+            if tunnel_opts.limit > 0 {
+                query.append_pair("limit", &tunnel_opts.limit.to_string());
+            }
         }
         let mut request = self.make_request(method, url).await?;
 

--- a/rs/src/management/tunnel_request_options.rs
+++ b/rs/src/management/tunnel_request_options.rs
@@ -36,6 +36,9 @@ pub struct TunnelRequestOptions {
     /// If true on a create or update request then upon a name conflict, attempt to rename the
     /// existing tunnel to null and give the name to the tunnel from the request.
     pub force_rename: bool,
+
+    /// Limits the number of tunnels returned when searching or listing tunnels.
+    pub limit: u32,
 }
 
 pub const NO_REQUEST_OPTIONS: &TunnelRequestOptions = &TunnelRequestOptions {
@@ -46,4 +49,5 @@ pub const NO_REQUEST_OPTIONS: &TunnelRequestOptions = &TunnelRequestOptions {
     require_all_tags: false,
     token_scopes: Vec::new(),
     force_rename: false,
+    limit: 0,
 };

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -747,6 +747,10 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
                 }
             }
 
+            if (options.limit) {
+                queryOptions['limit'] = [options.limit.toString()];
+            }
+
             queryItems.push(
                 ...Object.keys(queryOptions).map((key) => {
                     const value = queryOptions[key];

--- a/ts/src/management/tunnelRequestOptions.ts
+++ b/ts/src/management/tunnelRequestOptions.ts
@@ -76,4 +76,9 @@ export interface TunnelRequestOptions {
      * existing tunnel to null and give the name to the tunnel from the request.
      */
     forceRename?: boolean;
+
+    /**
+     * Limits the number of tunnels returned when searching or listing tunnels.
+     */
+    limit?: number;
 }


### PR DESCRIPTION
This adds a param to the tunnel list command to limit the number of tunnels returned. This can speed up queries to control plane when searching for single tunnels by tags