### PR TITLE
Fix subject regex, expose more constraints

### DIFF
--- a/cs/src/Contracts/TunnelAccessSubject.cs
+++ b/cs/src/Contracts/TunnelAccessSubject.cs
@@ -17,13 +17,6 @@ using static TunnelConstraints;
 /// </summary>
 public class TunnelAccessSubject
 {
-    private const int SubjectNameMaxLength = 200;
-
-    // Note <angle-brackets> are only allowed when they wrap an email address as part of a
-    // formatted name with email. The service will block any other use of angle brackets,
-    // to avoid any XSS risks.
-    private const string SubjectNamePattern = @"[ \w\d-.,""_@()<>]{0,200}";
-
     /// <summary>
     /// Gets or sets the type of subject, e.g. user, group, or organization.
     /// </summary>
@@ -57,8 +50,8 @@ public class TunnelAccessSubject
     /// a subject ID to name, the full name is returned if the ID was found.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [StringLength(SubjectNameMaxLength)]
-    [RegularExpression(SubjectNamePattern)]
+    [StringLength(AccessControlSubjectNameMaxLength)]
+    [RegularExpression(AccessControlSubjectNamePattern)]
     public string? Name { get; set; }
 
     /// <summary>

--- a/cs/src/Contracts/TunnelConstraints.cs
+++ b/cs/src/Contracts/TunnelConstraints.cs
@@ -114,7 +114,15 @@ public static class TunnelConstraints
     /// </summary>
     /// <seealso cref="TunnelAccessControlEntry.Subjects"/>
     /// <seealso cref="TunnelAccessControlEntry.Organization"/>
+    /// <seealso cref="TunnelAccessSubject.Id"/>
+    /// <seealso cref="TunnelAccessSubject.OrganizationId"/>
     public const int AccessControlSubjectMaxLength = 200;
+
+    /// <summary>
+    /// Max length of an access control subject name, when resolving names to IDs.
+    /// </summary>
+    /// <seealso cref="TunnelAccessSubject.Name"/>
+    public const int AccessControlSubjectNameMaxLength = 200;
 
     /// <summary>
     /// Maximum number of scopes in an access control entry.
@@ -225,14 +233,40 @@ public static class TunnelConstraints
     /// </summary>
     /// <seealso cref="TunnelAccessControlEntry.Subjects"/>
     /// <seealso cref="TunnelAccessControlEntry.Organization"/>
-    public const string AccessControlSubjectPattern = "[0-9a-zA-Z-._]{0,200}";
+    /// <seealso cref="TunnelAccessSubject.Id"/>
+    /// <seealso cref="TunnelAccessSubject.OrganizationId"/>
+    /// <remarks>
+    /// The : and / characters are allowed because subjects may include IP addresses and ranges.
+    /// </remarks>
+    public const string AccessControlSubjectPattern = "[0-9a-zA-Z-._:/]{0,200}";
 
     /// <summary>
     /// Regular expression that can match or validate an access control subject or organization ID.
     /// </summary>
     /// <seealso cref="TunnelAccessControlEntry.Subjects"/>
     /// <seealso cref="TunnelAccessControlEntry.Organization"/>
+    /// <seealso cref="TunnelAccessSubject.Id"/>
+    /// <seealso cref="TunnelAccessSubject.OrganizationId"/>
     public static Regex AccessControlSubjectRegex { get; } = new Regex(AccessControlSubjectPattern);
+
+    /// <summary>
+    /// Regular expression that can match or validate an access control subject name, when resolving
+    /// subject names to IDs.
+    /// </summary>
+    /// <seealso cref="TunnelAccessSubject.Name"/>
+    /// <remarks>
+    /// Note angle-brackets are only allowed when they wrap an email address as part of a
+    /// formatted name with email. The service will block any other use of angle-brackets,
+    /// to avoid any XSS risks.
+    /// </remarks>
+    public const string AccessControlSubjectNamePattern = "[ \\w\\d-.,'\"_@()<>]{0,200}";
+
+    /// <summary>
+    /// Regular expression that can match or validate an access control subject name, when resolving
+    /// subject names to IDs.
+    /// </summary>
+    /// <seealso cref="TunnelAccessSubject.Name"/>
+    public static Regex AccessControlSubjectNameRegex { get; } = new Regex(AccessControlSubjectNamePattern);
 
     /// <summary>
     /// Validates <paramref name="clusterId"/> and returns true if it is a valid cluster ID, otherwise false.

--- a/cs/tools/TunnelsSDK.Generator/GoContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/GoContractWriter.cs
@@ -354,7 +354,7 @@ internal class GoContractWriter : ContractWriter
         var csExpression = sourceText.Substring(
             equalsIndex + 1, semicolonIndex - equalsIndex - 1).Trim();
 
-        // Attempt to convert the CS expression to a Go expression. This involes several
+        // Attempt to convert the CS expression to a Go expression. This involves several
         // weak assumptions, and will not work for many kinds of expressions. But it might
         // be good enough.
         var goExpression = csExpression.Replace("new Regex", "regexp.MustCompile");
@@ -363,14 +363,12 @@ internal class GoContractWriter : ContractWriter
 
         // Assume any PascalCase identifiers are referncing other variables in scope.
         // Contvert integer constants to strings, allowing for integer offsets.
-        goExpression = new Regex("([A-Z][a-z]+){2,4}\\b(?!\\()").Replace(
+        goExpression = new Regex("([A-Z][a-z]+){2,6}\\b(?!\\()").Replace(
             goExpression, (m) => $"{member.ContainingType.Name}{m.Value}");
         goExpression = new Regex("\\(([A-Z][a-z]+){4,7} - \\d\\)").Replace(
             goExpression, (m) => $"strconv.Itoa{m.Value}");
         goExpression = new Regex("\\b([A-Z][a-z]+){3,6}Length\\b(?! - \\d)").Replace(
             goExpression, (m) => $"strconv.Itoa({m.Value})");
-        goExpression = new Regex("\"(([^\"]*\\\\)+[^\"]*)\"").Replace(
-            goExpression, (m) => $"`{m.Groups[1].Value.Replace("\\\\", "\\")}`");
         goExpression = FixPropertyNameCasing(goExpression);
         goExpression = goExpression.Replace("        ", "\t\t");
 

--- a/cs/tools/TunnelsSDK.Generator/JavaContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/JavaContractWriter.cs
@@ -361,7 +361,7 @@ internal class JavaContractWriter : ContractWriter
             .Replace("Replace", "replace");
 
         // Assume any PascalCase identifiers are referncing other variables in scope.
-        javaExpression = new Regex("(?<= |\\()([A-Z][a-z]+){2,4}\\b(?!\\()").Replace(
+        javaExpression = new Regex("(?<= |\\()([A-Z][a-z]+){2,6}\\b(?!\\()").Replace(
             javaExpression, (m) =>
             {
                 return (member.ContainingType.MemberNames.Contains(m.Value) ?

--- a/cs/tools/TunnelsSDK.Generator/RustContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/RustContractWriter.cs
@@ -302,7 +302,7 @@ internal class RustContractWriter : ContractWriter
             string? memberExpression = null;
             if (field.ConstantValue is string stringValue)
             {
-                memberExpression = $"&str = \"{stringValue}\"";
+                memberExpression = $"&str = \"{stringValue.Replace("\"", "\\\"")}\"";
             }
             else if (field.ConstantValue is int)
             {

--- a/cs/tools/TunnelsSDK.Generator/TSContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/TSContractWriter.cs
@@ -346,16 +346,16 @@ internal class TSContractWriter : ContractWriter
         var csExpression = sourceText.Substring(
             equalsIndex + 1, semicolonIndex - equalsIndex - 1).Trim();
 
-        // Attempt to convert the CS expression to a TS expression. This involes several
+        // Attempt to convert the CS expression to a TS expression. This involves several
         // weak assumptions, and will not work for many kinds of expressions. But it might
         // be good enough.
         var tsExpression = csExpression
-            .Replace('"', '\'')
+            .Replace("'", "^^^").Replace("\\\"", "$$$").Replace('"', '\'').Replace("$$$", "\"").Replace("^^^", "\\'")
             .Replace("Regex", "RegExp")
             .Replace("Replace", "replace");
 
         // Assume any PascalCase identifiers are referncing other variables in scope.
-        tsExpression = new Regex("([A-Z][a-z]+){2,4}\\b(?!\\()").Replace(
+        tsExpression = new Regex("([A-Z][a-z]+){2,6}\\b(?!\\()").Replace(
             tsExpression, (m) =>
             {
                 return (member.ContainingType.MemberNames.Contains(m.Value) ?

--- a/go/tunnels/tunnel_constraints.go
+++ b/go/tunnels/tunnel_constraints.go
@@ -58,6 +58,9 @@ const (
 	// Max length of an access control subject or organization ID.
 	TunnelConstraintsAccessControlSubjectMaxLength = 200
 
+	// Max length of an access control subject name, when resolving names to IDs.
+	TunnelConstraintsAccessControlSubjectNameMaxLength = 200
+
 	// Maximum number of scopes in an access control entry.
 	TunnelConstraintsAccessControlMaxScopes = 10
 
@@ -82,6 +85,9 @@ const (
 	// empty string because tunnels may be unnamed.
 	TunnelConstraintsTunnelNamePattern = "([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|"
 
+	// Regular expression that can match or validate tunnel or port tags.
+	TunnelConstraintsTagPattern = "[\\w-=]{1,50}"
+
 	// Regular expression that can match or validate tunnel domains.
 	//
 	// The tunnel service may perform additional contextual validation at the time the domain
@@ -90,7 +96,18 @@ const (
 
 	// Regular expression that can match or validate an access control subject or
 	// organization ID.
-	TunnelConstraintsAccessControlSubjectPattern = "[0-9a-zA-Z-._]{0,200}"
+	//
+	// The : and / characters are allowed because subjects may include IP addresses and
+	// ranges.
+	TunnelConstraintsAccessControlSubjectPattern = "[0-9a-zA-Z-._:/]{0,200}"
+
+	// Regular expression that can match or validate an access control subject name, when
+	// resolving subject names to IDs.
+	//
+	// Note angle-brackets are only allowed when they wrap an email address as part of a
+	// formatted name with email. The service will block any other use of angle-brackets, to
+	// avoid any XSS risks.
+	TunnelConstraintsAccessControlSubjectNamePattern = "[ \\w\\d-.,'\"_@()<>]{0,200}"
 )
 var (
 	// Regular expression that can match or validate tunnel cluster ID strings.
@@ -111,9 +128,6 @@ var (
 	TunnelConstraintsTunnelNameRegex = regexp.MustCompile(TunnelConstraintsTunnelNamePattern)
 
 	// Regular expression that can match or validate tunnel or port tags.
-	TunnelConstraintsTagPattern = `[\w-=]{1,50}`
-
-	// Regular expression that can match or validate tunnel or port tags.
 	TunnelConstraintsTagRegex = regexp.MustCompile(TunnelConstraintsTagPattern)
 
 	// Regular expression that can match or validate tunnel domains.
@@ -125,4 +139,8 @@ var (
 	// Regular expression that can match or validate an access control subject or
 	// organization ID.
 	TunnelConstraintsAccessControlSubjectRegex = regexp.MustCompile(TunnelConstraintsAccessControlSubjectPattern)
+
+	// Regular expression that can match or validate an access control subject name, when
+	// resolving subject names to IDs.
+	TunnelConstraintsAccessControlSubjectNameRegex = regexp.MustCompile(TunnelConstraintsAccessControlSubjectNamePattern)
 )

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
@@ -90,6 +90,11 @@ public class TunnelConstraints {
     public static final int accessControlSubjectMaxLength = 200;
 
     /**
+     * Max length of an access control subject name, when resolving names to IDs.
+     */
+    public static final int accessControlSubjectNameMaxLength = 200;
+
+    /**
      * Maximum number of scopes in an access control entry.
      */
     public static final int accessControlMaxScopes = 10;
@@ -175,14 +180,33 @@ public class TunnelConstraints {
     /**
      * Regular expression that can match or validate an access control subject or
      * organization ID.
+     *
+     * The : and / characters are allowed because subjects may include IP addresses and
+     * ranges.
      */
-    public static final String accessControlSubjectPattern = "[0-9a-zA-Z-._]{0,200}";
+    public static final String accessControlSubjectPattern = "[0-9a-zA-Z-._:/]{0,200}";
 
     /**
      * Regular expression that can match or validate an access control subject or
      * organization ID.
      */
     public static final Pattern accessControlSubjectRegex = java.util.regex.Pattern.compile(TunnelConstraints.accessControlSubjectPattern);
+
+    /**
+     * Regular expression that can match or validate an access control subject name, when
+     * resolving subject names to IDs.
+     *
+     * Note angle-brackets are only allowed when they wrap an email address as part of a
+     * formatted name with email. The service will block any other use of angle-brackets,
+     * to avoid any XSS risks.
+     */
+    public static final String accessControlSubjectNamePattern = "[ \\w\\d-.,'\"_@()<>]{0,200}";
+
+    /**
+     * Regular expression that can match or validate an access control subject name, when
+     * resolving subject names to IDs.
+     */
+    public static final Pattern accessControlSubjectNameRegex = java.util.regex.Pattern.compile(TunnelConstraints.accessControlSubjectNamePattern);
 
     /**
      * Validates <paramref name="clusterId"/> and returns true if it is a valid cluster

--- a/rs/src/contracts/tunnel_constraints.rs
+++ b/rs/src/contracts/tunnel_constraints.rs
@@ -53,6 +53,9 @@ pub const ACCESS_CONTROL_MAX_SUBJECTS: &i32 = 100;
 // Max length of an access control subject or organization ID.
 pub const ACCESS_CONTROL_SUBJECT_MAX_LENGTH: &i32 = 200;
 
+// Max length of an access control subject name, when resolving names to IDs.
+pub const ACCESS_CONTROL_SUBJECT_NAME_MAX_LENGTH: &i32 = 200;
+
 // Maximum number of scopes in an access control entry.
 pub const ACCESS_CONTROL_MAX_SCOPES: &i32 = 10;
 
@@ -88,4 +91,15 @@ pub const TUNNEL_DOMAIN_PATTERN: &str = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]";
 
 // Regular expression that can match or validate an access control subject or organization
 // ID.
-pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = "[0-9a-zA-Z-._]{0,200}";
+//
+// The : and / characters are allowed because subjects may include IP addresses and
+// ranges.
+pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = "[0-9a-zA-Z-._:/]{0,200}";
+
+// Regular expression that can match or validate an access control subject name, when
+// resolving subject names to IDs.
+//
+// Note angle-brackets are only allowed when they wrap an email address as part of a
+// formatted name with email. The service will block any other use of angle-brackets, to
+// avoid any XSS risks.
+pub const ACCESS_CONTROL_SUBJECT_NAME_PATTERN: &str = "[ \w\d-.,'\"_@()<>]{0,200}";

--- a/ts/src/contracts/tunnelConstraints.ts
+++ b/ts/src/contracts/tunnelConstraints.ts
@@ -87,6 +87,11 @@ namespace TunnelConstraints {
     export const accessControlSubjectMaxLength: number = 200;
 
     /**
+     * Max length of an access control subject name, when resolving names to IDs.
+     */
+    export const accessControlSubjectNameMaxLength: number = 200;
+
+    /**
      * Maximum number of scopes in an access control entry.
      */
     export const accessControlMaxScopes: number = 10;
@@ -172,12 +177,31 @@ namespace TunnelConstraints {
     /**
      * Regular expression that can match or validate an access control subject or
      * organization ID.
+     *
+     * The : and / characters are allowed because subjects may include IP addresses and
+     * ranges.
      */
-    export const accessControlSubjectPattern: string = '[0-9a-zA-Z-._]{0,200}';
+    export const accessControlSubjectPattern: string = '[0-9a-zA-Z-._:/]{0,200}';
 
     /**
      * Regular expression that can match or validate an access control subject or
      * organization ID.
      */
     export const accessControlSubjectRegex: RegExp = new RegExp(TunnelConstraints.accessControlSubjectPattern);
+
+    /**
+     * Regular expression that can match or validate an access control subject name, when
+     * resolving subject names to IDs.
+     *
+     * Note angle-brackets are only allowed when they wrap an email address as part of a
+     * formatted name with email. The service will block any other use of angle-brackets,
+     * to avoid any XSS risks.
+     */
+    export const accessControlSubjectNamePattern: string = '[ \\w\\d-.,\'"_@()<>]{0,200}';
+
+    /**
+     * Regular expression that can match or validate an access control subject name, when
+     * resolving subject names to IDs.
+     */
+    export const accessControlSubjectNameRegex: RegExp = new RegExp(TunnelConstraints.accessControlSubjectNamePattern);
 }


### PR DESCRIPTION
 - Add `:` and `/` characters to subject regex, to support IP addresses and ranges.
 - Make subject name constraints public.
 - Fix quote escaping in code generation.