### PR TITLE
Add tunnel expiration property to contracts

### DIFF
--- a/cs/src/Contracts/Tunnel.cs
+++ b/cs/src/Contracts/Tunnel.cs
@@ -132,4 +132,10 @@ public class Tunnel
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? Created { get; set; }
+
+    /// <summary>
+    /// Gets or the time the tunnel will be deleted if it is not used or updated.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? Expiration { get; }
 }

--- a/cs/src/Contracts/Tunnel.cs
+++ b/cs/src/Contracts/Tunnel.cs
@@ -137,5 +137,5 @@ public class Tunnel
     /// Gets or the time the tunnel will be deleted if it is not used or updated.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public DateTime? Expiration { get; }
+    public DateTime? Expiration { get; set; }
 }

--- a/go/tunnels/tunnel.go
+++ b/go/tunnels/tunnel.go
@@ -61,4 +61,7 @@ type Tunnel struct {
 
 	// Gets or sets the time in UTC of tunnel creation.
 	Created       *time.Time `json:"created,omitempty"`
+
+	// Gets or the time the tunnel will be deleted if it is not used or updated.
+	Expiration    *time.Time `json:"expiration,omitempty"`
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/Tunnel.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/Tunnel.java
@@ -108,5 +108,5 @@ public class Tunnel {
      * Gets or the time the tunnel will be deleted if it is not used or updated.
      */
     @Expose
-    public final Date expiration;
+    public Date expiration;
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/Tunnel.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/Tunnel.java
@@ -103,4 +103,10 @@ public class Tunnel {
      */
     @Expose
     public Date created;
+
+    /**
+     * Gets or the time the tunnel will be deleted if it is not used or updated.
+     */
+    @Expose
+    public final Date expiration;
 }

--- a/rs/src/contracts/tunnel.rs
+++ b/rs/src/contracts/tunnel.rs
@@ -69,4 +69,7 @@ pub struct Tunnel {
 
     // Gets or sets the time in UTC of tunnel creation.
     pub created: Option<DateTime<Utc>>,
+
+    // Gets or the time the tunnel will be deleted if it is not used or updated.
+    pub expiration: Option<DateTime<Utc>>,
 }

--- a/ts/src/contracts/tunnel.ts
+++ b/ts/src/contracts/tunnel.ts
@@ -91,4 +91,9 @@ export interface Tunnel {
      * Gets or sets the time in UTC of tunnel creation.
      */
     created?: Date;
+
+    /**
+     * Gets or the time the tunnel will be deleted if it is not used or updated.
+     */
+    expiration?: Date;
 }


### PR DESCRIPTION
This property will be returned from tunnel get operations and will contain the value of when the tunnel with be cleaned up if it is not used or updated.