### PR TITLE
Add valid chars to subject name and email regexes

### DIFF
--- a/cs/src/Contracts/TunnelConstraints.cs
+++ b/cs/src/Contracts/TunnelConstraints.cs
@@ -237,8 +237,9 @@ public static class TunnelConstraints
     /// <seealso cref="TunnelAccessSubject.OrganizationId"/>
     /// <remarks>
     /// The : and / characters are allowed because subjects may include IP addresses and ranges.
+    /// The @ character is allowed because MSA subjects may be identified by email address.
     /// </remarks>
-    public const string AccessControlSubjectPattern = "[0-9a-zA-Z-._:/]{0,200}";
+    public const string AccessControlSubjectPattern = "[0-9a-zA-Z-._:/@]{0,200}";
 
     /// <summary>
     /// Regular expression that can match or validate an access control subject or organization ID.
@@ -259,7 +260,7 @@ public static class TunnelConstraints
     /// formatted name with email. The service will block any other use of angle-brackets,
     /// to avoid any XSS risks.
     /// </remarks>
-    public const string AccessControlSubjectNamePattern = "[ \\w\\d-.,'\"_@()<>]{0,200}";
+    public const string AccessControlSubjectNamePattern = "[ \\w\\d-.,/'\"_@()<>]{0,200}";
 
     /// <summary>
     /// Regular expression that can match or validate an access control subject name, when resolving

--- a/go/tunnels/tunnel_constraints.go
+++ b/go/tunnels/tunnel_constraints.go
@@ -98,8 +98,9 @@ const (
 	// organization ID.
 	//
 	// The : and / characters are allowed because subjects may include IP addresses and
-	// ranges.
-	TunnelConstraintsAccessControlSubjectPattern = "[0-9a-zA-Z-._:/]{0,200}"
+	// ranges. The @ character is allowed because MSA subjects may be identified by email
+	// address.
+	TunnelConstraintsAccessControlSubjectPattern = "[0-9a-zA-Z-._:/@]{0,200}"
 
 	// Regular expression that can match or validate an access control subject name, when
 	// resolving subject names to IDs.
@@ -107,7 +108,7 @@ const (
 	// Note angle-brackets are only allowed when they wrap an email address as part of a
 	// formatted name with email. The service will block any other use of angle-brackets, to
 	// avoid any XSS risks.
-	TunnelConstraintsAccessControlSubjectNamePattern = "[ \\w\\d-.,'\"_@()<>]{0,200}"
+	TunnelConstraintsAccessControlSubjectNamePattern = "[ \\w\\d-.,/'\"_@()<>]{0,200}"
 )
 var (
 	// Regular expression that can match or validate tunnel cluster ID strings.

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
@@ -182,9 +182,10 @@ public class TunnelConstraints {
      * organization ID.
      *
      * The : and / characters are allowed because subjects may include IP addresses and
-     * ranges.
+     * ranges. The @ character is allowed because MSA subjects may be identified by email
+     * address.
      */
-    public static final String accessControlSubjectPattern = "[0-9a-zA-Z-._:/]{0,200}";
+    public static final String accessControlSubjectPattern = "[0-9a-zA-Z-._:/@]{0,200}";
 
     /**
      * Regular expression that can match or validate an access control subject or
@@ -200,7 +201,7 @@ public class TunnelConstraints {
      * formatted name with email. The service will block any other use of angle-brackets,
      * to avoid any XSS risks.
      */
-    public static final String accessControlSubjectNamePattern = "[ \\w\\d-.,'\"_@()<>]{0,200}";
+    public static final String accessControlSubjectNamePattern = "[ \\w\\d-.,/'\"_@()<>]{0,200}";
 
     /**
      * Regular expression that can match or validate an access control subject name, when

--- a/rs/src/contracts/tunnel_constraints.rs
+++ b/rs/src/contracts/tunnel_constraints.rs
@@ -93,8 +93,9 @@ pub const TUNNEL_DOMAIN_PATTERN: &str = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]";
 // ID.
 //
 // The : and / characters are allowed because subjects may include IP addresses and
-// ranges.
-pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = "[0-9a-zA-Z-._:/]{0,200}";
+// ranges. The @ character is allowed because MSA subjects may be identified by email
+// address.
+pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = "[0-9a-zA-Z-._:/@]{0,200}";
 
 // Regular expression that can match or validate an access control subject name, when
 // resolving subject names to IDs.
@@ -102,4 +103,4 @@ pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = "[0-9a-zA-Z-._:/]{0,200}";
 // Note angle-brackets are only allowed when they wrap an email address as part of a
 // formatted name with email. The service will block any other use of angle-brackets, to
 // avoid any XSS risks.
-pub const ACCESS_CONTROL_SUBJECT_NAME_PATTERN: &str = "[ \w\d-.,'\"_@()<>]{0,200}";
+pub const ACCESS_CONTROL_SUBJECT_NAME_PATTERN: &str = "[ \w\d-.,/'\"_@()<>]{0,200}";

--- a/ts/src/contracts/tunnelConstraints.ts
+++ b/ts/src/contracts/tunnelConstraints.ts
@@ -179,9 +179,10 @@ namespace TunnelConstraints {
      * organization ID.
      *
      * The : and / characters are allowed because subjects may include IP addresses and
-     * ranges.
+     * ranges. The @ character is allowed because MSA subjects may be identified by email
+     * address.
      */
-    export const accessControlSubjectPattern: string = '[0-9a-zA-Z-._:/]{0,200}';
+    export const accessControlSubjectPattern: string = '[0-9a-zA-Z-._:/@]{0,200}';
 
     /**
      * Regular expression that can match or validate an access control subject or
@@ -197,7 +198,7 @@ namespace TunnelConstraints {
      * formatted name with email. The service will block any other use of angle-brackets,
      * to avoid any XSS risks.
      */
-    export const accessControlSubjectNamePattern: string = '[ \\w\\d-.,\'"_@()<>]{0,200}';
+    export const accessControlSubjectNamePattern: string = '[ \\w\\d-.,/\'"_@()<>]{0,200}';
 
     /**
      * Regular expression that can match or validate an access control subject name, when


### PR DESCRIPTION
Fixes E2E test failures, with test cases that use MSA emails as the subject ID and org/team format as a subject name.