### PR TITLE
Reconnect tunnel client on 503

### DIFF
--- a/ts/src/connections/relayTunnelConnector.ts
+++ b/ts/src/connections/relayTunnelConnector.ts
@@ -216,6 +216,14 @@ export class RelayTunnelConnector implements TunnelConnector {
                             throwError(`The tunnel or port is not found${statusCodeText}`);
                             break;
 
+                        case 'error.serviceUnavailable':
+                            // Normally nginx choses another healthy pod when it encounters 503.
+                            // However, if there are no other pods, it returns 503 to the client.
+                            // This rare case may happen when the cluster recovers from a failure
+                            // and the nginx controller has started but Relay service has not yet.
+                            errorDescription = `Service temporarily unavailable${statusCodeText}`;
+                            continue;
+
                         case 'error.tooManyRequests':
                             errorDescription = `Rate limit exceeded${statusCodeText}. Too many requests in a given amount of time.`;
                             if (attempt > 4) {

--- a/ts/src/connections/sshHelpers.ts
+++ b/ts/src/connections/sshHelpers.ts
@@ -305,6 +305,7 @@ export enum RelayErrorType {
     ServerError = 5,
     TunnelPortNotFound = 6,
     TooManyRequests = 7,
+    ServiceUnavailable = 8,
 }
 /**
  * Error used when a connection to an Azure relay failed.
@@ -366,5 +367,11 @@ const webSocketClientContexts: WebSocketClientErrorContext[] = [
         statusCode: 500,
         error: 'relayServerError',
         errorType: RelayErrorType.ServerError,
+    },
+    {
+        regex: /status: 503/,
+        statusCode: 503,
+        error: 'serviceUnavailable',
+        errorType: RelayErrorType.ServiceUnavailable,
     },
 ];


### PR DESCRIPTION
Fix for https://github.com/microsoft/basis-planning/issues/581

Normally nginx choses another healthy pod when it encounters 503. However, if there are no other pods, it returns 503 to the client. This rare case may happen when the cluster recovers from a failure and the nginx controller has started but Relay service has not yet.