### PR TITLE
Revert "Update to latest SSH package"

### DIFF
--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -83,7 +83,7 @@
     <VisualStudioValidationVersion>15.5.31</VisualStudioValidationVersion>
     <VsSaaSPackageVersion>2.0.39</VsSaaSPackageVersion>
     <VsSaasTokenServiceClientPackageVersion>1.0.3642</VsSaasTokenServiceClientPackageVersion>
-    <DevTunnelsSshPackageVersion>3.10.6</DevTunnelsSshPackageVersion>
+    <DevTunnelsSshPackageVersion>3.9.3</DevTunnelsSshPackageVersion>
     <XunitExtensibilityCorePackageVersion>2.4.1</XunitExtensibilityCorePackageVersion>
     <XunitExtensibilityExecutionPackageVersion>2.4.1</XunitExtensibilityExecutionPackageVersion>
     <XunitExtensionsAssemblyFixturePackageVersion>2.2.0</XunitExtensionsAssemblyFixturePackageVersion>


### PR DESCRIPTION
Reverts microsoft/dev-tunnels#164

There's a stack overflow in the SSH lib that _sometimes_ causes tunnel connection tests to fail. It wasn't caught by PR builds, but failed in CI builds. I'm reverting the update until I can resolve the issue.