### PR TITLE
A suspend and resume reads to java

### DIFF
--- a/java/src/main/java/com/microsoft/tunnels/websocket/WebSocketSession.java
+++ b/java/src/main/java/com/microsoft/tunnels/websocket/WebSocketSession.java
@@ -79,4 +79,15 @@ public class WebSocketSession extends NettyIoSession {
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
     super.exceptionCaught(ctx, cause);
   }
+
+  @Override
+  public void suspendRead()  {
+    super.suspendRead();
+  }
+
+  @Override
+  public void resumeRead()  {
+    super.resumeRead();
+  }
+
 }


### PR DESCRIPTION
Fixes Customer issue

### Changes proposed: 
- Adds suspend and resume read functions to java websocketsession implementation

Note: these functions don't do anything in the NettyIoSession but should prevent errors from being thrown if they are referenced
