### PR TITLE
Restrict tunnel names ending in -inspect

### DIFF
--- a/cs/src/Contracts/TunnelConstraints.cs
+++ b/cs/src/Contracts/TunnelConstraints.cs
@@ -306,7 +306,7 @@ public static class TunnelConstraints
         {
             return false;
         }
-        if (tunnelName.EndsWith("-inspect"))
+        if (tunnelName.EndsWith("-inspect", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }

--- a/cs/src/Contracts/TunnelConstraints.cs
+++ b/cs/src/Contracts/TunnelConstraints.cs
@@ -306,6 +306,10 @@ public static class TunnelConstraints
         {
             return false;
         }
+        if (tunnelName.EndsWith("-inspect"))
+        {
+            return false;
+        }
 
         var m = TunnelNameRegex.Match(tunnelName);
         return m.Index == 0 && m.Length == tunnelName.Length && !IsValidTunnelId(tunnelName);


### PR DESCRIPTION
Fixes issue where tunnels ending in -inspect can get confused with inspection service routing

### Changes proposed: 
- Adds restriction that tunnel names cannot end in -inspect as this will be used by the inspection urls
- If name is rejected, reason will be shown in CLI (separate PR)
