### PR TITLE
Fix TunnelRelayTunneHost dispose error

### DIFF
--- a/ts/src/connections/tunnelRelayTunnelHost.ts
+++ b/ts/src/connections/tunnelRelayTunnelHost.ts
@@ -156,7 +156,9 @@ export class TunnelRelayTunnelHost extends tunnelRelaySessionClass(
             );
             await this.connectAndRunClientSession(stream, cancellation);
         } catch (ex) {
-            this.trace(TraceLevel.Error, 0, `Error running client SSH session: ${ex}`);
+            if (!(ex instanceof CancellationError) || !cancellation.isCancellationRequested) {
+                this.trace(TraceLevel.Error, 0, `Error running client SSH session: ${ex}`);
+            }
         }
     }
 


### PR DESCRIPTION
Do not trace error for expected cancellations during Tunnel Relay tunnel host disposal.

Fixes [#609](https://github.com/microsoft/basis-planning/issues/609)

### Changes proposed: 
- Do not trace error for expected cancellation during Tunnel Relay tunnel host disposal
