### PR TITLE
Specify nuget version 6.4.x in build pipeline

### DIFF
--- a/.pipelines/cs-build-steps.yaml
+++ b/.pipelines/cs-build-steps.yaml
@@ -12,7 +12,7 @@ steps:
     performMultiLevelLookup: true
     useGlobalJson: true
 
-- task: NuGetAuthenticate@0
+- task: NuGetAuthenticate@1
   displayName: 'NuGet Authenticate'
 
 - task: DotNetCoreCLI@2

--- a/.pipelines/cs-ci-build.yaml
+++ b/.pipelines/cs-ci-build.yaml
@@ -26,6 +26,10 @@ steps:
   inputs:
     signType: $(signType)
 
+- task: NuGetToolInstaller@1
+  inputs:
+    versionSpec: '6.4.0'
+
 # To archive our debug symbols with symweb, we need to convert the portable .pdb files that we build to windows .pdb files first
 # https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/672/Archive-Symbols-with-Symweb?anchor=portable-pdbs
 - task: NuGetCommand@2

--- a/.pipelines/cs-ci-build.yaml
+++ b/.pipelines/cs-ci-build.yaml
@@ -28,7 +28,7 @@ steps:
 
 - task: NuGetToolInstaller@1
   inputs:
-    versionSpec: '6.4.0'
+    versionSpec: '6.4.x'
 
 # To archive our debug symbols with symweb, we need to convert the portable .pdb files that we build to windows .pdb files first
 # https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/672/Archive-Symbols-with-Symweb?anchor=portable-pdbs

--- a/.pipelines/cs-pr-build.yaml
+++ b/.pipelines/cs-pr-build.yaml
@@ -18,16 +18,4 @@ variables:
   enableSigning: false
 
 steps:
-- task: NuGetCommand@2
-  inputs:
-    command: 'help'
-
-- task: NuGetToolInstaller@1
-  inputs:
-    versionSpec: '6.4.0'
-
-- task: NuGetCommand@2
-  inputs:
-    command: 'help'
-
 - template: cs-build-steps.yaml

--- a/.pipelines/cs-pr-build.yaml
+++ b/.pipelines/cs-pr-build.yaml
@@ -18,4 +18,8 @@ variables:
   enableSigning: false
 
 steps:
+- task: NuGetToolInstaller@1
+  inputs:
+    versionSpec: '6.4.0'
+
 - template: cs-build-steps.yaml

--- a/.pipelines/cs-pr-build.yaml
+++ b/.pipelines/cs-pr-build.yaml
@@ -18,8 +18,16 @@ variables:
   enableSigning: false
 
 steps:
+- task: NuGetCommand@2
+  inputs:
+    command: 'help'
+
 - task: NuGetToolInstaller@1
   inputs:
     versionSpec: '6.4.0'
+
+- task: NuGetCommand@2
+  inputs:
+    command: 'help'
 
 - template: cs-build-steps.yaml


### PR DESCRIPTION
Our build pipeline failed to publish the new .snupkg files to nuget.org because it was using an old version of the nuget CLI. This will install an appropriate version of nuget and prepend it to the build machine's PATH.

Here are some lines from our build pipeline output.

```
Detected NuGet version 4.1.0.2450 / 4.1.0
...

##[error]The nuget command failed with exit code(1) and error(System.AggregateException: One or more errors occurred. ---> System.Net.Http.HttpRequestException: Response status code does not indicate success: 400 (Snupkg upload failed. Please use latest NuGet clients (v 4.9.0 or above) and a V3 endpoint to push Symbol packages. For details, refer https://docs.microsoft.com/nuget/create-packages/symbol-packages-snupkg).
```