### PR TITLE
remove snupkg from nuget publish step

### DIFF
--- a/.pipelines/cs-ci-build.yaml
+++ b/.pipelines/cs-ci-build.yaml
@@ -83,6 +83,6 @@ steps:
   inputs:
     command: 'push'
     nugetFeedType: 'external'
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg;$(Build.ArtifactStagingDirectory)/*.snupkg'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
     publishFeedCredentials: 'dev-tunnels-nuget'
     publishPackageMetadata: true


### PR DESCRIPTION
This PR fixes a bug, which causes duplicate attempts to publihs snupkg to Nuget. It reverts one line of [this PR](https://github.com/microsoft/dev-tunnels/commit/5f128d4b193d0320204a86b4ed0a2bc84390e96d).

See this related PR for context: https://github.com/microsoft/dev-tunnels-ssh/pull/31

