### PR TITLE
Fix missing Implementation-Version from Java manifest

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -5,7 +5,9 @@ These instructions assume you are using vscode for development as SDK is configu
 1. Clone this repo and open the `java` folder in vscode.
 2. Install the recommended extension pack "Extension Pack for Java"
 3. The extension will prompt you to install a JDK. Choose JDK version 11 (LTS).
-4. Once you have the extension and JDK installed, run `mvn test` (see next section for test setup).
+4. Download and [install Maven](https://maven.apache.org/install.html).
+   - 👉 You may need to set up [M2_HOME and/or additional environment variables](https://www.tutorialspoint.com/maven/maven_environment_setup.htm) manually.
+5. Once you have the extension and JDK installed, run `mvn test` (see next section for test setup).
 
 ### Testing
 1. Get a user token using the CLI command: `user show --verbose`

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -157,6 +157,13 @@
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.0.2</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
## Summary
The Java SDK's jar file was missing the Implementation-Version header, which is forwarded by the SDK as the user agent version [here](https://github.com/microsoft/dev-tunnels/blob/29db4c551f21fbf066626be3d9bf175a8d439bd0/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java#L41).

This update to the pom.xml file ensures that these values are set ([plugin docs](https://maven.apache.org/shared/maven-archiver/index.html)).

## Verification Steps
I verified this fix by first building the jar before the change:
```
mvn -B package --file pom.xml -Drevision='1.1.1' -Dtest=TunnelContractsTests
```
and extracting/inspecting the produced manifest file, which did not contain the Implementation-Version header:
```
jar xvf .\target\tunnels-java-sdk-1.1.1.jar META-INF/MANIFEST
```

I repeated the same steps on a clean repo after the change and the Implementation-Version header _was_ included.