### PR TITLE
fix: rust build errors

### DIFF
--- a/cs/tools/TunnelsSDK.Generator/RustContractWriter.cs
+++ b/cs/tools/TunnelsSDK.Generator/RustContractWriter.cs
@@ -302,11 +302,11 @@ internal class RustContractWriter : ContractWriter
             string? memberExpression = null;
             if (field.ConstantValue is string stringValue)
             {
-                memberExpression = $"&str = \"{stringValue.Replace("\"", "\\\"")}\"";
+                memberExpression = $"&str = r#\"{stringValue}\"#";
             }
             else if (field.ConstantValue is int)
             {
-                memberExpression = $"&i32 = {field.ConstantValue}";
+                memberExpression = $"i32 = {field.ConstantValue}";
             }
 
             if (memberExpression != null)

--- a/rs/src/contracts/tunnel_access_control_entry.rs
+++ b/rs/src/contracts/tunnel_access_control_entry.rs
@@ -82,19 +82,19 @@ pub struct TunnelAccessControlEntry {
 // Constants for well-known identity providers.
 
 // Microsoft (AAD) identity provider.
-pub const PROVIDERS_MICROSOFT: &str = "microsoft";
+pub const PROVIDERS_MICROSOFT: &str = r#"microsoft"#;
 
 // GitHub identity provider.
-pub const PROVIDERS_GITHUB: &str = "github";
+pub const PROVIDERS_GITHUB: &str = r#"github"#;
 
 // SSH public keys.
-pub const PROVIDERS_SSH: &str = "ssh";
+pub const PROVIDERS_SSH: &str = r#"ssh"#;
 
 // IPv4 addresses.
-pub const PROVIDERS_IPV4: &str = "ipv4";
+pub const PROVIDERS_IPV4: &str = r#"ipv4"#;
 
 // IPv6 addresses.
-pub const PROVIDERS_IPV6: &str = "ipv6";
+pub const PROVIDERS_IPV6: &str = r#"ipv6"#;
 
 // Service tags.
-pub const PROVIDERS_SERVICE_TAG: &str = "service-tag";
+pub const PROVIDERS_SERVICE_TAG: &str = r#"service-tag"#;

--- a/rs/src/contracts/tunnel_access_scopes.rs
+++ b/rs/src/contracts/tunnel_access_scopes.rs
@@ -12,21 +12,21 @@
 // Allows creating tunnels. This scope is valid only in policies at the global, domain, or
 // organization level; it is not relevant to an already-created tunnel or tunnel port.
 // (Creation of ports requires "manage" or "host" access to the tunnel.)
-pub const TUNNEL_ACCESS_SCOPES_CREATE: &str = "create";
+pub const TUNNEL_ACCESS_SCOPES_CREATE: &str = r#"create"#;
 
 // Allows management operations on tunnels and tunnel ports.
-pub const TUNNEL_ACCESS_SCOPES_MANAGE: &str = "manage";
+pub const TUNNEL_ACCESS_SCOPES_MANAGE: &str = r#"manage"#;
 
 // Allows management operations on all ports of a tunnel, but does not allow updating any
 // other tunnel properties or deleting the tunnel.
-pub const TUNNEL_ACCESS_SCOPES_MANAGE_PORTS: &str = "manage:ports";
+pub const TUNNEL_ACCESS_SCOPES_MANAGE_PORTS: &str = r#"manage:ports"#;
 
 // Allows accepting connections on tunnels as a host. Includes access to update tunnel
 // endpoints and ports.
-pub const TUNNEL_ACCESS_SCOPES_HOST: &str = "host";
+pub const TUNNEL_ACCESS_SCOPES_HOST: &str = r#"host"#;
 
 // Allows inspecting tunnel connection activity and data.
-pub const TUNNEL_ACCESS_SCOPES_INSPECT: &str = "inspect";
+pub const TUNNEL_ACCESS_SCOPES_INSPECT: &str = r#"inspect"#;
 
 // Allows connecting to tunnels or ports as a client.
-pub const TUNNEL_ACCESS_SCOPES_CONNECT: &str = "connect";
+pub const TUNNEL_ACCESS_SCOPES_CONNECT: &str = r#"connect"#;

--- a/rs/src/contracts/tunnel_authentication_schemes.rs
+++ b/rs/src/contracts/tunnel_authentication_schemes.rs
@@ -5,10 +5,10 @@
 // Defines string constants for authentication schemes supported by tunnel service APIs.
 
 // Authentication scheme for AAD (or Microsoft account) access tokens.
-pub const TUNNEL_AUTHENTICATION_SCHEMES_AAD: &str = "aad";
+pub const TUNNEL_AUTHENTICATION_SCHEMES_AAD: &str = r#"aad"#;
 
 // Authentication scheme for GitHub access tokens.
-pub const TUNNEL_AUTHENTICATION_SCHEMES_GITHUB: &str = "github";
+pub const TUNNEL_AUTHENTICATION_SCHEMES_GITHUB: &str = r#"github"#;
 
 // Authentication scheme for tunnel access tokens.
-pub const TUNNEL_AUTHENTICATION_SCHEMES_TUNNEL: &str = "tunnel";
+pub const TUNNEL_AUTHENTICATION_SCHEMES_TUNNEL: &str = r#"tunnel"#;

--- a/rs/src/contracts/tunnel_constraints.rs
+++ b/rs/src/contracts/tunnel_constraints.rs
@@ -5,89 +5,89 @@
 // Tunnel constraints.
 
 // Min length of tunnel cluster ID.
-pub const CLUSTER_ID_MIN_LENGTH: &i32 = 3;
+pub const CLUSTER_ID_MIN_LENGTH: i32 = 3;
 
 // Max length of tunnel cluster ID.
-pub const CLUSTER_ID_MAX_LENGTH: &i32 = 12;
+pub const CLUSTER_ID_MAX_LENGTH: i32 = 12;
 
 // Length of tunnel id.
-pub const TUNNEL_ID_LENGTH: &i32 = 8;
+pub const TUNNEL_ID_LENGTH: i32 = 8;
 
 // Min length of tunnel name.
-pub const TUNNEL_NAME_MIN_LENGTH: &i32 = 3;
+pub const TUNNEL_NAME_MIN_LENGTH: i32 = 3;
 
 // Max length of tunnel name.
-pub const TUNNEL_NAME_MAX_LENGTH: &i32 = 60;
+pub const TUNNEL_NAME_MAX_LENGTH: i32 = 60;
 
 // Max length of tunnel or port description.
-pub const DESCRIPTION_MAX_LENGTH: &i32 = 400;
+pub const DESCRIPTION_MAX_LENGTH: i32 = 400;
 
 // Min length of a single tunnel or port tag.
-pub const TAG_MIN_LENGTH: &i32 = 1;
+pub const TAG_MIN_LENGTH: i32 = 1;
 
 // Max length of a single tunnel or port tag.
-pub const TAG_MAX_LENGTH: &i32 = 50;
+pub const TAG_MAX_LENGTH: i32 = 50;
 
 // Maximum number of tags that can be applied to a tunnel or port.
-pub const MAX_TAGS: &i32 = 100;
+pub const MAX_TAGS: i32 = 100;
 
 // Min length of a tunnel domain.
-pub const TUNNEL_DOMAIN_MIN_LENGTH: &i32 = 4;
+pub const TUNNEL_DOMAIN_MIN_LENGTH: i32 = 4;
 
 // Max length of a tunnel domain.
-pub const TUNNEL_DOMAIN_MAX_LENGTH: &i32 = 180;
+pub const TUNNEL_DOMAIN_MAX_LENGTH: i32 = 180;
 
 // Maximum number of items allowed in the tunnel ports array. The actual limit on number
 // of ports that can be created may be much lower, and may depend on various resource
 // limitations or policies.
-pub const TUNNEL_MAX_PORTS: &i32 = 1000;
+pub const TUNNEL_MAX_PORTS: i32 = 1000;
 
 // Maximum number of access control entries (ACEs) in a tunnel or tunnel port access
 // control list (ACL).
-pub const ACCESS_CONTROL_MAX_ENTRIES: &i32 = 40;
+pub const ACCESS_CONTROL_MAX_ENTRIES: i32 = 40;
 
 // Maximum number of subjects (such as user IDs) in a tunnel or tunnel port access control
 // entry (ACE).
-pub const ACCESS_CONTROL_MAX_SUBJECTS: &i32 = 100;
+pub const ACCESS_CONTROL_MAX_SUBJECTS: i32 = 100;
 
 // Max length of an access control subject or organization ID.
-pub const ACCESS_CONTROL_SUBJECT_MAX_LENGTH: &i32 = 200;
+pub const ACCESS_CONTROL_SUBJECT_MAX_LENGTH: i32 = 200;
 
 // Max length of an access control subject name, when resolving names to IDs.
-pub const ACCESS_CONTROL_SUBJECT_NAME_MAX_LENGTH: &i32 = 200;
+pub const ACCESS_CONTROL_SUBJECT_NAME_MAX_LENGTH: i32 = 200;
 
 // Maximum number of scopes in an access control entry.
-pub const ACCESS_CONTROL_MAX_SCOPES: &i32 = 10;
+pub const ACCESS_CONTROL_MAX_SCOPES: i32 = 10;
 
 // Regular expression that can match or validate tunnel cluster ID strings.
 //
 // Cluster IDs are alphanumeric; hyphens are not permitted.
-pub const CLUSTER_ID_PATTERN: &str = "[a-z][a-z0-9]{2,11}";
+pub const CLUSTER_ID_PATTERN: &str = r#"[a-z][a-z0-9]{2,11}"#;
 
 // Characters that are valid in tunnel IDs. Includes numbers and lowercase letters,
 // excluding vowels and 'y' (to avoid accidentally generating any random words).
-pub const TUNNEL_ID_CHARS: &str = "0123456789bcdfghjklmnpqrstvwxz";
+pub const TUNNEL_ID_CHARS: &str = r#"0123456789bcdfghjklmnpqrstvwxz"#;
 
 // Regular expression that can match or validate tunnel ID strings.
 //
 // Tunnel IDs are fixed-length and have a limited character set of numbers and lowercase
 // letters (minus vowels and y).
-pub const TUNNEL_ID_PATTERN: &str = "[0123456789bcdfghjklmnpqrstvwxz]{8}";
+pub const TUNNEL_ID_PATTERN: &str = r#"[0123456789bcdfghjklmnpqrstvwxz]{8}"#;
 
 // Regular expression that can match or validate tunnel names.
 //
 // Tunnel names are alphanumeric and may contain hyphens. The pattern also allows an empty
 // string because tunnels may be unnamed.
-pub const TUNNEL_NAME_PATTERN: &str = "([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|";
+pub const TUNNEL_NAME_PATTERN: &str = r#"([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|"#;
 
 // Regular expression that can match or validate tunnel or port tags.
-pub const TAG_PATTERN: &str = "[\w-=]{1,50}";
+pub const TAG_PATTERN: &str = r#"[\w-=]{1,50}"#;
 
 // Regular expression that can match or validate tunnel domains.
 //
 // The tunnel service may perform additional contextual validation at the time the domain
 // is registered.
-pub const TUNNEL_DOMAIN_PATTERN: &str = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]";
+pub const TUNNEL_DOMAIN_PATTERN: &str = r#"[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]"#;
 
 // Regular expression that can match or validate an access control subject or organization
 // ID.
@@ -95,7 +95,7 @@ pub const TUNNEL_DOMAIN_PATTERN: &str = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]";
 // The : and / characters are allowed because subjects may include IP addresses and
 // ranges. The @ character is allowed because MSA subjects may be identified by email
 // address.
-pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = "[0-9a-zA-Z-._:/@]{0,200}";
+pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = r#"[0-9a-zA-Z-._:/@]{0,200}"#;
 
 // Regular expression that can match or validate an access control subject name, when
 // resolving subject names to IDs.
@@ -103,4 +103,4 @@ pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = "[0-9a-zA-Z-._:/@]{0,200}";
 // Note angle-brackets are only allowed when they wrap an email address as part of a
 // formatted name with email. The service will block any other use of angle-brackets, to
 // avoid any XSS risks.
-pub const ACCESS_CONTROL_SUBJECT_NAME_PATTERN: &str = "[ \w\d-.,/'\"_@()<>]{0,200}";
+pub const ACCESS_CONTROL_SUBJECT_NAME_PATTERN: &str = r#"[ \w\d-.,/'"_@()<>]{0,200}"#;

--- a/rs/src/contracts/tunnel_header_names.rs
+++ b/rs/src/contracts/tunnel_header_names.rs
@@ -8,14 +8,14 @@
 // authenticate and authorize the client. The format of the value is the same as
 // Authorization header that is sent to the Tunnel service by the tunnel SDK. Supported
 // schemes: "tunnel" with the tunnel access JWT good for 'Connect' scope.
-pub const X_TUNNEL_AUTHORIZATION: &str = "X-Tunnel-Authorization";
+pub const X_TUNNEL_AUTHORIZATION: &str = r#"X-Tunnel-Authorization"#;
 
 // Request ID header that nginx ingress controller adds to all requests if it's not there.
-pub const X_REQUEST_ID: &str = "X-Request-ID";
+pub const X_REQUEST_ID: &str = r#"X-Request-ID"#;
 
 // Github Ssh public key which can be used to validate if it belongs to tunnel's owner.
-pub const X_GITHUB_SSH_KEY: &str = "X-Github-Ssh-Key";
+pub const X_GITHUB_SSH_KEY: &str = r#"X-Github-Ssh-Key"#;
 
 // Header that will skip the antiphishing page when connection to a tunnel through web
 // forwarding.
-pub const X_TUNNEL_SKIP_ANTIPHISHING_PAGE: &str = "X-Tunnel-Skip-AntiPhishing-Page";
+pub const X_TUNNEL_SKIP_ANTIPHISHING_PAGE: &str = r#"X-Tunnel-Skip-AntiPhishing-Page"#;

--- a/rs/src/contracts/tunnel_protocol.rs
+++ b/rs/src/contracts/tunnel_protocol.rs
@@ -5,22 +5,22 @@
 // Defines possible values for the protocol of a `TunnelPort`.
 
 // The protocol is automatically detected. (TODO: Define detection semantics.)
-pub const TUNNEL_PROTOCOL_AUTO: &str = "auto";
+pub const TUNNEL_PROTOCOL_AUTO: &str = r#"auto"#;
 
 // Unknown TCP protocol.
-pub const TUNNEL_PROTOCOL_TCP: &str = "tcp";
+pub const TUNNEL_PROTOCOL_TCP: &str = r#"tcp"#;
 
 // Unknown UDP protocol.
-pub const TUNNEL_PROTOCOL_UDP: &str = "udp";
+pub const TUNNEL_PROTOCOL_UDP: &str = r#"udp"#;
 
 // SSH protocol.
-pub const TUNNEL_PROTOCOL_SSH: &str = "ssh";
+pub const TUNNEL_PROTOCOL_SSH: &str = r#"ssh"#;
 
 // Remote desktop protocol.
-pub const TUNNEL_PROTOCOL_RDP: &str = "rdp";
+pub const TUNNEL_PROTOCOL_RDP: &str = r#"rdp"#;
 
 // HTTP protocol.
-pub const TUNNEL_PROTOCOL_HTTP: &str = "http";
+pub const TUNNEL_PROTOCOL_HTTP: &str = r#"http"#;
 
 // HTTPS protocol.
-pub const TUNNEL_PROTOCOL_HTTPS: &str = "https";
+pub const TUNNEL_PROTOCOL_HTTPS: &str = r#"https"#;

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -17,7 +17,7 @@ use crate::contracts::{
 
 use super::{
     Authorization, AuthorizationProvider, HttpError, HttpResult, ResponseError, TunnelLocator,
-    TunnelRequestOptions,
+    TunnelRequestOptions, NO_REQUEST_OPTIONS,
 };
 
 #[derive(Clone)]
@@ -90,15 +90,17 @@ impl TunnelManagementClient {
         self.execute_json("create_tunnel", request).await
     }
 
-     /// Gets if tunnel name is avilable.
-     pub async fn check_name_availability(
-        &self,
-        name : &str,
-    ) -> HttpResult<bool> {
-        let path = format!("{}/{}{}", TUNNELS_API_PATH, name, CHECK_TUNNEL_NAME_SUB_PATH);
-        let mut url = self.build_uri(None, path);
+    /// Gets if tunnel name is avilable.
+    pub async fn check_name_availability(&self, name: &str) -> HttpResult<bool> {
+        let path = format!(
+            "{}/{}{}",
+            TUNNELS_API_PATH, name, CHECK_TUNNEL_NAME_SUB_PATH
+        );
+        let url = self.build_uri(None, &path);
 
-        let request = self.make_tunnel_request(Method::GET, url, NO_REQUEST_OPTIONS).await?;
+        let request = self
+            .make_tunnel_request(Method::GET, url, NO_REQUEST_OPTIONS)
+            .await?;
         self.execute_json("get_name_availability", request).await
     }
 


### PR DESCRIPTION
The latest Rust code was not compiling. Fixes that.

It'd be nice to add CI for Rust to avoid these kinds of breakages; e.g. it looks like at one point new code was added that didn't compile.