### PR TITLE
rust: add support for HTTPS_PROXY

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "eslint.workingDirectories": [
         "ts"
-    ]
+    ],
+    "rust-analyzer.cargo.features": ["connections", "vendored-openssl"],
 }

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -1739,6 +1739,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "hyper",
  "log",
  "opentelemetry",
  "rand 0.8.5",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -21,7 +21,7 @@ tungstenite = { version = "0.17", optional = true }
 uuid = { version = "0.8.2", features = ["v4"], optional = true }
 russh = { version = "0.34.0-beta.16", default-features = false, features = ["openssl", "flate2"], optional = true }
 russh-keys = { version = "0.22.0-beta.7", default-features = false, features = ["openssl"], optional = true }
-
+hyper = "0.14"
 
 [dev-dependencies]
 tokio = { version = "1.20", features = ["full"] }

--- a/rs/src/connections/errors.rs
+++ b/rs/src/connections/errors.rs
@@ -26,4 +26,13 @@ pub enum TunnelError {
 
     #[error("port {0} already exists in the relay")]
     PortAlreadyExists(u32),
+
+    #[error("proxy connection failed: {0}")]
+    ProxyConnectionFailed(std::io::Error),
+
+    #[error("proxy handshake failed: {0}")]
+    ProxyHandshakeFailed(hyper::Error),
+
+    #[error("proxy connect request failed: {0}")]
+    ProxyConnectRequestFailed(hyper::Error)
 }


### PR DESCRIPTION
Tungstenite [doesn't support proxies](https://github.com/snapview/tungstenite-rs/issues/177) automatically like reqwest does, so this adds support for them in the SDK.

Request on VS Code's side: https://github.com/microsoft/vscode/issues/169333