### PR TITLE
Fix rust agent header and empty query string

### DIFF
--- a/rs/CONTRIBUTING.md
+++ b/rs/CONTRIBUTING.md
@@ -7,3 +7,7 @@ dotnet build --no-incremental
 ```
 
 We then have some end-to-end tests in the management client. These can be executed by first setting a the `TUNNEL_TEST_CLIENT_ID` to some valid AAD app ID, and then running `cargo test --features end_to_end -- --nocapture`. The first time you run the tests, you will be prompted to log in with device code authentication.
+
+## Code Style and Formatting
+
+Before checking in, please run `cargo fmt` to format your changes (or use an IDE with a Rust analyzer to format your files).

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -44,6 +44,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1223,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1768,7 @@ dependencies = [
  "log",
  "opentelemetry",
  "rand 0.8.5",
+ "regex",
  "reqwest",
  "russh",
  "russh-keys",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -26,6 +26,7 @@ russh-keys = { version = "0.22.0-beta.7", default-features = false, features = [
 [dev-dependencies]
 tokio = { version = "1.20", features = ["full"] }
 rand = "0.8"
+regex = "1"
 
 [features]
 default = []

--- a/rs/src/contracts/tunnel.rs
+++ b/rs/src/contracts/tunnel.rs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/Tunnel.cs
 
-use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControl;
 use crate::contracts::TunnelEndpoint;
 use crate::contracts::TunnelOptions;
 use crate::contracts::TunnelPort;
 use crate::contracts::TunnelStatus;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/rs/src/contracts/tunnel_port.rs
+++ b/rs/src/contracts/tunnel_port.rs
@@ -43,7 +43,7 @@ pub struct TunnelPort {
     // A client that connects to a tunnel (by ID or name) without specifying a port number
     // will connect to the default port for the tunnel, if a default is configured. Or if
     // the tunnel has only one port then the single port is the implicit default.
-    // 
+    //
     // Selection of a default port for a connection also depends on matching the
     // connection to the port `TunnelPort.Protocol`, so it is possible to configure
     // separate defaults for distinct protocols like `TunnelProtocol.Http` and

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -32,6 +32,8 @@ const TUNNELS_API_PATH: &str = "/api/v1/tunnels";
 const ENDPOINTS_API_SUB_PATH: &str = "endpoints";
 const PORTS_API_SUB_PATH: &str = "ports";
 const CHECK_TUNNEL_NAME_SUB_PATH: &str = "/checkNameAvailability";
+const PKG_VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
+
 impl TunnelManagementClient {
     /// Returns a builder that creates a new client, starting with the current
     /// client's options.
@@ -472,12 +474,14 @@ pub struct TunnelClientBuilder {
 /// Creates a new tunnel client builder. You can set options, then use `into()`
 /// to get the client instance (or cast automatically).
 pub fn new_tunnel_management(user_agent: &str) -> TunnelClientBuilder {
+    let pkg_version: &str = PKG_VERSION.unwrap_or("unknown");
+    let fq_user_agent = format!("{}{}{}", user_agent, " Visual-Studio-Tunnel-Service-Rust-SDK/", pkg_version);
     TunnelClientBuilder {
         authorization: Arc::new(Box::new(super::StaticAuthorizationProvider(
             Authorization::Anonymous,
         ))),
         client: None,
-        user_agent: HeaderValue::from_str(user_agent).unwrap(),
+        user_agent: HeaderValue::from_str(&fq_user_agent).unwrap(),
         environment: env_production(),
     }
 }

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -474,14 +474,14 @@ pub struct TunnelClientBuilder {
 /// Creates a new tunnel client builder. You can set options, then use `into()`
 /// to get the client instance (or cast automatically).
 pub fn new_tunnel_management(user_agent: &str) -> TunnelClientBuilder {
-    let pkg_version: &str = PKG_VERSION.unwrap_or("unknown");
-    let fq_user_agent = format!("{}{}{}", user_agent, " Visual-Studio-Tunnel-Service-Rust-SDK/", pkg_version);
+    let pkg_version = PKG_VERSION.unwrap_or("unknown");
+    let full_user_agent = format!("{}{}{}", user_agent, " Visual-Studio-Tunnel-Service-Rust-SDK/", pkg_version);
     TunnelClientBuilder {
         authorization: Arc::new(Box::new(super::StaticAuthorizationProvider(
             Authorization::Anonymous,
         ))),
         client: None,
-        user_agent: HeaderValue::from_str(&fq_user_agent).unwrap(),
+        user_agent: HeaderValue::from_str(&full_user_agent).unwrap(),
         environment: env_production(),
     }
 }

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -398,7 +398,7 @@ impl TunnelManagementClient {
         mut url: Url,
         tunnel_opts: &TunnelRequestOptions,
     ) -> HttpResult<Request> {
-        url = add_query(url, tunnel_opts);
+        add_query(&mut url, tunnel_opts);
         let mut request = self.make_request(method, url).await?;
 
         let headers = request.headers_mut();
@@ -452,7 +452,10 @@ pub struct TunnelClientBuilder {
 /// to get the client instance (or cast automatically).
 pub fn new_tunnel_management(user_agent: &str) -> TunnelClientBuilder {
     let pkg_version = PKG_VERSION.unwrap_or("unknown");
-    let full_user_agent = format!("{}{}{}", user_agent, " Visual-Studio-Tunnel-Service-Rust-SDK/", pkg_version);
+    let full_user_agent = format!(
+        "{}{}{}",
+        user_agent, " Visual-Studio-Tunnel-Service-Rust-SDK/", pkg_version
+    );
     TunnelClientBuilder {
         authorization: Arc::new(Box::new(super::StaticAuthorizationProvider(
             Authorization::Anonymous,
@@ -499,31 +502,32 @@ impl From<TunnelClientBuilder> for TunnelManagementClient {
     }
 }
 
-fn add_query(mut url: Url, tunnel_opts: &TunnelRequestOptions) -> Url
-{
+fn add_query(url: &mut Url, tunnel_opts: &TunnelRequestOptions) {
     if tunnel_opts.include_ports {
         url.query_pairs_mut().append_pair("includePorts", "true");
     }
     if tunnel_opts.include_access_control {
-        url.query_pairs_mut().append_pair("includeAccessControl", "true");
+        url.query_pairs_mut()
+            .append_pair("includeAccessControl", "true");
     }
     if !tunnel_opts.token_scopes.is_empty() {
-        url.query_pairs_mut().append_pair("tokenScopes", &tunnel_opts.token_scopes.join(","));
+        url.query_pairs_mut()
+            .append_pair("tokenScopes", &tunnel_opts.token_scopes.join(","));
     }
     if tunnel_opts.force_rename {
         url.query_pairs_mut().append_pair("forceRename", "true");
     }
     if !tunnel_opts.tags.is_empty() {
-        url.query_pairs_mut().append_pair("tags", &tunnel_opts.tags.join(","));
+        url.query_pairs_mut()
+            .append_pair("tags", &tunnel_opts.tags.join(","));
         if tunnel_opts.require_all_tags {
             url.query_pairs_mut().append_pair("allTags", "true");
         }
     }
     if tunnel_opts.limit > 0 {
-        url.query_pairs_mut().append_pair("limit", &tunnel_opts.limit.to_string());
+        url.query_pairs_mut()
+            .append_pair("limit", &tunnel_opts.limit.to_string());
     }
-
-    url
 }
 
 // End to end tests can be run with `cargo test --features end_to_end -- --nocapture`
@@ -665,9 +669,12 @@ mod tests {
     fn new_tunnel_management_has_user_agent() {
         // test
         let builder = super::new_tunnel_management("test-caller");
-        
+
         // verify
-        let re = Regex::new(r"^test-caller Visual-Studio-Tunnel-Service-Rust-SDK/[0-9]+\.[0-9]+\.[0-9]+$").unwrap();
+        let re = Regex::new(
+            r"^test-caller Visual-Studio-Tunnel-Service-Rust-SDK/[0-9]+\.[0-9]+\.[0-9]+$",
+        )
+        .unwrap();
         let full_agent = builder.user_agent.to_str().unwrap();
         assert!(re.is_match(full_agent));
     }
@@ -676,8 +683,8 @@ mod tests {
     fn add_query_omits_empty_query() {
         let mut url = Url::parse("https://tunnels.api.visualstudio.com/api/v1/tunnels").unwrap();
         let options = NO_REQUEST_OPTIONS;
-        
-        url = super::add_query(url, options);
+
+        super::add_query(&mut url, options);
 
         assert!(!url.to_string().ends_with("?"));
     }
@@ -687,9 +694,9 @@ mod tests {
         let mut url = Url::parse("https://tunnels.api.visualstudio.com/api/v1/tunnels").unwrap();
         let mut options = NO_REQUEST_OPTIONS.clone();
         options.include_ports = true;
-        
-        url = super::add_query(url, &options);
-        
+
+        super::add_query(&mut url, &options);
+
         assert!(url.query().unwrap().contains("includePorts=true"));
     }
 }

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -649,3 +649,19 @@ mod test_end_to_end {
         c.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use regex::Regex;
+
+    #[test]
+    fn new_tunnel_management_has_user_agent() {
+        // test
+        let builder = super::new_tunnel_management("test-caller");
+        
+        // verify
+        let re = Regex::new(r"^test-caller Visual-Studio-Tunnel-Service-Rust-SDK/[0-9]+\.[0-9]+\.[0-9]+$").unwrap();
+        let full_agent = builder.user_agent.to_str().unwrap();
+        assert!(re.is_match(full_agent));
+    }
+}


### PR DESCRIPTION
Cleans up the Rust http_client

### Changes proposed: 
- Ensure that the rust SDK version is included in the user agent header
- Fix a rust bug that appended `?` to URLs, even when there is no query string


