### PR TITLE
Negotiate relay connection protocol version

### DIFF
--- a/cs/src/Connections/IRelayClient.cs
+++ b/cs/src/Connections/IRelayClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IRelayClient.cs" company="Microsoft">
+// <copyright file="IRelayClient.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>
@@ -31,6 +31,11 @@ internal interface IRelayClient
     /// Create stream to the tunnel.
     /// </summary>
     Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation);
+
+    /// <summary>
+    /// Gets the connection protocol (websocket subprotocol) that was negotiated between client and server.
+    /// </summary>
+    string? ConnectionProtocol { get; }
 
     /// <summary>
     /// Configures tunnel SSH session with the given stream.

--- a/cs/src/Connections/ITunnelRelayStreamFactory.cs
+++ b/cs/src/Connections/ITunnelRelayStreamFactory.cs
@@ -27,14 +27,15 @@ namespace Microsoft.DevTunnels.Connections
         /// </summary>
         /// <param name="relayUri">URI of the tunnel relay to connect to.</param>
         /// <param name="accessToken">Tunnel host access token, or null if anonymous.</param>
-        /// <param name="connectionType">Type of stream connection to create, aka
-        /// websocket sub-protocol.</param>
+        /// <param name="subprotocols">One or more websocket subprotocols (relay connection
+        /// protocols).</param>
         /// <param name="cancellation">Cancellation token.</param>
-        /// <returns>Stream connected to the relay.</returns>
-        Task<Stream> CreateRelayStreamAsync(
+        /// <returns>Stream connected to the relay, along with the actual subprotocol that was
+        /// selected by the server.</returns>
+        Task<(Stream Stream, string SubProtocol)> CreateRelayStreamAsync(
             Uri relayUri,
             string? accessToken,
-            string connectionType,
+            string[] subprotocols,
             CancellationToken cancellation);
     }
 }

--- a/cs/src/Connections/TunnelRelayStreamFactory.cs
+++ b/cs/src/Connections/TunnelRelayStreamFactory.cs
@@ -17,15 +17,18 @@ namespace Microsoft.DevTunnels.Connections
     public class TunnelRelayStreamFactory : ITunnelRelayStreamFactory
     {
         /// <inheritdoc/>
-        public virtual async Task<Stream> CreateRelayStreamAsync(
+        public virtual async Task<(Stream Stream, string SubProtocol)> CreateRelayStreamAsync(
             Uri relayUri,
             string? accessToken,
-            string connectionType,
+            string[] subprotocols,
             CancellationToken cancellation)
         {
             void ConfigureWebSocketOptions(ClientWebSocketOptions options)
             {
-                options.AddSubProtocol(connectionType);
+                foreach (var subprotocol in subprotocols)
+                {
+                    options.AddSubProtocol(subprotocol);
+                }
                 options.UseDefaultCredentials = false;
                 if (!string.IsNullOrEmpty(accessToken))
                 {
@@ -35,7 +38,7 @@ namespace Microsoft.DevTunnels.Connections
 
             var stream = await WebSocketStream.ConnectToWebSocketAsync(
                 relayUri, ConfigureWebSocketOptions, cancellation);
-            return stream;
+            return (stream, stream.SubProtocol);
         }
     }
 }

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -14,162 +14,172 @@ using Microsoft.DevTunnels.Ssh;
 using Microsoft.DevTunnels.Contracts;
 using Microsoft.DevTunnels.Management;
 
-namespace Microsoft.DevTunnels.Connections
+namespace Microsoft.DevTunnels.Connections;
+
+/// <summary>
+/// Tunnel client implementation that connects via a tunnel relay.
+/// </summary>
+public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
 {
     /// <summary>
-    /// Tunnel client implementation that connects via a tunnel relay.
+    /// Web socket sub-protocol to connect to the tunnel relay endpoint with v1 client protocol.
     /// </summary>
-    public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
+    public const string WebSocketSubProtocol = "tunnel-relay-client";
+
+    /// <summary>
+    /// Web socket sub-protocol to connect to the tunnel relay endpoint with v2 client protocol.
+    /// </summary>
+    public const string WebSocketSubProtocolV2 = "tunnel-relay-client-v2";
+
+    private Uri? relayUri;
+
+    /// <summary>
+    /// Creates a new instance of a client that connects to a tunnel via a tunnel relay.
+    /// </summary>
+    public TunnelRelayTunnelClient(TraceSource trace) : this(managementClient: null, trace)
     {
-        /// <summary>
-        /// Web socket sub-protocol to connect to the tunnel relay endpoint.
-        /// </summary>
-        public const string WebSocketSubProtocol = "tunnel-relay-client";
-
-        private Uri? relayUri;
-
-        /// <summary>
-        /// Creates a new instance of a client that connects to a tunnel via a tunnel relay.
-        /// </summary>
-        public TunnelRelayTunnelClient(TraceSource trace) : this(managementClient: null, trace)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new instance of a client that connects to a tunnel via a tunnel relay.
-        /// </summary>
-        public TunnelRelayTunnelClient(ITunnelManagementClient? managementClient, TraceSource trace) : base(managementClient, trace) { }
-
-        /// <summary>
-        /// Gets or sets a factory for creating relay streams.
-        /// </summary>
-        /// <remarks>
-        /// Normally the default <see cref="TunnelRelayStreamFactory" /> can be used. However a
-        /// different factory class may be used to customize the connection (or mock the connection
-        /// for testing).
-        /// </remarks>
-        public ITunnelRelayStreamFactory StreamFactory { get; set; } = new TunnelRelayStreamFactory();
-
-        /// <inheritdoc />
-        public override IReadOnlyCollection<TunnelConnectionMode> ConnectionModes
-             => new[] { TunnelConnectionMode.TunnelRelay };
-
-        /// <inheritdoc />
-        protected override Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
-        {
-            Requires.NotNull(Tunnel!, nameof(Tunnel));
-            Requires.NotNull(Tunnel.Endpoints!, nameof(Tunnel.Endpoints));
-
-            var endpointGroups = Tunnel.Endpoints.GroupBy((ep) => ep.HostId).ToArray();
-            IGrouping<string?, TunnelEndpoint> endpoints;
-            if (HostId != null)
-            {
-                endpoints = endpointGroups.SingleOrDefault((g) => g.Key == HostId) ??
-                    throw new InvalidOperationException(
-                        "The specified host is not currently accepting connections to the tunnel.");
-            }
-            else if (endpointGroups.Length > 1)
-            {
-                throw new InvalidOperationException(
-                    "There are multiple hosts for the tunnel. Specify a host ID to connect to.");
-            }
-            else
-            {
-                endpoints = endpointGroups.Single();
-            }
-
-            var endpoint = endpoints
-                .OfType<TunnelRelayTunnelEndpoint>()
-                .SingleOrDefault() ??
-                throw new InvalidOperationException(
-                    "The host is not currently accepting Tunnel relay connections.");
-
-            Requires.Argument(
-                !string.IsNullOrEmpty(endpoint?.ClientRelayUri),
-                nameof(Tunnel),
-                $"The tunnel client relay endpoint URI is missing.");
-
-            // The access token might be null if connecting to a tunnel that allows anonymous access.
-            Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken);
-            this.relayUri = new Uri(endpoint.ClientRelayUri, UriKind.Absolute);
-
-            ITunnelConnector result = new RelayTunnelConnector(this);
-            return Task.FromResult(result);
-        }
-
-        /// <summary>
-        /// Connect to the clientRelayUri using accessToken.
-        /// </summary>
-        protected Task ConnectAsync(string clientRelayUri, string? accessToken, CancellationToken cancellation)
-        {
-            Requires.NotNull(clientRelayUri, nameof(clientRelayUri));
-            return ConnectTunnelSessionAsync(
-                (cancellation) =>
-                {
-                    this.relayUri = new Uri(clientRelayUri, UriKind.Absolute);
-                    this.accessToken = accessToken;
-                    this.connector = new RelayTunnelConnector(this);
-                    return this.connector.ConnectSessionAsync(isReconnect: false, cancellation);
-                },
-                cancellation);
-        }
-
-        /// <summary>
-        /// Create stream to the tunnel.
-        /// </summary>
-        protected virtual Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
-        {
-            ValidateAccessToken();
-            Trace.TraceInformation("Connecting to client tunnel relay {0}", this.relayUri!.AbsoluteUri);
-            return this.StreamFactory.CreateRelayStreamAsync(
-                this.relayUri!,
-                this.accessToken,
-                WebSocketSubProtocol,
-                cancellation);
-        }
-
-        /// <summary>
-        /// Configures tunnel SSH session with the given stream.
-        /// </summary>
-        protected virtual async Task ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
-        {
-            if (isReconnect && SshSession != null && !SshSession.IsClosed)
-            {
-                await SshSession.ReconnectAsync(stream, cancellation);
-            }
-            else
-            {
-                await StartSshSessionAsync(stream, cancellation);
-            }
-        }
-
-        #region IRelayClient
-
-        /// <inheritdoc />
-        string IRelayClient.TunnelAccessScope => TunnelAccessScope;
-
-        /// <inheritdoc />
-        TraceSource IRelayClient.Trace => Trace;
-
-        /// <inheritdoc />
-        Task<Stream> IRelayClient.CreateSessionStreamAsync(CancellationToken cancellation) => 
-            CreateSessionStreamAsync(cancellation);
-
-        /// <inheritdoc />
-        Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception) =>
-            CloseSessionAsync(disconnectReason, exception);
-
-        /// <inheritdoc />
-        Task IRelayClient.ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation) =>
-            ConfigureSessionAsync(stream, isReconnect, cancellation);
-
-        /// <inheritdoc />
-        Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>
-            RefreshTunnelAccessTokenAsync(cancellation);
-
-        /// <inheritdoc />
-        void IRelayClient.OnRetrying(RetryingTunnelConnectionEventArgs e) => OnRetrying(e);
-
-        #endregion IRelayClient
     }
+
+    /// <summary>
+    /// Creates a new instance of a client that connects to a tunnel via a tunnel relay.
+    /// </summary>
+    public TunnelRelayTunnelClient(ITunnelManagementClient? managementClient, TraceSource trace) : base(managementClient, trace) { }
+
+    /// <inheritdoc/>
+    public string? ConnectionProtocol { get; private set; }
+
+    /// <summary>
+    /// Gets or sets a factory for creating relay streams.
+    /// </summary>
+    /// <remarks>
+    /// Normally the default <see cref="TunnelRelayStreamFactory" /> can be used. However a
+    /// different factory class may be used to customize the connection (or mock the connection
+    /// for testing).
+    /// </remarks>
+    public ITunnelRelayStreamFactory StreamFactory { get; set; } = new TunnelRelayStreamFactory();
+
+    /// <inheritdoc />
+    public override IReadOnlyCollection<TunnelConnectionMode> ConnectionModes
+         => new[] { TunnelConnectionMode.TunnelRelay };
+
+    /// <inheritdoc />
+    protected override Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
+    {
+        Requires.NotNull(Tunnel!, nameof(Tunnel));
+        Requires.NotNull(Tunnel.Endpoints!, nameof(Tunnel.Endpoints));
+
+        var endpointGroups = Tunnel.Endpoints.GroupBy((ep) => ep.HostId).ToArray();
+        IGrouping<string?, TunnelEndpoint> endpoints;
+        if (HostId != null)
+        {
+            endpoints = endpointGroups.SingleOrDefault((g) => g.Key == HostId) ??
+                throw new InvalidOperationException(
+                    "The specified host is not currently accepting connections to the tunnel.");
+        }
+        else if (endpointGroups.Length > 1)
+        {
+            throw new InvalidOperationException(
+                "There are multiple hosts for the tunnel. Specify a host ID to connect to.");
+        }
+        else
+        {
+            endpoints = endpointGroups.Single();
+        }
+
+        var endpoint = endpoints
+            .OfType<TunnelRelayTunnelEndpoint>()
+            .SingleOrDefault() ??
+            throw new InvalidOperationException(
+                "The host is not currently accepting Tunnel relay connections.");
+
+        Requires.Argument(
+            !string.IsNullOrEmpty(endpoint?.ClientRelayUri),
+            nameof(Tunnel),
+            $"The tunnel client relay endpoint URI is missing.");
+
+        // The access token might be null if connecting to a tunnel that allows anonymous access.
+        Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken);
+        this.relayUri = new Uri(endpoint.ClientRelayUri, UriKind.Absolute);
+
+        ITunnelConnector result = new RelayTunnelConnector(this);
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Connect to the clientRelayUri using accessToken.
+    /// </summary>
+    protected Task ConnectAsync(string clientRelayUri, string? accessToken, CancellationToken cancellation)
+    {
+        Requires.NotNull(clientRelayUri, nameof(clientRelayUri));
+        return ConnectTunnelSessionAsync(
+            (cancellation) =>
+            {
+                this.relayUri = new Uri(clientRelayUri, UriKind.Absolute);
+                this.accessToken = accessToken;
+                this.connector = new RelayTunnelConnector(this);
+                return this.connector.ConnectSessionAsync(isReconnect: false, cancellation);
+            },
+            cancellation);
+    }
+
+    /// <summary>
+    /// Create stream to the tunnel.
+    /// </summary>
+    protected virtual async Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
+    {
+        ValidateAccessToken();
+        Trace.TraceInformation("Connecting to client tunnel relay {0}", this.relayUri!.AbsoluteUri);
+        var (stream, subprotocol) = await this.StreamFactory.CreateRelayStreamAsync(
+            this.relayUri!,
+            this.accessToken,
+            new[] { WebSocketSubProtocol },
+            cancellation);
+        Trace.TraceEvent(TraceEventType.Verbose, 0, "Connected with subprotocol '{0}'", subprotocol);
+        ConnectionProtocol = subprotocol;
+        return stream;
+    }
+
+    /// <summary>
+    /// Configures tunnel SSH session with the given stream.
+    /// </summary>
+    protected virtual async Task ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
+    {
+        if (isReconnect && SshSession != null && !SshSession.IsClosed)
+        {
+            await SshSession.ReconnectAsync(stream, cancellation);
+        }
+        else
+        {
+            await StartSshSessionAsync(stream, cancellation);
+        }
+    }
+
+    #region IRelayClient
+
+    /// <inheritdoc />
+    string IRelayClient.TunnelAccessScope => TunnelAccessScope;
+
+    /// <inheritdoc />
+    TraceSource IRelayClient.Trace => Trace;
+
+    /// <inheritdoc />
+    Task<Stream> IRelayClient.CreateSessionStreamAsync(CancellationToken cancellation) => 
+        CreateSessionStreamAsync(cancellation);
+
+    /// <inheritdoc />
+    Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception) =>
+        CloseSessionAsync(disconnectReason, exception);
+
+    /// <inheritdoc />
+    Task IRelayClient.ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation) =>
+        ConfigureSessionAsync(stream, isReconnect, cancellation);
+
+    /// <inheritdoc />
+    Task<bool> IRelayClient.RefreshTunnelAccessTokenAsync(CancellationToken cancellation) =>
+        RefreshTunnelAccessTokenAsync(cancellation);
+
+    /// <inheritdoc />
+    void IRelayClient.OnRetrying(RetryingTunnelConnectionEventArgs e) => OnRetrying(e);
+
+    #endregion IRelayClient
 }

--- a/cs/src/Connections/WebSocketStream.cs
+++ b/cs/src/Connections/WebSocketStream.cs
@@ -66,6 +66,11 @@ namespace Microsoft.DevTunnels.Connections
         }
 
         /// <summary>
+        /// Gets the websocket sub-protocol.
+        /// </summary>
+        public string SubProtocol => this.socket.SubProtocol!;
+
+        /// <summary>
         /// Current web socket close status or null if not closed.
         /// </summary>
         public WebSocketCloseStatus? CloseStatus

--- a/cs/test/TunnelsSDK.Test/Mocks/MockTunnelRelayStreamFactory.cs
+++ b/cs/test/TunnelsSDK.Test/Mocks/MockTunnelRelayStreamFactory.cs
@@ -17,16 +17,17 @@ public class MockTunnelRelayStreamFactory : ITunnelRelayStreamFactory
 
     public Func<string, Task<Stream>> StreamFactory { get; set; }
 
-    public Task<Stream> CreateRelayStreamAsync(
+    public async Task<(Stream, string)> CreateRelayStreamAsync(
         Uri relayUri,
         string accessToken,
-        string connectionType,
+        string[] subprotocols,
         CancellationToken cancellation)
     {
         Assert.NotNull(relayUri);
         Assert.NotNull(accessToken);
-        Assert.Equal(this.connectionType, connectionType);
+        Assert.Contains(this.connectionType, subprotocols);
 
-        return StreamFactory(accessToken);
+        var stream = await StreamFactory(accessToken);
+        return (stream, this.connectionType);
     }
 }


### PR DESCRIPTION
This change adds support for negotiating the relay connection protocol version via the websocket subprotocol. Actual implementation of the v2 protocol is not included; that will come later.

 - Update `TunnelRelayStreamFactory` to support _requesting_ multiple protocols and _returning_ the single negotiated protocol selected by the service.
 - Add a public `ConnectionProtocol` property to tunnel host and client. (This property will primarily be used by the relay service to follow a different code path depending on the protocol version.)
 - Log the negotiated connection protocol in the verbose log. 