### PR TITLE
Support local testing for Java SDK

### DIFF
--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -284,13 +284,13 @@ public class TunnelManagementClient implements ITunnelManagementClient {
       throw new Error("Error parsing URI: " + this.baseAddress);
     }
     String host = null;
-    int port = -1;
+    int port = baseAddress.getPort();
 
     if (StringUtils.isNotBlank(clusterId)) {
-      if (baseAddress.getHost() != "localhost"
+      if (!baseAddress.getHost().equals("localhost")
           && !baseAddress.getHost().startsWith(clusterId + ".")) {
         host = (clusterId + "." + baseAddress.getHost()).replace("global.", "");
-      } else if (baseAddress.getScheme() == "https"
+      } else if (baseAddress.getScheme().equals("https")
           && clusterId.startsWith("localhost")
           && baseAddress.getPort() % 10 > 0) {
         var clusterNumber = Integer.parseInt(clusterId.substring("localhost".length()));


### PR DESCRIPTION
Updating Java SDK to support local testing with http://localhost:9900 service url.
We found that this is not working while testing the fix for JetBrains [issue](https://github.com/microsoft/basis-planning/issues/685)