### PR TITLE
Update SSH package version to include IgnoreMessage change

### DIFF
--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -84,7 +84,7 @@
     <VisualStudioValidationVersion>15.5.31</VisualStudioValidationVersion>
     <VsSaaSPackageVersion>2.0.39</VsSaaSPackageVersion>
     <VsSaasTokenServiceClientPackageVersion>1.0.3642</VsSaasTokenServiceClientPackageVersion>
-    <DevTunnelsSshPackageVersion>3.10.19</DevTunnelsSshPackageVersion>
+    <DevTunnelsSshPackageVersion>3.10.21</DevTunnelsSshPackageVersion>
     <XunitExtensibilityCorePackageVersion>2.4.1</XunitExtensibilityCorePackageVersion>
     <XunitExtensibilityExecutionPackageVersion>2.4.1</XunitExtensibilityExecutionPackageVersion>
     <XunitExtensionsAssemblyFixturePackageVersion>2.2.0</XunitExtensionsAssemblyFixturePackageVersion>


### PR DESCRIPTION
Bumping up SSH package version to include IgnoreMessage [change](https://github.com/microsoft/dev-tunnels-ssh/pull/34). This is for JetBrains [issue](https://github.com/microsoft/basis-planning/issues/685) and while testing the [change](https://devdiv.visualstudio.com/OnlineServices/_git/tunnels/pullrequest/452476) found that CLI requires SDK to use the SSH [fix](https://github.com/microsoft/dev-tunnels-ssh/pull/34).