### PR TITLE
Add inspection uri to port contract

### DIFF
--- a/cs/src/Contracts/TunnelPort.cs
+++ b/cs/src/Contracts/TunnelPort.cs
@@ -147,8 +147,8 @@ public class TunnelPort
     public string[]? PortForwardingUris { get; set; }
 
     /// <summary>
-    /// Gets or sets inspection URIs.
-    /// If set, it's a list of absolute URIs where the port's traffic can be inspected.
+    /// Gets or sets inspection URI.
+    /// If set, it's an absolute URIs where the port's traffic can be inspected.
     /// </summary>
-    public string[]? InspectionUris { get; set; }
+    public string? InspectionUri { get; set; }
 }

--- a/cs/src/Contracts/TunnelPort.cs
+++ b/cs/src/Contracts/TunnelPort.cs
@@ -145,4 +145,10 @@ public class TunnelPort
     /// If set, it's a list of absolute URIs where the port can be accessed with web forwarding.
     /// </summary>
     public string[]? PortForwardingUris { get; set; }
+
+    /// <summary>
+    /// Gets or sets inspection URIs.
+    /// If set, it's a list of absolute URIs where the port's traffic can be inspected.
+    /// </summary>
+    public string[]? InspectionUris { get; set; }
 }

--- a/go/tunnels/tunnel_port.go
+++ b/go/tunnels/tunnel_port.go
@@ -68,7 +68,7 @@ type TunnelPort struct {
 	// can be accessed with web forwarding.
 	PortForwardingURIs []string `json:"portForwardingUris"`
 
-	// Gets or sets inspection URIs. If set, it's a list of absolute URIs where the port's
-	// traffic can be inspected.
-	InspectionURIs     []string `json:"inspectionUris"`
+	// Gets or sets inspection URI. If set, it's an absolute URIs where the port's traffic
+	// can be inspected.
+	InspectionURI      string `json:"inspectionUri"`
 }

--- a/go/tunnels/tunnel_port.go
+++ b/go/tunnels/tunnel_port.go
@@ -67,4 +67,8 @@ type TunnelPort struct {
 	// Gets or sets web forwarding URIs. If set, it's a list of absolute URIs where the port
 	// can be accessed with web forwarding.
 	PortForwardingURIs []string `json:"portForwardingUris"`
+
+	// Gets or sets inspection URIs. If set, it's a list of absolute URIs where the port's
+	// traffic can be inspected.
+	InspectionURIs     []string `json:"inspectionUris"`
 }

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.8"
+const PackageVersion = "0.0.9"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelPort.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelPort.java
@@ -118,9 +118,9 @@ public class TunnelPort {
     public String[] portForwardingUris;
 
     /**
-     * Gets or sets inspection URIs. If set, it's a list of absolute URIs where the port's
-     * traffic can be inspected.
+     * Gets or sets inspection URI. If set, it's an absolute URIs where the port's traffic
+     * can be inspected.
      */
     @Expose
-    public String[] inspectionUris;
+    public String inspectionUri;
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelPort.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelPort.java
@@ -116,4 +116,11 @@ public class TunnelPort {
      */
     @Expose
     public String[] portForwardingUris;
+
+    /**
+     * Gets or sets inspection URIs. If set, it's a list of absolute URIs where the port's
+     * traffic can be inspected.
+     */
+    @Expose
+    public String[] inspectionUris;
 }

--- a/rs/src/contracts/tunnel.rs
+++ b/rs/src/contracts/tunnel.rs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/Tunnel.cs
 
+use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControl;
 use crate::contracts::TunnelEndpoint;
 use crate::contracts::TunnelOptions;
 use crate::contracts::TunnelPort;
 use crate::contracts::TunnelStatus;
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/rs/src/contracts/tunnel_port.rs
+++ b/rs/src/contracts/tunnel_port.rs
@@ -43,7 +43,7 @@ pub struct TunnelPort {
     // A client that connects to a tunnel (by ID or name) without specifying a port number
     // will connect to the default port for the tunnel, if a default is configured. Or if
     // the tunnel has only one port then the single port is the implicit default.
-    //
+    // 
     // Selection of a default port for a connection also depends on matching the
     // connection to the port `TunnelPort.Protocol`, so it is possible to configure
     // separate defaults for distinct protocols like `TunnelProtocol.Http` and
@@ -77,4 +77,9 @@ pub struct TunnelPort {
     // port can be accessed with web forwarding.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub port_forwarding_uris: Vec<String>,
+
+    // Gets or sets inspection URIs. If set, it's a list of absolute URIs where the port's
+    // traffic can be inspected.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub inspection_uris: Vec<String>,
 }

--- a/rs/src/contracts/tunnel_port.rs
+++ b/rs/src/contracts/tunnel_port.rs
@@ -78,8 +78,7 @@ pub struct TunnelPort {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub port_forwarding_uris: Vec<String>,
 
-    // Gets or sets inspection URIs. If set, it's a list of absolute URIs where the port's
-    // traffic can be inspected.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub inspection_uris: Vec<String>,
+    // Gets or sets inspection URI. If set, it's an absolute URIs where the port's traffic
+    // can be inspected.
+    pub inspection_uri: Option<String>,
 }

--- a/ts/src/contracts/tunnelPort.ts
+++ b/ts/src/contracts/tunnelPort.ts
@@ -104,8 +104,8 @@ export interface TunnelPort {
     portForwardingUris?: string[];
 
     /**
-     * Gets or sets inspection URIs. If set, it's a list of absolute URIs where the port's
-     * traffic can be inspected.
+     * Gets or sets inspection URI. If set, it's an absolute URIs where the port's traffic
+     * can be inspected.
      */
-    inspectionUris?: string[];
+    inspectionUri?: string;
 }

--- a/ts/src/contracts/tunnelPort.ts
+++ b/ts/src/contracts/tunnelPort.ts
@@ -102,4 +102,10 @@ export interface TunnelPort {
      * port can be accessed with web forwarding.
      */
     portForwardingUris?: string[];
+
+    /**
+     * Gets or sets inspection URIs. If set, it's a list of absolute URIs where the port's
+     * traffic can be inspected.
+     */
+    inspectionUris?: string[];
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/basis-planning/issues/715

### Changes proposed: 
- Adds list of inspection URIs to tunnel port contract

### Other Tasks:
- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
