### PR TITLE
Connection protocol v2 SDK implementation (C#)

### DIFF
--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -48,7 +48,7 @@
     <ReportGeneratorVersion>4.8.13</ReportGeneratorVersion>
     <SystemTextEncodingsWebPackageVersion>4.7.2</SystemTextEncodingsWebPackageVersion>
     <VisualStudioValidationVersion>15.5.31</VisualStudioValidationVersion>
-    <DevTunnelsSshPackageVersion>3.10.26</DevTunnelsSshPackageVersion>
+    <DevTunnelsSshPackageVersion>3.10.27</DevTunnelsSshPackageVersion>
     <XunitRunnerVisualStudioVersion>2.4.0</XunitRunnerVisualStudioVersion>
     <XunitVersion>2.4.0</XunitVersion>
   </PropertyGroup>

--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -48,7 +48,7 @@
     <ReportGeneratorVersion>4.8.13</ReportGeneratorVersion>
     <SystemTextEncodingsWebPackageVersion>4.7.2</SystemTextEncodingsWebPackageVersion>
     <VisualStudioValidationVersion>15.5.31</VisualStudioValidationVersion>
-    <DevTunnelsSshPackageVersion>3.10.27</DevTunnelsSshPackageVersion>
+    <DevTunnelsSshPackageVersion>3.10.29</DevTunnelsSshPackageVersion>
     <XunitRunnerVisualStudioVersion>2.4.0</XunitRunnerVisualStudioVersion>
     <XunitVersion>2.4.0</XunitVersion>
   </PropertyGroup>

--- a/cs/src/Connections/Messages/PortRelayConnectMessage.cs
+++ b/cs/src/Connections/Messages/PortRelayConnectMessage.cs
@@ -1,0 +1,46 @@
+// <copyright file="PortRelayConnectMessage.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Text;
+using Microsoft.DevTunnels.Ssh.Messages;
+using Microsoft.DevTunnels.Ssh.IO;
+
+namespace Microsoft.DevTunnels.Connections.Messages;
+
+/// <summary>
+/// Extends port-forward channel open messages to include additional properties required
+/// by the tunnel relay.
+/// </summary>
+public class PortRelayConnectMessage : PortForwardChannelOpenMessage
+{
+    /// <summary>
+    /// Access token with 'connect' scope used to authorize the port connection request.
+    /// </summary>
+    /// <remarks>
+    /// A long-running client may need handle the
+    /// <see cref="ITunnelHost.RefreshingTunnelAccessToken" /> event to refresh the access token
+    /// before opening additional connections (channels) to forwarded ports.
+    /// </remarks>
+    public string? AccessToken { get; set; }
+
+    /// <inheritdoc/>
+    protected override void OnWrite(ref SshDataWriter writer)
+    {
+        base.OnWrite(ref writer);
+
+        writer.Write(
+            AccessToken ?? throw new InvalidOperationException("An access token is required."),
+            Encoding.UTF8);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnRead(ref SshDataReader reader)
+    {
+        base.OnRead(ref reader);
+
+        AccessToken = reader.ReadString(Encoding.UTF8);
+    }
+}

--- a/cs/src/Connections/Messages/PortRelayRequestMessage.cs
+++ b/cs/src/Connections/Messages/PortRelayRequestMessage.cs
@@ -1,0 +1,46 @@
+// <copyright file="PortRelayRequestMessage.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Text;
+using Microsoft.DevTunnels.Ssh.Messages;
+using Microsoft.DevTunnels.Ssh.IO;
+
+namespace Microsoft.DevTunnels.Connections.Messages;
+
+/// <summary>
+/// Extends port-forward request messagse to include additional properties required
+/// by the tunnel relay.
+/// </summary>
+public class PortRelayRequestMessage : PortForwardRequestMessage
+{
+    /// <summary>
+    /// Access token with 'host' scope used to authorize the port-forward request.
+    /// </summary>
+    /// <remarks>
+    /// A long-running host may need to handle the
+    /// <see cref="ITunnelHost.RefreshingTunnelAccessToken" /> event to refresh the access token
+    /// before forwarding additional ports.
+    /// </remarks>
+    public string? AccessToken { get; set; }
+
+    /// <inheritdoc/>
+    protected override void OnWrite(ref SshDataWriter writer)
+    {
+        base.OnWrite(ref writer);
+
+        writer.Write(
+            AccessToken ?? throw new InvalidOperationException("An access token is required."),
+            Encoding.UTF8);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnRead(ref SshDataReader reader)
+    {
+        base.OnRead(ref reader);
+
+        AccessToken = reader.ReadString(Encoding.UTF8);
+    }
+}

--- a/cs/src/Connections/RelayTunnelConnector.cs
+++ b/cs/src/Connections/RelayTunnelConnector.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RelayTunnelConnector.cs" company="Microsoft">
+// <copyright file="RelayTunnelConnector.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>
@@ -163,6 +163,8 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
                 // These exceptions are not recoverable
                 if (ex is InvalidOperationException ||
                     ex is ObjectDisposedException ||
+                    ex is NotSupportedException ||
+                    ex is NotImplementedException ||
                     ex is NullReferenceException ||
                     ex is ArgumentNullException ||
                     ex is ArgumentException)

--- a/cs/src/Connections/SessionPortKey.cs
+++ b/cs/src/Connections/SessionPortKey.cs
@@ -8,47 +8,47 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.DevTunnels.Connections
+namespace Microsoft.DevTunnels.Connections;
+
+/// <summary>
+/// Class for comparing equality in SSH session ID port pairs.
+/// </summary>
+/// <remarks>
+/// This class is public for testing purposes, and may be removed in the future.
+/// </remarks>
+public class SessionPortKey
 {
     /// <summary>
-    /// Class for comparing equality in sessionId port pairs
+    /// Session ID of the client SSH session, or null if the session does not have an ID
+    /// (because it is not encrypted and not client-specific).
     /// </summary>
-    public class SessionPortKey
+    public byte[]? SessionId { get; }
+
+    /// <summary>
+    /// Forwarded port number.
+    /// </summary>
+    public ushort Port { get; }
+
+    /// <summary>
+    /// Creates a new instance of the SessionPortKey class.
+    /// </summary>
+    public SessionPortKey(byte[]? sessionId, ushort port)
     {
-        /// <summary>
-        /// Session Id from host
-        /// </summary>
-        public byte[] SessionId { get; }
-
-        /// <summary>
-        /// Port that is hosted client side
-        /// </summary>
-        public ushort Port { get; }
-
-        /// <summary>
-        /// Creates a new instance of the SessionPortKey class.
-        /// </summary>
-        public SessionPortKey(byte[] sessionId, ushort port)
-        {
-            if (sessionId == null)
-            {
-                throw new ArgumentNullException("SessionId cannot be null");
-            }
-
-            this.SessionId = sessionId;
-            this.Port = port;
-        }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) =>
-            obj is SessionPortKey other &&
-            other.Port == this.Port &&
-            Enumerable.SequenceEqual(other.SessionId, this.SessionId);
-
-        /// <inheritdoc />
-        public override int GetHashCode() =>
-            HashCode.Combine(
-                this.Port,
-                ((IStructuralEquatable)this.SessionId).GetHashCode(EqualityComparer<byte>.Default));
+        this.SessionId = sessionId;
+        this.Port = port;
     }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) =>
+        obj is SessionPortKey other &&
+        other.Port == this.Port &&
+        ((this.SessionId == null && other.SessionId == null) ||
+        ((this.SessionId != null && other.SessionId != null) &&
+        Enumerable.SequenceEqual(other.SessionId, this.SessionId)));
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(
+        this.Port,
+        this.SessionId == null ? 0 :
+            ((IStructuralEquatable)this.SessionId).GetHashCode(EqualityComparer<byte>.Default));
 }

--- a/cs/src/Connections/TunnelHost.cs
+++ b/cs/src/Connections/TunnelHost.cs
@@ -45,9 +45,9 @@ public abstract class TunnelHost : TunnelConnection, ITunnelHost
     /// <summary>
     /// Enumeration of sessions created between this host and clients. Thread safe.
     /// </summary>
-    protected IEnumerable<SshServerSession> SshSessions 
-    { 
-        get 
+    protected IEnumerable<SshServerSession> SshSessions
+    {
+        get
         {
             lock (this.sshSessions)
             {
@@ -56,10 +56,17 @@ public abstract class TunnelHost : TunnelConnection, ITunnelHost
         }
     }
 
+    /// <inheritdoc/>
+    public string? ConnectionProtocol { get; protected set; }
+
     /// <summary>
     /// Port Forwarders between host and clients
     /// </summary>
-    public ConcurrentDictionary<SessionPortKey, RemotePortForwarder> RemoteForwarders { get; } = new ConcurrentDictionary<SessionPortKey, RemotePortForwarder>();
+    /// <remarks>
+    /// This property is public for testing purposes, and may be removed in the future.
+    /// </remarks>
+    public ConcurrentDictionary<SessionPortKey, RemotePortForwarder> RemoteForwarders { get; }
+        = new ConcurrentDictionary<SessionPortKey, RemotePortForwarder>();
 
     /// <summary>
     /// Private key used for connections.
@@ -104,8 +111,6 @@ public abstract class TunnelHost : TunnelConnection, ITunnelHost
         TunnelPort port,
         CancellationToken cancellation)
     {
-        var sessionId = Requires.NotNull(pfs.Session.SessionId!, nameof(pfs.Session.SessionId));
-
         var portNumber = (int)port.PortNumber;
 
         if (pfs.LocalForwardedPorts.Any((p) => p.LocalPort == portNumber))
@@ -136,7 +141,7 @@ public abstract class TunnelHost : TunnelConnection, ITunnelHost
 
         if (forwarder == null)
         {
-            // The forwarding request was rejected by the client.
+            // The forwarding request was rejected by the relay (V2) or client (V1).
             return;
         }
 
@@ -146,60 +151,17 @@ public abstract class TunnelHost : TunnelConnection, ITunnelHost
         // its remoteConnectors whether the port is being forwarded.
         // Disposing of the RemotePortForwarder stops the forwarding and removes the remote connector
         // from PFS.remoteConnectors.
+        //
+        // Note the session ID may be null here in V2 protocol, when one (possibly unencrypted)
+        // session is shared by all clients.
         RemoteForwarders.TryAdd(
-            new SessionPortKey(sessionId, (ushort)forwarder.LocalPort),
+            new SessionPortKey(pfs.Session.SessionId, (ushort)forwarder.LocalPort),
             forwarder);
         return;
     }
 
-
     /// <inheritdoc />
-    public async Task RefreshPortsAsync(CancellationToken cancellation)
-    {
-        if (Tunnel == null || ManagementClient == null)
-        {
-            return;
-        }
-
-        var updatedTunnel = await ManagementClient.GetTunnelAsync(
-            Tunnel, new TunnelRequestOptions { IncludePorts = true });
-
-        var updatedPorts = updatedTunnel?.Ports ?? Array.Empty<TunnelPort>();
-        Tunnel.Ports = updatedPorts;
-
-        var forwardTasks = new List<Task>();
-
-        foreach (var port in updatedPorts)
-        {
-            foreach (var session in SshSessions
-                .Where((s) => s.IsConnected && s.SessionId != null))
-            {
-                var key = new SessionPortKey(session.SessionId!, port.PortNumber);
-                if (!RemoteForwarders.ContainsKey(key))
-                {
-                    // Overlapping refresh operations could cause duplicate forward requests to be
-                    // sent to clients, but clients should ignore the duplicate requests.
-                    var pfs = session.GetService<PortForwardingService>() !;
-                    forwardTasks.Add(ForwardPortAsync(pfs, port, cancellation));
-                }
-            }
-        }
-
-        foreach (var forwarder in RemoteForwarders)
-        {
-            if (!updatedPorts.Any((p) => p.PortNumber == forwarder.Value.LocalPort))
-            {
-                // Since RemoteForwarders is a concurrent dictionary, overlapping refresh
-                // operations will only be able to remove and dispose a forwarder once.
-                if (RemoteForwarders.TryRemove(forwarder.Key, out _))
-                {
-                    forwarder.Value.Dispose();
-                }
-            }
-        }
-
-        await Task.WhenAll(forwardTasks);
-    }
+    public abstract Task RefreshPortsAsync(CancellationToken cancellation);
 
     /// <summary>
     /// Add client SSH session. Duplicates are ignored.

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -33,8 +33,9 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
 
     /// <summary>
     /// Web socket sub-protocol to connect to the tunnel relay endpoint with v2 host protocol.
+    /// (The "-dev" suffix will be dropped when the v2 protocol is stable.)
     /// </summary>
-    public const string WebSocketSubProtocolV2 = "tunnel-relay-host-v2";
+    public const string WebSocketSubProtocolV2 = "tunnel-relay-host-v2-dev";
 
     /// <summary>
     /// Ssh channel type in host relay ssh session where client session streams are passed.
@@ -45,7 +46,7 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
     private readonly string hostId;
     private readonly ICollection<SshServerSession> reconnectableSessions = new List<SshServerSession>();
 
-    private MultiChannelStream? hostSession;
+    private SshClientSession? hostSession;
     private Uri? relayUri;
 
     /// <summary>
@@ -56,9 +57,6 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
     {
         this.hostId = MultiModeTunnelHost.HostId;
     }
-
-    /// <inheritdoc/>
-    public string? ConnectionProtocol { get; private set; }
 
     /// <summary>
     /// Gets or sets a factory for creating relay streams.
@@ -79,7 +77,7 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
         if (hostSession != null)
         {
             this.hostSession = null;
-            await hostSession.CloseAsync();
+            await hostSession.CloseAsync(SshDisconnectReason.None);
             hostSession.Dispose();
         }
 
@@ -152,12 +150,21 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
     /// </summary>
     protected virtual async Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
     {
+        var protocols = Environment.GetEnvironmentVariable("DEVTUNNELS_PROTOCOL_VERSION") switch
+        {
+            "1" => new[] { WebSocketSubProtocol },
+            "2" => new[] { WebSocketSubProtocolV2 },
+
+            // By default, prefer V2 and fall back to V1.
+            _ => new[] { WebSocketSubProtocolV2, WebSocketSubProtocol },
+        };
+
         ValidateAccessToken();
         Trace.TraceInformation("Connecting to host tunnel relay {0}", this.relayUri!.AbsoluteUri);
         var (stream, subprotocol) = await this.StreamFactory.CreateRelayStreamAsync(
             this.relayUri!,
             this.accessToken,
-            new[] { WebSocketSubProtocol },
+            protocols,
             cancellation);
         Trace.TraceEvent(TraceEventType.Verbose, 0, "Connected with subprotocol '{0}'", subprotocol);
         ConnectionProtocol = subprotocol;
@@ -171,7 +178,7 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
         var hostSession = this.hostSession;
         if (hostSession != null)
         {
-            await hostSession.CloseAsync();
+            await hostSession.CloseAsync(disconnectReason);
             hostSession.Dispose();
         }
     }
@@ -191,16 +198,60 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
     /// <inheritdoc />
     async Task IRelayClient.ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
     {
-        this.hostSession = new MultiChannelStream(stream, Trace.WithName("HostSSH"));
+        SshClientSession session;
+        if (ConnectionProtocol == WebSocketSubProtocol)
+        {
+            // The V1 protocol always configures no security, equivalent to SSH MultiChannelStream.
+            // The websocket transport is still encrypted and authenticated.
+            session = new SshClientSession(
+                SshSessionConfiguration.NoSecurity, Trace.WithName("HostSSH"));
+        }
+        else
+        {
+            // The V2 protocol configures optional encryption, including "none" as an enabled and
+            // preferred key-exchange algorithm, because encryption of the outer SSH session is
+            // optional since it is already over a TLS websocket.
+            var config = new SshSessionConfiguration();
+            config.KeyExchangeAlgorithms.Clear();
+            config.KeyExchangeAlgorithms.Add(SshAlgorithms.KeyExchange.None);
+            config.KeyExchangeAlgorithms.Add(SshAlgorithms.KeyExchange.EcdhNistp384);
+            config.KeyExchangeAlgorithms.Add(SshAlgorithms.KeyExchange.EcdhNistp256);
+            config.KeyExchangeAlgorithms.Add(SshAlgorithms.KeyExchange.DHGroup16Sha512);
+            config.KeyExchangeAlgorithms.Add(SshAlgorithms.KeyExchange.DHGroup14Sha256);
 
-        // Increase max window size to work around channel congestion bug.
-        // This does not entirely eliminate the problem, but reduces the chance.
-        // TODO: Change the protocol to avoid layering SSH sessions, which will resolve the issue.
-        this.hostSession.ChannelMaxWindowSize = SshChannel.DefaultMaxWindowSize * 5;
+            config.AddService(typeof(PortForwardingService));
+            session = new SshClientSession(config, Trace.WithName("HostSSH"));
 
-        this.hostSession.ChannelOpening += HostSession_ChannelOpening;
-        this.hostSession.Closed += HostSession_Closed;
-        await this.hostSession.ConnectAsync(cancellation);
+            // Relay server authentication is done via the websocket TLS host certificate.
+            // If SSH encryption/authentication is used anyway, just accept any SSH host key.
+            session.Authenticating += (_, e) =>
+                e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
+
+            var hostPfs = session.ActivateService<PortForwardingService>();
+            hostPfs.MessageFactory = this;
+        }
+
+        this.hostSession = session;
+        session.ChannelOpening += HostSession_ChannelOpening;
+        session.Closed += HostSession_Closed;
+        await session.ConnectAsync(stream, cancellation);
+
+        // SSH authentication is skipped in V1 protocol, optional in V2 depending on whether the
+        // session performed a key exchange (as indicated by having a session ID or not). In the
+        // latter case a password is not required. Strong authentication was already handled by
+        // the relay service via the tunnel access token used for the websocket connection.
+        if (session.SessionId != null)
+        {
+            var clientCredentials = new SshClientCredentials("tunnel", password: null);
+            await session.AuthenticateAsync(clientCredentials);
+        }
+
+        if (ConnectionProtocol == WebSocketSubProtocolV2)
+        {
+            // In the v2 protocol, the host starts "forwarding" the ports as soon as it connects.
+            // Then the relay will forward the forwarded ports to clients as they connect.
+            await StartForwardingExistingPortsAsync(session);
+        }
     }
 
     /// <inheritdoc />
@@ -218,7 +269,7 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
 
     private void HostSession_Closed(object? sender, SshSessionClosedEventArgs e)
     {
-        var session = (MultiChannelStream)sender!;
+        var session = (SshClientSession)sender!;
         session.Closed -= HostSession_Closed;
         session.ChannelOpening -= HostSession_ChannelOpening;
         this.hostSession = null;
@@ -240,12 +291,34 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
             return;
         }
 
-        if (e.Channel.ChannelType != ClientStreamChannelType)
+        if (ConnectionProtocol == WebSocketSubProtocolV2 &&
+            e.Channel.ChannelType == "forwarded-tcpip")
         {
-            e.FailureDescription = $"Unexpected channel type. Only {ClientStreamChannelType} is supported.";
+            // V2 protocol.
+
+            // Increase the max window size so that it is at least larer than the window size
+            // of one client channel.
+            e.Channel.MaxWindowSize = SshChannel.DefaultMaxWindowSize * 2;
+
+            // In the future the relay might send additional information in an extended
+            // channel request message, for example a user identifier that would enable the
+            // host to group channels by user.
+
+            // Allow the channel to open; the SSH PortForwardingService will forward the connection.
+            return;
+        }
+        else if (e.Channel.ChannelType != ClientStreamChannelType)
+        {
+            e.FailureDescription = $"Unknown channel type: {e.Channel.ChannelType}.";
             e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
             return;
         }
+
+        // V1 protocol.
+
+        // Increase max window size to work around channel congestion bug.
+        // This does not entirely eliminate the problem, but reduces the chance.
+        e.Channel.MaxWindowSize = SshChannel.DefaultMaxWindowSize * 5;
 
         Task task;
         lock (DisposeLock)
@@ -257,7 +330,7 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
                 return;
             }
 
-            task = AcceptClientSessionAsync((MultiChannelStream)sender!, DisposeToken);
+            task = AcceptClientSessionAsync(e.Channel, DisposeToken);
             this.clientSessionTasks.Add(task);
         }
 
@@ -272,11 +345,11 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
         }
     }
 
-    private async Task AcceptClientSessionAsync(MultiChannelStream hostSession, CancellationToken cancellation)
+    private async Task AcceptClientSessionAsync(SshChannel clientSessionChannel, CancellationToken cancellation)
     {
         try
         {
-            var stream = await hostSession.AcceptStreamAsync(ClientStreamChannelType, cancellation);
+            var stream = new SshStream(clientSessionChannel);
             await ConnectAndRunClientSessionAsync(stream, cancellation);
         }
         catch (OperationCanceledException)
@@ -414,7 +487,7 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
         await StartForwardingExistingPortsAsync((SshServerSession)sender!, removeUnusedPorts: true);
 
     private async Task StartForwardingExistingPortsAsync(
-        SshServerSession session, bool removeUnusedPorts = false)
+        SshSession session, bool removeUnusedPorts = false)
     {
         var tunnelPorts = Tunnel!.Ports ?? Enumerable.Empty<TunnelPort>();
         var pfs = session.ActivateService<PortForwardingService>();
@@ -450,7 +523,9 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
 
             var remoteForwardersToDispose = RemoteForwarders
                 .Where((kvp) =>
-                    Enumerable.SequenceEqual(kvp.Key.SessionId, session.SessionId) &&
+                    ((kvp.Key.SessionId == null && session.SessionId == null) ||
+                        ((kvp.Key.SessionId != null && session.SessionId != null) &&
+                        Enumerable.SequenceEqual(kvp.Key.SessionId, session.SessionId))) &&
                     unusedlocalPorts.Contains(kvp.Value.LocalPort))
                 .Select(kvp => kvp.Key);
 
@@ -506,5 +581,60 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
             Trace.Warning("Unrecognized channel type " + portForwardRequest.ChannelType);
             e.FailureReason = SshChannelOpenFailureReason.UnknownChannelType;
         }
+    }
+
+    /// <inheritdoc />
+    public override async Task RefreshPortsAsync(CancellationToken cancellation)
+    {
+        if (Tunnel == null || ManagementClient == null)
+        {
+            return;
+        }
+
+        var updatedTunnel = await ManagementClient.GetTunnelAsync(
+            Tunnel, new TunnelRequestOptions { IncludePorts = true });
+
+        var updatedPorts = updatedTunnel?.Ports ?? Array.Empty<TunnelPort>();
+        Tunnel.Ports = updatedPorts;
+
+        var forwardTasks = new List<Task>();
+
+        var sessions = SshSessions.Cast<SshSession?>();
+        if (ConnectionProtocol == WebSocketSubProtocolV2)
+        {
+            // In the V2 protocol, ports are forwarded direclty on the host session.
+            // (But even when the host is V2, some clients may still connect with V1.)
+            sessions = sessions.Append(this.hostSession);
+        }
+
+        foreach (var port in updatedPorts)
+        {
+            foreach (var session in sessions.Where((s) => s?.IsConnected == true))
+            {
+                var key = new SessionPortKey(session!.SessionId!, port.PortNumber);
+                if (!RemoteForwarders.ContainsKey(key))
+                {
+                    // Overlapping refresh operations could cause duplicate forward requests to be
+                    // sent to clients, but clients should ignore the duplicate requests.
+                    var pfs = session.GetService<PortForwardingService>()!;
+                    forwardTasks.Add(ForwardPortAsync(pfs, port, cancellation));
+                }
+            }
+        }
+
+        foreach (var forwarder in RemoteForwarders)
+        {
+            if (!updatedPorts.Any((p) => p.PortNumber == forwarder.Value.RemotePort))
+            {
+                // Since RemoteForwarders is a concurrent dictionary, overlapping refresh
+                // operations will only be able to remove and dispose a forwarder once.
+                if (RemoteForwarders.TryRemove(forwarder.Key, out _))
+                {
+                    forwarder.Value.Dispose();
+                }
+            }
+        }
+
+        await Task.WhenAll(forwardTasks);
     }
 }

--- a/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Security.Claims;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DevTunnels.Ssh;
 using Microsoft.DevTunnels.Ssh.Algorithms;
@@ -260,7 +258,7 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
 
         var tunnel = CreateRelayTunnel();
         await Assert.ThrowsAsync<ArgumentNullException>(
-            "foobar", 
+            "foobar",
             () => ConnectRelayClientAsync(relayClient, tunnel, (_) => throw new ArgumentNullException("foobar")));
         Assert.IsType<ArgumentNullException>(await disconnectedException.Task);
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -6,8 +6,8 @@
 			"name": "@microsoft/dev-tunnels",
 			"license": "MIT",
 			"dependencies": {
-				"@microsoft/dev-tunnels-ssh": "^3.10.27",
-				"@microsoft/dev-tunnels-ssh-tcp": "^3.10.27",
+				"@microsoft/dev-tunnels-ssh": "^3.10.29",
+				"@microsoft/dev-tunnels-ssh-tcp": "^3.10.29",
 				"await-semaphore": "^0.1.3",
 				"axios": "^0.21.1",
 				"buffer": "^5.2.1",
@@ -129,9 +129,9 @@
 			"dev": true
 		},
 		"node_modules/@microsoft/dev-tunnels-ssh": {
-			"version": "3.10.27",
-			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.10.27.tgz",
-			"integrity": "sha512-LV0ssAsZc1kt2YG931E+0ikFyg7j/G+pIRgDYxVZ284t0z1N2L+Oqfp+50U8wxUicrw59uzZG67oNrFKBNpBBw==",
+			"version": "3.10.29",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.10.29.tgz",
+			"integrity": "sha512-9vosuuRyr1+FaRH7ny/rLu4jAUaLmxVUREuwzB5MBNStz4jOsibXr0B3Pkylqx7gjTsyxUUpHIxnZBFzpPVWlw==",
 			"dependencies": {
 				"buffer": "^5.2.1",
 				"debug": "^4.1.1",
@@ -140,9 +140,9 @@
 			}
 		},
 		"node_modules/@microsoft/dev-tunnels-ssh-tcp": {
-			"version": "3.10.27",
-			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.10.27.tgz",
-			"integrity": "sha512-f3E/gY8FE6CkJRBMB0KuUD7wDEHHexhv6Gs0h0HA5UhmSe8xrOFmEONLV/77D58kzr7o9cg6ZThQ0JvWaIgVag==",
+			"version": "3.10.29",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.10.29.tgz",
+			"integrity": "sha512-xLYfYj83liXZZYSzdryrKJbiM97idwKoAi6hieb7HhCvI/cHvRcN/wIrAoj9Aqdpa2T6qm+qlb4fFDObw9lCJA==",
 			"dependencies": {
 				"@microsoft/dev-tunnels-ssh": "~3.10"
 			}
@@ -4880,9 +4880,9 @@
 			"dev": true
 		},
 		"@microsoft/dev-tunnels-ssh": {
-			"version": "3.10.27",
-			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.10.27.tgz",
-			"integrity": "sha512-LV0ssAsZc1kt2YG931E+0ikFyg7j/G+pIRgDYxVZ284t0z1N2L+Oqfp+50U8wxUicrw59uzZG67oNrFKBNpBBw==",
+			"version": "3.10.29",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.10.29.tgz",
+			"integrity": "sha512-9vosuuRyr1+FaRH7ny/rLu4jAUaLmxVUREuwzB5MBNStz4jOsibXr0B3Pkylqx7gjTsyxUUpHIxnZBFzpPVWlw==",
 			"requires": {
 				"buffer": "^5.2.1",
 				"debug": "^4.1.1",
@@ -4891,9 +4891,9 @@
 			}
 		},
 		"@microsoft/dev-tunnels-ssh-tcp": {
-			"version": "3.10.27",
-			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.10.27.tgz",
-			"integrity": "sha512-f3E/gY8FE6CkJRBMB0KuUD7wDEHHexhv6Gs0h0HA5UhmSe8xrOFmEONLV/77D58kzr7o9cg6ZThQ0JvWaIgVag==",
+			"version": "3.10.29",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.10.29.tgz",
+			"integrity": "sha512-xLYfYj83liXZZYSzdryrKJbiM97idwKoAi6hieb7HhCvI/cHvRcN/wIrAoj9Aqdpa2T6qm+qlb4fFDObw9lCJA==",
 			"requires": {
 				"@microsoft/dev-tunnels-ssh": "~3.10"
 			}

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,7 +1,4815 @@
 {
 	"name": "@microsoft/dev-tunnels",
 	"requires": true,
-	"lockfileVersion": 1,
+	"packages": {
+		"": {
+			"name": "@microsoft/dev-tunnels",
+			"license": "MIT",
+			"dependencies": {
+				"@microsoft/dev-tunnels-ssh": "^3.10.27",
+				"@microsoft/dev-tunnels-ssh-tcp": "^3.10.27",
+				"await-semaphore": "^0.1.3",
+				"axios": "^0.21.1",
+				"buffer": "^5.2.1",
+				"debug": "^4.1.1",
+				"uuid": "^3.3.3",
+				"vscode-jsonrpc": "^4.0.0"
+			},
+			"devDependencies": {
+				"@testdeck/mocha": "^0.1.0",
+				"@types/debug": "^4.1.4",
+				"@types/mocha": "^5.2.6",
+				"@types/node": "^12.12.6",
+				"@types/tmp": "0.0.34",
+				"@types/uuid": "^3.3.3",
+				"@types/websocket": "0.0.40",
+				"@types/yargs": "^17.0.3",
+				"@typescript-eslint/eslint-plugin-tslint": "^4.14.2",
+				"@typescript-eslint/parser": "^4.14.2",
+				"brfs": "^2.0.2",
+				"browserify": "^16.2.3",
+				"chalk": "^2.4.2",
+				"eslint": "^7.19.0",
+				"eslint-config-prettier": "^7.2.0",
+				"eslint-plugin-prettier": "^3.3.1",
+				"mocha": "^9.2.2",
+				"mocha-junit-reporter": "^2.0.2",
+				"mocha-multi-reporters": "^1.1.7",
+				"moment": "^2.29.4",
+				"nerdbank-gitversioning": "^3.1.91",
+				"prettier": "^1.19.1",
+				"source-map-support": "^0.5.11",
+				"tmp": "^0.1.0",
+				"tslint": "^6.1.3",
+				"tslint-microsoft-contrib": "^6.2.0",
+				"typescript": "^4.1.3",
+				"websocket": "^1.0.28",
+				"yargs": "^17.2.1"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.12.11",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@babel/code-frame/-/code-frame-7.12.11.tgz",
+			"integrity": "sha1-9K1DWqJj25NbjxDyxVLSP7cWpj8=",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.14.9",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+			"integrity": "sha1-ZlTRcbICT22O4VG/JQlpmRkTHUg=",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight": {
+			"version": "7.14.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@babel/highlight/-/highlight-7.14.5.tgz",
+			"integrity": "sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.14.5",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@eslint/eslintrc": {
+			"version": "0.4.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+			"integrity": "sha1-nkKYHvA1vrPdSa3ResuW6P9vOUw=",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.1.1",
+				"espree": "^7.3.0",
+				"globals": "^13.9.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^3.13.1",
+				"minimatch": "^3.0.4",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/ignore": {
+			"version": "4.0.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array": {
+			"version": "0.5.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+			"integrity": "sha1-FAeWfUxu7Nc4j4Os8er00Mbljvk=",
+			"dev": true,
+			"dependencies": {
+				"@humanwhocodes/object-schema": "^1.2.0",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/object-schema": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+			"integrity": "sha1-h956+cIxgm/daKxyWPd8Qp4OX88=",
+			"dev": true
+		},
+		"node_modules/@microsoft/dev-tunnels-ssh": {
+			"version": "3.10.27",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.10.27.tgz",
+			"integrity": "sha512-LV0ssAsZc1kt2YG931E+0ikFyg7j/G+pIRgDYxVZ284t0z1N2L+Oqfp+50U8wxUicrw59uzZG67oNrFKBNpBBw==",
+			"dependencies": {
+				"buffer": "^5.2.1",
+				"debug": "^4.1.1",
+				"diffie-hellman": "^5.0.3",
+				"vscode-jsonrpc": "^4.0.0"
+			}
+		},
+		"node_modules/@microsoft/dev-tunnels-ssh-tcp": {
+			"version": "3.10.27",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.10.27.tgz",
+			"integrity": "sha512-f3E/gY8FE6CkJRBMB0KuUD7wDEHHexhv6Gs0h0HA5UhmSe8xrOFmEONLV/77D58kzr7o9cg6ZThQ0JvWaIgVag==",
+			"dependencies": {
+				"@microsoft/dev-tunnels-ssh": "~3.10"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@testdeck/core": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@testdeck/core/-/core-0.1.2.tgz",
+			"integrity": "sha512-rggcFQqSejqtkqK1JcwZE/utD4oNsM1JMHwrYxH1PKYx0uL2cMs0Q4zMVLKw0oacIASCfkIUSdXx7rDNdCDlvA==",
+			"dev": true
+		},
+		"node_modules/@testdeck/mocha": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@testdeck/mocha/-/mocha-0.1.2.tgz",
+			"integrity": "sha512-yn3OkFUlO9EkdBkDV08bPV0r26U2FC/8KvU9FdiS0ligOsjB5Ry4sp3eUQJAFxjrGJBpih0t7rZ/GzdsgCv/EQ==",
+			"dev": true,
+			"dependencies": {
+				"@testdeck/core": "^0.1.2"
+			},
+			"bin": {
+				"testdeck-watch": "bin/watch"
+			}
+		},
+		"node_modules/@types/debug": {
+			"version": "4.1.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@types/debug/-/debug-4.1.7.tgz",
+			"integrity": "sha1-fMDqdhUJEkcJuLLRCQ2PbBeq24I=",
+			"dev": true,
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
+		"node_modules/@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
+			"dev": true
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.9",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@types/json-schema/-/json-schema-7.0.9.tgz",
+			"integrity": "sha1-l+3JA36gw4WFMgsolk3eOznkZg0=",
+			"dev": true
+		},
+		"node_modules/@types/mocha": {
+			"version": "5.2.7",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+			"dev": true
+		},
+		"node_modules/@types/ms": {
+			"version": "0.7.31",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@types/ms/-/ms-0.7.31.tgz",
+			"integrity": "sha1-MbfKZAcSij0rvCf+LSGzRTl/YZc=",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "12.20.24",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@types/node/-/node-12.20.24.tgz",
+			"integrity": "sha1-w3rGnLKUivtM75X0JPoAN5camlw=",
+			"dev": true
+		},
+		"node_modules/@types/tmp": {
+			"version": "0.0.34",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@types/tmp/-/tmp-0.0.34.tgz",
+			"integrity": "sha1-TQHAr84Kyb4xbF/FK2QHxvyM1EA=",
+			"dev": true
+		},
+		"node_modules/@types/uuid": {
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+			"integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==",
+			"dev": true
+		},
+		"node_modules/@types/websocket": {
+			"version": "0.0.40",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@types/websocket/-/websocket-0.0.40.tgz",
+			"integrity": "sha1-iHzWMqiz0NEdp7nQ0QavhZl7NYw=",
+			"dev": true,
+			"dependencies": {
+				"@types/events": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.3.tgz",
+			"integrity": "sha512-K7rm3Ke3ag/pAniBe80A6J6fjoqRibvCrl3dRmtXV9eCEt9h/pZwmHX9MzjQVUc/elneQTL4Ky7XKorC71Lmxw==",
+			"dev": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "20.2.1",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+			"integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+			"dev": true
+		},
+		"node_modules/@typescript-eslint/eslint-plugin-tslint": {
+			"version": "4.31.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-4.31.0.tgz",
+			"integrity": "sha1-pApDwEmCL49FgbN/IlMtmzT8KvE=",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/experimental-utils": "4.31.0",
+				"lodash": "^4.17.21"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^5.0.0 || ^6.0.0 || ^7.0.0",
+				"tslint": "^5.0.0 || ^6.0.0",
+				"typescript": "*"
+			}
+		},
+		"node_modules/@typescript-eslint/experimental-utils": {
+			"version": "4.31.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.0.tgz",
+			"integrity": "sha1-DvHV2GwzT5g6APMQ5Dwc5MFOBU0=",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.7",
+				"@typescript-eslint/scope-manager": "4.31.0",
+				"@typescript-eslint/types": "4.31.0",
+				"@typescript-eslint/typescript-estree": "4.31.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "4.31.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@typescript-eslint/parser/-/parser-4.31.0.tgz",
+			"integrity": "sha1-h7fNFrJLkXDHdZXYsTY/gEcSHgU=",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "4.31.0",
+				"@typescript-eslint/types": "4.31.0",
+				"@typescript-eslint/typescript-estree": "4.31.0",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "4.31.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-4.31.0.tgz",
+			"integrity": "sha1-m+M67U6ZAdt1OAO6Iztw15qH/D4=",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "4.31.0",
+				"@typescript-eslint/visitor-keys": "4.31.0"
+			},
+			"engines": {
+				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "4.31.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@typescript-eslint/types/-/types-4.31.0.tgz",
+			"integrity": "sha1-mnyG/MFiAYlWfcTkbK1++gfujc4=",
+			"dev": true,
+			"engines": {
+				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "4.31.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.0.tgz",
+			"integrity": "sha1-TaTLYnSn7zsh1T+ecUfMdvJ4oHg=",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "4.31.0",
+				"@typescript-eslint/visitor-keys": "4.31.0",
+				"debug": "^4.3.1",
+				"globby": "^11.0.3",
+				"is-glob": "^4.0.1",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "4.31.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.0.tgz",
+			"integrity": "sha1-Toe3dhy04OYn3CBHAhqmk/x26is=",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "4.31.0",
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@ungap/promise-all-settled": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+			"dev": true
+		},
+		"node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
+			"dev": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/acorn-node": {
+			"version": "1.8.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/acorn-node/-/acorn-node-1.8.2.tgz",
+			"integrity": "sha1-EUyV1kU55T3t4j3oudlt98euKvg=",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^7.0.0",
+				"acorn-walk": "^7.0.0",
+				"xtend": "^4.0.2"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "7.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/acorn-walk/-/acorn-walk-7.2.0.tgz",
+			"integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-colors": {
+			"version": "4.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ansi-colors/-/ansi-colors-4.1.1.tgz",
+			"integrity": "sha1-y7muJWv3UK8eqzRPIpqif+lLo0g=",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"dev": true,
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/array-from": {
+			"version": "2.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+			"dev": true
+		},
+		"node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/asn1.js": {
+			"version": "5.4.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha1-EamAuE67kXgc41sP3C7ilON4Pwc=",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"node_modules/assert": {
+			"version": "1.5.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/assert/-/assert-1.5.0.tgz",
+			"integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+			"dev": true,
+			"dependencies": {
+				"object-assign": "^4.1.1",
+				"util": "0.10.3"
+			}
+		},
+		"node_modules/assert/node_modules/inherits": {
+			"version": "2.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/inherits/-/inherits-2.0.1.tgz",
+			"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+			"dev": true
+		},
+		"node_modules/assert/node_modules/util": {
+			"version": "0.10.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/util/-/util-0.10.3.tgz",
+			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "2.0.1"
+			}
+		},
+		"node_modules/astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/await-semaphore": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/await-semaphore/-/await-semaphore-0.1.3.tgz",
+			"integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q=="
+		},
+		"node_modules/axios": {
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+			"dependencies": {
+				"follow-redirects": "^1.14.0"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+			"dev": true
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/binary-extensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og="
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+			"dev": true,
+			"dependencies": {
+				"fill-range": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/brfs": {
+			"version": "2.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/brfs/-/brfs-2.0.2.tgz",
+			"integrity": "sha1-RCN4ePqCqkec5PX+LBeW7GnweEU=",
+			"dev": true,
+			"dependencies": {
+				"quote-stream": "^1.0.1",
+				"resolve": "^1.1.5",
+				"static-module": "^3.0.2",
+				"through2": "^2.0.0"
+			},
+			"bin": {
+				"brfs": "bin/cmd.js"
+			}
+		},
+		"node_modules/brorand": {
+			"version": "1.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"node_modules/browser-pack": {
+			"version": "6.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browser-pack/-/browser-pack-6.1.0.tgz",
+			"integrity": "sha1-w0uhDQuc4WK1ryJ8cTHJLC7NV3Q=",
+			"dev": true,
+			"dependencies": {
+				"combine-source-map": "~0.8.0",
+				"defined": "^1.0.0",
+				"JSONStream": "^1.0.3",
+				"safe-buffer": "^5.1.1",
+				"through2": "^2.0.0",
+				"umd": "^3.0.0"
+			},
+			"bin": {
+				"browser-pack": "bin/cmd.js"
+			}
+		},
+		"node_modules/browser-resolve": {
+			"version": "2.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browser-resolve/-/browser-resolve-2.0.0.tgz",
+			"integrity": "sha1-mbcwTLOS+Nc9unQbstfaKMbXhCs=",
+			"dev": true,
+			"dependencies": {
+				"resolve": "^1.17.0"
+			}
+		},
+		"node_modules/browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
+		"node_modules/browserify": {
+			"version": "16.5.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browserify/-/browserify-16.5.2.tgz",
+			"integrity": "sha1-2SaDXpKA+l/Vf1vDAfLvJKly3f4=",
+			"dev": true,
+			"dependencies": {
+				"assert": "^1.4.0",
+				"browser-pack": "^6.0.1",
+				"browser-resolve": "^2.0.0",
+				"browserify-zlib": "~0.2.0",
+				"buffer": "~5.2.1",
+				"cached-path-relative": "^1.0.0",
+				"concat-stream": "^1.6.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "~1.0.0",
+				"crypto-browserify": "^3.0.0",
+				"defined": "^1.0.0",
+				"deps-sort": "^2.0.0",
+				"domain-browser": "^1.2.0",
+				"duplexer2": "~0.1.2",
+				"events": "^2.0.0",
+				"glob": "^7.1.0",
+				"has": "^1.0.0",
+				"htmlescape": "^1.1.0",
+				"https-browserify": "^1.0.0",
+				"inherits": "~2.0.1",
+				"insert-module-globals": "^7.0.0",
+				"JSONStream": "^1.0.3",
+				"labeled-stream-splicer": "^2.0.0",
+				"mkdirp-classic": "^0.5.2",
+				"module-deps": "^6.2.3",
+				"os-browserify": "~0.3.0",
+				"parents": "^1.0.1",
+				"path-browserify": "~0.0.0",
+				"process": "~0.11.0",
+				"punycode": "^1.3.2",
+				"querystring-es3": "~0.2.0",
+				"read-only-stream": "^2.0.0",
+				"readable-stream": "^2.0.2",
+				"resolve": "^1.1.4",
+				"shasum": "^1.0.0",
+				"shell-quote": "^1.6.1",
+				"stream-browserify": "^2.0.0",
+				"stream-http": "^3.0.0",
+				"string_decoder": "^1.1.1",
+				"subarg": "^1.0.0",
+				"syntax-error": "^1.1.1",
+				"through2": "^2.0.0",
+				"timers-browserify": "^1.0.1",
+				"tty-browserify": "0.0.1",
+				"url": "~0.11.0",
+				"util": "~0.10.1",
+				"vm-browserify": "^1.0.0",
+				"xtend": "^4.0.0"
+			},
+			"bin": {
+				"browserify": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/browserify-aes": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+			"dev": true,
+			"dependencies": {
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/browserify-cipher": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+			"integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+			"dev": true,
+			"dependencies": {
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
+			}
+		},
+		"node_modules/browserify-des": {
+			"version": "1.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browserify-des/-/browserify-des-1.0.2.tgz",
+			"integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+			"dev": true,
+			"dependencies": {
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"node_modules/browserify-rsa": {
+			"version": "4.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+			"integrity": "sha1-sv0Gtbda4pf3zi3GUfkY9b4VjI0=",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^5.0.0",
+				"randombytes": "^2.0.1"
+			}
+		},
+		"node_modules/browserify-rsa/node_modules/bn.js": {
+			"version": "5.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha1-NYhgZ0OWxpl3canQUfzBtX1K4AI=",
+			"dev": true
+		},
+		"node_modules/browserify-sign": {
+			"version": "4.2.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browserify-sign/-/browserify-sign-4.2.1.tgz",
+			"integrity": "sha1-6vSt1G3VS+O7OzbAzxWrvrp5VsM=",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^5.1.1",
+				"browserify-rsa": "^4.0.1",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"elliptic": "^6.5.3",
+				"inherits": "^2.0.4",
+				"parse-asn1": "^5.1.5",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			}
+		},
+		"node_modules/browserify-sign/node_modules/bn.js": {
+			"version": "5.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha1-NYhgZ0OWxpl3canQUfzBtX1K4AI=",
+			"dev": true
+		},
+		"node_modules/browserify-sign/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/browserify-zlib": {
+			"version": "0.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+			"dev": true,
+			"dependencies": {
+				"pako": "~1.0.5"
+			}
+		},
+		"node_modules/browserify/node_modules/buffer": {
+			"version": "5.2.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/buffer/-/buffer-5.2.1.tgz",
+			"integrity": "sha1-3Vf6DxCaxZxgJHkETcp7iz0LcdY=",
+			"dev": true,
+			"dependencies": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/buffer-equal": {
+			"version": "0.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/buffer-equal/-/buffer-equal-0.0.1.tgz",
+			"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
+			"dev": true
+		},
+		"node_modules/buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
+		},
+		"node_modules/bufferutil": {
+			"version": "4.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/bufferutil/-/bufferutil-4.0.3.tgz",
+			"integrity": "sha1-ZnJLdWvtI818KMTTBteZT5lDzGs=",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-gyp-build": "^4.2.0"
+			}
+		},
+		"node_modules/builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/builtin-status-codes": {
+			"version": "3.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+			"dev": true
+		},
+		"node_modules/cached-path-relative": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
+			"integrity": "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==",
+			"dev": true
+		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/camel-case": {
+			"version": "4.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha1-lygHKpVPgFIoIlpt7qazhGHhvVo=",
+			"dev": true,
+			"dependencies": {
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/camel-case/node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE=",
+			"dev": true
+		},
+		"node_modules/camelcase": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"node_modules/combine-source-map": {
+			"version": "0.8.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/combine-source-map/-/combine-source-map-0.8.0.tgz",
+			"integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+			"dev": true,
+			"dependencies": {
+				"convert-source-map": "~1.1.0",
+				"inline-source-map": "~0.6.0",
+				"lodash.memoize": "~3.0.3",
+				"source-map": "~0.5.3"
+			}
+		},
+		"node_modules/combine-source-map/node_modules/convert-source-map": {
+			"version": "1.1.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/convert-source-map/-/convert-source-map-1.1.3.tgz",
+			"integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+			"dev": true
+		},
+		"node_modules/combine-source-map/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+			"dev": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"node_modules/concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+			"dev": true,
+			"engines": [
+				"node >= 0.8"
+			],
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
+		"node_modules/console-browserify": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/console-browserify/-/console-browserify-1.2.0.tgz",
+			"integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
+			"dev": true
+		},
+		"node_modules/constants-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/constants-browserify/-/constants-browserify-1.0.0.tgz",
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+			"dev": true
+		},
+		"node_modules/convert-source-map": {
+			"version": "1.8.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/convert-source-map/-/convert-source-map-1.8.0.tgz",
+			"integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"node_modules/convert-source-map/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"dev": true
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
+			"dev": true
+		},
+		"node_modules/create-ecdh": {
+			"version": "4.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/create-ecdh/-/create-ecdh-4.0.4.tgz",
+			"integrity": "sha1-1uf0v/pmc2CFoHYv06YyaE2rzE4=",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.5.3"
+			}
+		},
+		"node_modules/create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+			"dev": true,
+			"dependencies": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"node_modules/create-hmac": {
+			"version": "1.1.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+			"dev": true,
+			"dependencies": {
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/crypto-browserify": {
+			"version": "3.12.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+			"dev": true,
+			"dependencies": {
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/d": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/d/-/d-1.0.1.tgz",
+			"integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
+			"dev": true,
+			"dependencies": {
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
+			}
+		},
+		"node_modules/dash-ast": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/dash-ast/-/dash-ast-1.0.0.tgz",
+			"integrity": "sha1-EgKbpfsviqbwqGF5WyPBtLbCfTc=",
+			"dev": true
+		},
+		"node_modules/debug": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
+			"dev": true
+		},
+		"node_modules/defined": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+			"dev": true
+		},
+		"node_modules/deps-sort": {
+			"version": "2.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/deps-sort/-/deps-sort-2.0.1.tgz",
+			"integrity": "sha1-nf3IdtK87DOGtoKaxSFizan6II0=",
+			"dev": true,
+			"dependencies": {
+				"JSONStream": "^1.0.3",
+				"shasum-object": "^1.0.0",
+				"subarg": "^1.0.0",
+				"through2": "^2.0.0"
+			},
+			"bin": {
+				"deps-sort": "bin/cmd.js"
+			}
+		},
+		"node_modules/des.js": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/des.js/-/des.js-1.0.1.tgz",
+			"integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"node_modules/detective": {
+			"version": "5.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/detective/-/detective-5.2.0.tgz",
+			"integrity": "sha1-/rKnfoW5BOzepFmtiXzJCpm9Kns=",
+			"dev": true,
+			"dependencies": {
+				"acorn-node": "^1.6.1",
+				"defined": "^1.0.0",
+				"minimist": "^1.1.1"
+			},
+			"bin": {
+				"detective": "bin/detective.js"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/diffie-hellman": {
+			"version": "5.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+			"dependencies": {
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
+			}
+		},
+		"node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
+			"dev": true,
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/domain-browser": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4",
+				"npm": ">=1.2"
+			}
+		},
+		"node_modules/duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/elliptic": {
+			"version": "6.5.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha1-2jfOvTHnmhNn6UG1ku0fvr1Yq7s=",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+			"dev": true
+		},
+		"node_modules/enquirer": {
+			"version": "2.3.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/enquirer/-/enquirer-2.3.6.tgz",
+			"integrity": "sha1-Kn/l3WNKHkElqXXsmU/1RW3Dc00=",
+			"dev": true,
+			"dependencies": {
+				"ansi-colors": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/es5-ext": {
+			"version": "0.10.53",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/es5-ext/-/es5-ext-0.10.53.tgz",
+			"integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
+			"dev": true,
+			"dependencies": {
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.3",
+				"next-tick": "~1.0.0"
+			}
+		},
+		"node_modules/es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"dev": true,
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"node_modules/es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-set": "~0.1.5",
+				"es6-symbol": "~3.1.1",
+				"event-emitter": "~0.3.5"
+			}
+		},
+		"node_modules/es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "~0.3.5"
+			}
+		},
+		"node_modules/es6-set/node_modules/es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"node_modules/es6-symbol": {
+			"version": "3.1.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
+			"dev": true,
+			"dependencies": {
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "1.14.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/escodegen/-/escodegen-1.14.3.tgz",
+			"integrity": "sha1-TnuB+6YVgdyXWC7XjKt/Do1j9QM=",
+			"dev": true,
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=4.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "7.32.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint/-/eslint-7.32.0.tgz",
+			"integrity": "sha1-xtMooUvj+wjI0dIeEsAv23oqgS0=",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "7.12.11",
+				"@eslint/eslintrc": "^0.4.3",
+				"@humanwhocodes/config-array": "^0.5.0",
+				"ajv": "^6.10.0",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"enquirer": "^2.3.5",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^2.1.0",
+				"eslint-visitor-keys": "^2.0.0",
+				"espree": "^7.3.1",
+				"esquery": "^1.4.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob-parent": "^5.1.2",
+				"globals": "^13.6.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.0.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.1",
+				"progress": "^2.0.0",
+				"regexpp": "^3.1.0",
+				"semver": "^7.2.1",
+				"strip-ansi": "^6.0.0",
+				"strip-json-comments": "^3.1.0",
+				"table": "^6.0.9",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-config-prettier": {
+			"version": "7.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
+			"integrity": "sha1-9KS9KDLoEOjMfBQR7IWz6FwMU/k=",
+			"dev": true,
+			"bin": {
+				"eslint-config-prettier": "bin/cli.js"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-prettier": {
+			"version": "3.4.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
+			"integrity": "sha1-6d2yAO+289Bf/oOxZlpxavSjh+U=",
+			"dev": true,
+			"dependencies": {
+				"prettier-linter-helpers": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=5.0.0",
+				"prettier": ">=1.13.0"
+			},
+			"peerDependenciesMeta": {
+				"eslint-config-prettier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha1-iuuvrOc0W7M1WdsKHxOh0tSMNnI=",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha1-9lMoJZMFknOSyTjtROsKXJsr0wM=",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/eslint/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/eslint/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+			"dev": true
+		},
+		"node_modules/eslint/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-utils": {
+			"version": "2.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-utils/-/eslint-utils-2.1.0.tgz",
+			"integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslint/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "4.0.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/eslint/node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/eslint/node_modules/optionator": {
+			"version": "0.9.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/optionator/-/optionator-0.9.1.tgz",
+			"integrity": "sha1-TyNqY3Pa4FZqbUPhMmZ09QwpFJk=",
+			"dev": true,
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/eslint/node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/eslint/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint/node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/espree": {
+			"version": "7.3.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/espree/-/espree-7.3.1.tgz",
+			"integrity": "sha1-8t8zC3Usb1UBn4vYm3ZgA5wbu7Y=",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^7.4.0",
+				"acorn-jsx": "^5.3.1",
+				"eslint-visitor-keys": "^1.3.0"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+			"dev": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/esquery": {
+			"version": "1.4.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/esquery/-/esquery-1.4.0.tgz",
+			"integrity": "sha1-IUj/w4uC6McFff7UhCWz5h8PJKU=",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/esquery/node_modules/estraverse": {
+			"version": "5.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/estraverse/-/estraverse-5.2.0.tgz",
+			"integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esrecurse/node_modules/estraverse": {
+			"version": "5.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/estraverse/-/estraverse-5.2.0.tgz",
+			"integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estree-is-function": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/estree-is-function/-/estree-is-function-1.0.0.tgz",
+			"integrity": "sha1-wK3CmAbX8Yp0233w87JmZwLjetI=",
+			"dev": true
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"node_modules/events": {
+			"version": "2.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/events/-/events-2.1.0.tgz",
+			"integrity": "sha1-KpoeGOYQbg6BKqnr1KgZs8KcC6U=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.x"
+			}
+		},
+		"node_modules/evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+			"dev": true,
+			"dependencies": {
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"node_modules/ext": {
+			"version": "1.5.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ext/-/ext-1.5.0.tgz",
+			"integrity": "sha1-6TuXrgyyP4NwOA9hB9LSt4h2h60=",
+			"dev": true,
+			"dependencies": {
+				"type": "^2.5.0"
+			}
+		},
+		"node_modules/ext/node_modules/type": {
+			"version": "2.5.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/type/-/type-2.5.0.tgz",
+			"integrity": "sha1-Ci54wud5B7JSq+XymMGwHGPw2z0=",
+			"dev": true
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+			"dev": true
+		},
+		"node_modules/fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
+			"dev": true
+		},
+		"node_modules/fast-glob": {
+			"version": "3.2.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fast-glob/-/fast-glob-3.2.7.tgz",
+			"integrity": "sha1-/Wy3otfpqnp4RhEehaGW1rL3ZqE=",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+			"dev": true
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"node_modules/fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha1-xAaoO25w2eNc47MKgRQd8wrrqIQ=",
+			"dev": true
+		},
+		"node_modules/fastq": {
+			"version": "1.12.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fastq/-/fastq-1.12.0.tgz",
+			"integrity": "sha1-7XtqtdYjk/ssxZHIU2UqXDGL95Q=",
+			"dev": true,
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/file-entry-cache": {
+			"version": "6.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
+			"dev": true,
+			"dependencies": {
+				"flat-cache": "^3.0.4"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+			"dev": true,
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true,
+			"bin": {
+				"flat": "cli.js"
+			}
+		},
+		"node_modules/flat-cache": {
+			"version": "3.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/flat-cache/-/flat-cache-3.0.4.tgz",
+			"integrity": "sha1-YbAzgwKy/p+Vfcwy/CqH8cMEixE=",
+			"dev": true,
+			"dependencies": {
+				"flatted": "^3.1.0",
+				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.2.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/flatted/-/flatted-3.2.2.tgz",
+			"integrity": "sha1-ZL/tXLaP48p4s+shStl7Y77c5WE=",
+			"dev": true
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.14.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+			"dev": true
+		},
+		"node_modules/functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
+		"node_modules/get-assigned-identifiers": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+			"integrity": "sha1-bb9BHeZIy6+NkWnrsNLVdhkeL/E=",
+			"dev": true
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/globals": {
+			"version": "13.11.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/globals/-/globals-13.11.0.tgz",
+			"integrity": "sha1-QO9njaEX/nvS4o8fqySVG9AlW+c=",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globby": {
+			"version": "11.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/globby/-/globby-11.0.4.tgz",
+			"integrity": "sha1-LLr/d8Lypi5x6bKBOme5ejowAaU=",
+			"dev": true,
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.x"
+			}
+		},
+		"node_modules/has": {
+			"version": "1.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/hash-base": {
+			"version": "3.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/hash-base/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true,
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"dev": true,
+			"dependencies": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
+		"node_modules/htmlescape": {
+			"version": "1.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/htmlescape/-/htmlescape-1.1.1.tgz",
+			"integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/https-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+			"dev": true
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/ignore": {
+			"version": "5.1.8",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ignore/-/ignore-5.1.8.tgz",
+			"integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc=",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/import-fresh": {
+			"version": "3.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
+			"dev": true,
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+			"dev": true
+		},
+		"node_modules/inline-source-map": {
+			"version": "0.6.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/inline-source-map/-/inline-source-map-0.6.2.tgz",
+			"integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+			"dev": true,
+			"dependencies": {
+				"source-map": "~0.5.3"
+			}
+		},
+		"node_modules/inline-source-map/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/insert-module-globals": {
+			"version": "7.2.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+			"integrity": "sha1-1eMxhRgaTh8zsV978QDukYkNXLM=",
+			"dev": true,
+			"dependencies": {
+				"acorn-node": "^1.5.2",
+				"combine-source-map": "^0.8.0",
+				"concat-stream": "^1.6.1",
+				"is-buffer": "^1.1.0",
+				"JSONStream": "^1.0.3",
+				"path-is-absolute": "^1.0.1",
+				"process": "~0.11.0",
+				"through2": "^2.0.0",
+				"undeclared-identifiers": "^1.1.2",
+				"xtend": "^4.0.0"
+			},
+			"bin": {
+				"insert-module-globals": "bin/cmd.js"
+			}
+		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+			"dev": true
+		},
+		"node_modules/is-core-module": {
+			"version": "2.6.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/is-core-module/-/is-core-module-2.6.0.tgz",
+			"integrity": "sha1-11U7JSb+Wbkro+QMjfdX7Ipwnhk=",
+			"dev": true,
+			"dependencies": {
+				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+			"dev": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+			"dev": true
+		},
+		"node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+			"dev": true
+		},
+		"node_modules/json-stable-stringify": {
+			"version": "0.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+			"integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+			"dev": true,
+			"dependencies": {
+				"jsonify": "~0.0.0"
+			}
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/jsonparse": {
+			"version": "1.3.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/jsonparse/-/jsonparse-1.3.1.tgz",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"dev": true,
+			"engines": [
+				"node >= 0.2.0"
+			]
+		},
+		"node_modules/JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha1-MgjB8I06TZkmGrZPkjArwV4RHKA=",
+			"dev": true,
+			"dependencies": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			},
+			"bin": {
+				"JSONStream": "bin.js"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/labeled-stream-splicer": {
+			"version": "2.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+			"integrity": "sha1-QqQaFqvNRv0EYwbPTyw1dv/7HCE=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"stream-splicer": "^2.0.0"
+			}
+		},
+		"node_modules/levn": {
+			"version": "0.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+			"dev": true
+		},
+		"node_modules/lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
+		"node_modules/lodash.memoize": {
+			"version": "3.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+			"integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+			"dev": true
+		},
+		"node_modules/lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
+			"dev": true
+		},
+		"node_modules/lodash.truncate": {
+			"version": "4.4.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+			"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+			"dev": true
+		},
+		"node_modules/log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/log-symbols/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/log-symbols/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/log-symbols/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/log-symbols/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/log-symbols/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha1-b6I3xj29xKgsoP2ILkci3F5jTig=",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/lower-case/node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE=",
+			"dev": true
+		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.25.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/magic-string/-/magic-string-0.25.1.tgz",
+			"integrity": "sha1-scJIs5nNdIXaD+c4XC/HARhDJm4=",
+			"dev": true,
+			"dependencies": {
+				"sourcemap-codec": "^1.4.1"
+			}
+		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
+		"node_modules/md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+			"dev": true,
+			"dependencies": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"node_modules/merge-source-map": {
+			"version": "1.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/merge-source-map/-/merge-source-map-1.0.4.tgz",
+			"integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+			"dev": true,
+			"dependencies": {
+				"source-map": "^0.5.6"
+			}
+		},
+		"node_modules/merge-source-map/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/micromatch/-/micromatch-4.0.4.tgz",
+			"integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+			"dev": true,
+			"dependencies": {
+				"braces": "^3.0.1",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/miller-rabin": {
+			"version": "4.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/miller-rabin/-/miller-rabin-4.0.1.tgz",
+			"integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+			"dependencies": {
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
+			},
+			"bin": {
+				"miller-rabin": "bin/miller-rabin"
+			}
+		},
+		"node_modules/minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+			"dev": true
+		},
+		"node_modules/minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"dev": true
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+			"dev": true
+		},
+		"node_modules/mkdirp": {
+			"version": "0.5.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.5"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=",
+			"dev": true
+		},
+		"node_modules/mocha": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+			"integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+			"dev": true,
+			"dependencies": {
+				"@ungap/promise-all-settled": "1.1.2",
+				"ansi-colors": "4.1.1",
+				"browser-stdout": "1.3.1",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
+				"diff": "5.0.0",
+				"escape-string-regexp": "4.0.0",
+				"find-up": "5.0.0",
+				"glob": "7.2.0",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "4.1.0",
+				"log-symbols": "4.1.0",
+				"minimatch": "4.2.1",
+				"ms": "2.1.3",
+				"nanoid": "3.3.1",
+				"serialize-javascript": "6.0.0",
+				"strip-json-comments": "3.1.1",
+				"supports-color": "8.1.1",
+				"which": "2.0.2",
+				"workerpool": "6.2.0",
+				"yargs": "16.2.0",
+				"yargs-parser": "20.2.4",
+				"yargs-unparser": "2.0.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mochajs"
+			}
+		},
+		"node_modules/mocha-junit-reporter": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.0.2.tgz",
+			"integrity": "sha512-vYwWq5hh3v1lG0gdQCBxwNipBfvDiAM1PHroQRNp96+2l72e9wEUTw+mzoK+O0SudgfQ7WvTQZ9Nh3qkAYAjfg==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^2.2.0",
+				"md5": "^2.1.0",
+				"mkdirp": "~0.5.1",
+				"strip-ansi": "^6.0.1",
+				"xml": "^1.0.0"
+			},
+			"peerDependencies": {
+				"mocha": ">=2.2.5"
+			}
+		},
+		"node_modules/mocha-junit-reporter/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/mocha-junit-reporter/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true
+		},
+		"node_modules/mocha-multi-reporters": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.5.1.tgz",
+			"integrity": "sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"lodash": "^4.17.15"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			},
+			"peerDependencies": {
+				"mocha": ">=3.1.2"
+			}
+		},
+		"node_modules/mocha/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/mocha/node_modules/diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/mocha/node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/mocha/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+			"integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/mocha/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true
+		},
+		"node_modules/mocha/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/mocha/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/module-deps": {
+			"version": "6.2.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/module-deps/-/module-deps-6.2.3.tgz",
+			"integrity": "sha1-FUkLwCr0tWz2IpnHwXy6Mtcalu4=",
+			"dev": true,
+			"dependencies": {
+				"browser-resolve": "^2.0.0",
+				"cached-path-relative": "^1.0.2",
+				"concat-stream": "~1.6.0",
+				"defined": "^1.0.0",
+				"detective": "^5.2.0",
+				"duplexer2": "^0.1.2",
+				"inherits": "^2.0.1",
+				"JSONStream": "^1.0.3",
+				"parents": "^1.0.0",
+				"readable-stream": "^2.0.2",
+				"resolve": "^1.4.0",
+				"stream-combiner2": "^1.1.1",
+				"subarg": "^1.0.0",
+				"through2": "^2.0.0",
+				"xtend": "^4.0.0"
+			},
+			"bin": {
+				"module-deps": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/moment": {
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+			"integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+			"dev": true,
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"node_modules/nerdbank-gitversioning": {
+			"version": "3.4.231",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/nerdbank-gitversioning/-/nerdbank-gitversioning-3.4.231.tgz",
+			"integrity": "sha1-C8rfYQHGaH6NJF1dreSch6ut+OA=",
+			"dev": true,
+			"dependencies": {
+				"camel-case": "^4.1.1"
+			},
+			"bin": {
+				"nbgv": "main.js",
+				"nbgv-setversion": "npmVersion.js"
+			}
+		},
+		"node_modules/next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+			"dev": true
+		},
+		"node_modules/no-case": {
+			"version": "3.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha1-02H9XJgA9VhVGoNp/A3NRmK2Ek0=",
+			"dev": true,
+			"dependencies": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/no-case/node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE=",
+			"dev": true
+		},
+		"node_modules/node-gyp-build": {
+			"version": "4.2.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+			"integrity": "sha1-zmJ3+FODX3GIKe+0fbIPPk2cRzk=",
+			"dev": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.11.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/object-inspect/-/object-inspect-1.11.0.tgz",
+			"integrity": "sha1-nc6xRs7dQUig2eUauI00z1CZIrE=",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/optionator": {
+			"version": "0.8.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+			"dev": true,
+			"dependencies": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.6",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"word-wrap": "~1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/os-browserify": {
+			"version": "0.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+			"dev": true
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
+			"dev": true
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+			"dev": true,
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/parents": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/parents/-/parents-1.0.1.tgz",
+			"integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+			"dev": true,
+			"dependencies": {
+				"path-platform": "~0.11.15"
+			}
+		},
+		"node_modules/parse-asn1": {
+			"version": "5.1.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/parse-asn1/-/parse-asn1-5.1.6.tgz",
+			"integrity": "sha1-OFCAo+wTy2KmLTlAnLPoiETNrtQ=",
+			"dev": true,
+			"dependencies": {
+				"asn1.js": "^5.2.0",
+				"browserify-aes": "^1.0.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"node_modules/pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha1-tI4O8rmOIF58Ha50fQsVCCN2YOs=",
+			"dev": true,
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/pascal-case/node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE=",
+			"dev": true
+		},
+		"node_modules/path-browserify": {
+			"version": "0.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/path-browserify/-/path-browserify-0.0.1.tgz",
+			"integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
+			"dev": true
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+			"dev": true
+		},
+		"node_modules/path-platform": {
+			"version": "0.11.15",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/path-platform/-/path-platform-0.11.15.tgz",
+			"integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pbkdf2": {
+			"version": "3.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/pbkdf2/-/pbkdf2-3.1.2.tgz",
+			"integrity": "sha1-3YIqoIh1gOUvGgOdw+2hCO+uMHU=",
+			"dev": true,
+			"dependencies": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/picomatch/-/picomatch-2.3.0.tgz",
+			"integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "1.19.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha1-0j1B/hN1ZG3i0BBNNFSjAIgCz3s=",
+			"dev": true,
+			"dependencies": {
+				"fast-diff": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+			"dev": true
+		},
+		"node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/public-encrypt": {
+			"version": "4.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/public-encrypt/-/public-encrypt-4.0.3.tgz",
+			"integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "1.4.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
+		},
+		"node_modules/querystring": {
+			"version": "0.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.x"
+			}
+		},
+		"node_modules/querystring-es3": {
+			"version": "0.2.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/querystring-es3/-/querystring-es3-0.2.1.tgz",
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.x"
+			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/quote-stream": {
+			"version": "1.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/quote-stream/-/quote-stream-1.0.2.tgz",
+			"integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
+			"dev": true,
+			"dependencies": {
+				"buffer-equal": "0.0.1",
+				"minimist": "^1.1.3",
+				"through2": "^2.0.0"
+			},
+			"bin": {
+				"quote-stream": "bin/cmd.js"
+			}
+		},
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/randomfill": {
+			"version": "1.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+			"dev": true,
+			"dependencies": {
+				"randombytes": "^2.0.5",
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/read-only-stream": {
+			"version": "2.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/read-only-stream/-/read-only-stream-2.0.0.tgz",
+			"integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+			"dev": true,
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"dev": true
+		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/regexpp": {
+			"version": "3.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha1-BCWido2PI7rXDKS5BGH6LxIT4bI=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.20.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.2.0",
+				"path-parse": "^1.0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+			"dev": true,
+			"dependencies": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+			"dev": true
+		},
+		"node_modules/scope-analyzer": {
+			"version": "2.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/scope-analyzer/-/scope-analyzer-2.1.1.tgz",
+			"integrity": "sha1-UVbCfeCE10v3WvnpUGqvlcbnPdY=",
+			"dev": true,
+			"dependencies": {
+				"array-from": "^2.1.1",
+				"dash-ast": "^1.0.0",
+				"es6-map": "^0.1.5",
+				"es6-set": "^0.1.5",
+				"es6-symbol": "^3.1.1",
+				"estree-is-function": "^1.0.0",
+				"get-assigned-identifiers": "^1.1.0"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.3.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/serialize-javascript": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"dev": true,
+			"dependencies": {
+				"randombytes": "^2.1.0"
+			}
+		},
+		"node_modules/sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			},
+			"bin": {
+				"sha.js": "bin.js"
+			}
+		},
+		"node_modules/shallow-copy": {
+			"version": "0.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/shallow-copy/-/shallow-copy-0.0.1.tgz",
+			"integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=",
+			"dev": true
+		},
+		"node_modules/shasum": {
+			"version": "1.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/shasum/-/shasum-1.0.2.tgz",
+			"integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+			"dev": true,
+			"dependencies": {
+				"json-stable-stringify": "~0.0.0",
+				"sha.js": "~2.4.4"
+			}
+		},
+		"node_modules/shasum-object": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/shasum-object/-/shasum-object-1.0.0.tgz",
+			"integrity": "sha1-C3t0/1tm7PkDVHVSL6BQkKxH4p4=",
+			"dev": true,
+			"dependencies": {
+				"fast-safe-stringify": "^2.0.7"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shell-quote": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+			"integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+			"dev": true
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8=",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha1-UA6N0P1VsFgVCGJVsxla3ypF/ms=",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+			"dev": true
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.20",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/source-map-support/-/source-map-support-0.5.20.tgz",
+			"integrity": "sha1-EhZgifj15ejFaSazd2Mzkt0stsk=",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
+			"dev": true
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"node_modules/static-eval": {
+			"version": "2.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/static-eval/-/static-eval-2.1.0.tgz",
+			"integrity": "sha1-oW2+VFItf6XvE4kSnYE/1HsUgBQ=",
+			"dev": true,
+			"dependencies": {
+				"escodegen": "^1.11.1"
+			}
+		},
+		"node_modules/static-module": {
+			"version": "3.0.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/static-module/-/static-module-3.0.4.tgz",
+			"integrity": "sha1-v70dHDjdH7vwu0rwwbOuGKk6K2g=",
+			"dev": true,
+			"dependencies": {
+				"acorn-node": "^1.3.0",
+				"concat-stream": "~1.6.0",
+				"convert-source-map": "^1.5.1",
+				"duplexer2": "~0.1.4",
+				"escodegen": "^1.11.1",
+				"has": "^1.0.1",
+				"magic-string": "0.25.1",
+				"merge-source-map": "1.0.4",
+				"object-inspect": "^1.6.0",
+				"readable-stream": "~2.3.3",
+				"scope-analyzer": "^2.0.1",
+				"shallow-copy": "~0.0.1",
+				"static-eval": "^2.0.5",
+				"through2": "~2.0.3"
+			}
+		},
+		"node_modules/stream-browserify": {
+			"version": "2.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/stream-browserify/-/stream-browserify-2.0.2.tgz",
+			"integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/stream-combiner2": {
+			"version": "1.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+			"integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+			"dev": true,
+			"dependencies": {
+				"duplexer2": "~0.1.0",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/stream-http": {
+			"version": "3.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/stream-http/-/stream-http-3.2.0.tgz",
+			"integrity": "sha1-GHLfzyTLFXUmd+QOXD+cwZJgKLU=",
+			"dev": true,
+			"dependencies": {
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"xtend": "^4.0.2"
+			}
+		},
+		"node_modules/stream-http/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/stream-splicer": {
+			"version": "2.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/stream-splicer/-/stream-splicer-2.0.1.tgz",
+			"integrity": "sha1-CxO37itax+BgmnRj2DiZWJo2P80=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"dev": true
+		},
+		"node_modules/string-width": {
+			"version": "4.2.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/string-width/-/string-width-4.2.2.tgz",
+			"integrity": "sha1-2v1PlVmnWFz7pSnGoKT3NIjr1MU=",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/subarg": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/subarg/-/subarg-1.0.0.tgz",
+			"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.1.0"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/syntax-error": {
+			"version": "1.4.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/syntax-error/-/syntax-error-1.4.0.tgz",
+			"integrity": "sha1-LZ1P9cBkrLcRWUo+O5UFStUdkHw=",
+			"dev": true,
+			"dependencies": {
+				"acorn-node": "^1.2.0"
+			}
+		},
+		"node_modules/table": {
+			"version": "6.7.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/table/-/table-6.7.1.tgz",
+			"integrity": "sha1-7gVZK3FDgxqMlPPO5qrkwczvM+I=",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^8.0.1",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/table/node_modules/ajv": {
+			"version": "8.6.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ajv/-/ajv-8.6.2.tgz",
+			"integrity": "sha1-L7ReDl/LwIEzJsHD2lNdGIG7BXE=",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/table/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
+			"dev": true
+		},
+		"node_modules/text-table": {
+			"version": "0.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"node_modules/through": {
+			"version": "2.3.8",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"node_modules/through2": {
+			"version": "2.0.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
+		"node_modules/timers-browserify": {
+			"version": "1.4.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/timers-browserify/-/timers-browserify-1.4.2.tgz",
+			"integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+			"dev": true,
+			"dependencies": {
+				"process": "~0.11.0"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/tmp": {
+			"version": "0.1.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tmp/-/tmp-0.1.0.tgz",
+			"integrity": "sha1-7kNKTiJUMILilLpiAdzG6v76KHc=",
+			"dev": true,
+			"dependencies": {
+				"rimraf": "^2.6.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tmp/node_modules/rimraf": {
+			"version": "2.7.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+			"dev": true,
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+			"dev": true
+		},
+		"node_modules/tslint": {
+			"version": "6.1.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tslint/-/tslint-6.1.3.tgz",
+			"integrity": "sha1-XCOy7MwySH1VI706Rw6aoxeJ2QQ=",
+			"deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^4.0.1",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.13.1",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.3",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.13.0",
+				"tsutils": "^2.29.0"
+			},
+			"bin": {
+				"tslint": "bin/tslint"
+			},
+			"engines": {
+				"node": ">=4.8.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev"
+			}
+		},
+		"node_modules/tslint-microsoft-contrib": {
+			"version": "6.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.2.0.tgz",
+			"integrity": "sha1-iqD0BYTQZtBeal55iNpRY7hfKtQ=",
+			"dev": true,
+			"dependencies": {
+				"tsutils": "^2.27.2 <2.29.0"
+			},
+			"peerDependencies": {
+				"tslint": "^5.1.0",
+				"typescript": "^2.1.0 || ^3.0.0"
+			}
+		},
+		"node_modules/tslint-microsoft-contrib/node_modules/tsutils": {
+			"version": "2.28.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tsutils/-/tsutils-2.28.0.tgz",
+			"integrity": "sha1-a9ceFggo+dAZtvToRHQiKPhRaaE=",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^1.8.1"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
+			}
+		},
+		"node_modules/tslint/node_modules/semver": {
+			"version": "5.7.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/tslint/node_modules/tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^1.8.1"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
+			}
+		},
+		"node_modules/tsutils": {
+			"version": "3.21.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tsutils/-/tsutils-3.21.0.tgz",
+			"integrity": "sha1-tIcX05TOpsHglpg+7Vjp1hcVtiM=",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^1.8.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+			}
+		},
+		"node_modules/tty-browserify": {
+			"version": "0.0.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/tty-browserify/-/tty-browserify-0.0.1.tgz",
+			"integrity": "sha1-PwUlHuF5BN/QZ3VGZw25ZRaCuBE=",
+			"dev": true
+		},
+		"node_modules/type": {
+			"version": "1.2.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/type/-/type-1.2.0.tgz",
+			"integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A=",
+			"dev": true
+		},
+		"node_modules/type-check": {
+			"version": "0.3.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"node_modules/typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+			"dev": true,
+			"dependencies": {
+				"is-typedarray": "^1.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.4.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/typescript/-/typescript-4.4.2.tgz",
+			"integrity": "sha1-bWGGQNQw41aaHftE99fmAM7T7oY=",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/umd": {
+			"version": "3.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/umd/-/umd-3.0.3.tgz",
+			"integrity": "sha1-qp/mU8QrkJdnhInAEACstp8LJs8=",
+			"dev": true,
+			"bin": {
+				"umd": "bin/cli.js"
+			}
+		},
+		"node_modules/undeclared-identifiers": {
+			"version": "1.1.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+			"integrity": "sha1-klTB03vawKwrUt5LZyJ5LSqR4w8=",
+			"dev": true,
+			"dependencies": {
+				"acorn-node": "^1.3.0",
+				"dash-ast": "^1.0.0",
+				"get-assigned-identifiers": "^1.2.0",
+				"simple-concat": "^1.0.0",
+				"xtend": "^4.0.1"
+			},
+			"bin": {
+				"undeclared-identifiers": "bin.js"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/uri-js/node_modules/punycode": {
+			"version": "2.1.1",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/url": {
+			"version": "0.11.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"dev": true,
+			"dependencies": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			}
+		},
+		"node_modules/url/node_modules/punycode": {
+			"version": "1.3.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/punycode/-/punycode-1.3.2.tgz",
+			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+			"dev": true
+		},
+		"node_modules/utf-8-validate": {
+			"version": "5.0.5",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
+			"integrity": "sha1-3TLC6CxyAC3J8C62e6Z2H0NFbKE=",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-gyp-build": "^4.2.0"
+			}
+		},
+		"node_modules/util": {
+			"version": "0.10.4",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/util/-/util-0.10.4.tgz",
+			"integrity": "sha1-OqASW/5mikZy3liFfTrOJ+y3aQE=",
+			"dev": true,
+			"dependencies": {
+				"inherits": "2.0.3"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"node_modules/util/node_modules/inherits": {
+			"version": "2.0.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
+		"node_modules/v8-compile-cache": {
+			"version": "2.3.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+			"integrity": "sha1-LeGWGMZtwkfc+2+ZM4A12CRaLO4=",
+			"dev": true
+		},
+		"node_modules/vm-browserify": {
+			"version": "1.1.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/vm-browserify/-/vm-browserify-1.1.2.tgz",
+			"integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
+			"dev": true
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "4.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+			"integrity": "sha1-p7907zJU0KDCcvqxXIISjjeLO+k=",
+			"engines": {
+				"node": ">=8.0.0 || >=10.0.0"
+			}
+		},
+		"node_modules/websocket": {
+			"version": "1.0.34",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/websocket/-/websocket-1.0.34.tgz",
+			"integrity": "sha1-K9wmAsCL8sgiU7cwZVwO99yrMRE=",
+			"dev": true,
+			"dependencies": {
+				"bufferutil": "^4.0.1",
+				"debug": "^2.2.0",
+				"es5-ext": "^0.10.50",
+				"typedarray-to-buffer": "^3.1.5",
+				"utf-8-validate": "^5.0.2",
+				"yaeti": "^0.0.6"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/websocket/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/websocket/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/workerpool": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+			"dev": true
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"node_modules/xml": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+			"integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+			"dev": true
+		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yaeti": {
+			"version": "0.0.6",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/yaeti/-/yaeti-0.0.6.tgz",
+			"integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.32"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+			"dev": true
+		},
+		"node_modules/yargs": {
+			"version": "17.2.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
+			"integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.4",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+			"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-unparser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	},
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.12.11",
@@ -72,9 +4880,9 @@
 			"dev": true
 		},
 		"@microsoft/dev-tunnels-ssh": {
-			"version": "3.10.26",
-			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.10.26.tgz",
-			"integrity": "sha512-w6cj5iblpc4yw2g/murihbVAwnoy1ukWg7iGkaltg/PWJwR768SD2J5IgGcIv5I1/HMLhvtGlUffjBkgNQmhTg==",
+			"version": "3.10.27",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.10.27.tgz",
+			"integrity": "sha512-LV0ssAsZc1kt2YG931E+0ikFyg7j/G+pIRgDYxVZ284t0z1N2L+Oqfp+50U8wxUicrw59uzZG67oNrFKBNpBBw==",
 			"requires": {
 				"buffer": "^5.2.1",
 				"debug": "^4.1.1",
@@ -83,9 +4891,9 @@
 			}
 		},
 		"@microsoft/dev-tunnels-ssh-tcp": {
-			"version": "3.10.26",
-			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.10.26.tgz",
-			"integrity": "sha512-X2MsRaC478nbGEew0LJMurG+mpLkb8p0sDo6B7d/GynM0gMNg5UZJM05wrEbJ5CEZnf04SMceAEUtOZTO8/DVA==",
+			"version": "3.10.27",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.10.27.tgz",
+			"integrity": "sha512-f3E/gY8FE6CkJRBMB0KuUD7wDEHHexhv6Gs0h0HA5UhmSe8xrOFmEONLV/77D58kzr7o9cg6ZThQ0JvWaIgVag==",
 			"requires": {
 				"@microsoft/dev-tunnels-ssh": "~3.10"
 			}

--- a/ts/package.json
+++ b/ts/package.json
@@ -21,8 +21,8 @@
 		"build-pack-publish": "npm run build && npm run pack && npm run publish"
 	},
 	"dependencies": {
-		"@microsoft/dev-tunnels-ssh": "^3.10.26",
-		"@microsoft/dev-tunnels-ssh-tcp": "^3.10.26",
+		"@microsoft/dev-tunnels-ssh": "^3.10.27",
+		"@microsoft/dev-tunnels-ssh-tcp": "^3.10.27",
 		"await-semaphore": "^0.1.3",
 		"axios": "^0.21.1",
 		"buffer": "^5.2.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -21,8 +21,8 @@
 		"build-pack-publish": "npm run build && npm run pack && npm run publish"
 	},
 	"dependencies": {
-		"@microsoft/dev-tunnels-ssh": "^3.10.27",
-		"@microsoft/dev-tunnels-ssh-tcp": "^3.10.27",
+		"@microsoft/dev-tunnels-ssh": "^3.10.29",
+		"@microsoft/dev-tunnels-ssh-tcp": "^3.10.29",
 		"await-semaphore": "^0.1.3",
 		"axios": "^0.21.1",
 		"buffer": "^5.2.1",


### PR DESCRIPTION
This change implements the host and client SDK parts of the V2 relay connection protocol, for C# only. Ports to other SDK languages will come in separate PR(s).

For design & background info, refer to the [ADR](https://github.com/microsoft/basis-planning/blob/main/ADRs/0029-tunnel-connection-protocol.md).

Host and client SDKs have simultaneous support for V1 and V2 protocols; they prefer V2 but allow the service to choose V1 via the websocket subprotocol negotiation. So the V2 protocol is not used unless the service enables it, and that is currently conditional on a feature flag.

SDK client changes:
 - The client configures the SSH session to support negotiation of no encryption. Since that session is not E2E encrypted, it's more efficient to skip it. (V2 E2E encryption will be added back in in a future PR.)
 - The client sends its access token whenever it opens a new connection, using an extension of the `PortForwardChannelOpenMessage` class.

SDK host changes:
 - The host configures its SSH session with optional encryption, rather than using a SSH `MultiChannelStream`. That allows for more flexibility in dealing with session requests and port-forwarding.
 - The host sends its access token whenever it forwards a port, using an extension of the `PortForwardRequestMessage` class.
 - The host handles incoming client channels differently for V2 vs V1 because there's no longer an embedded session for each client. (Refer to the ADR.)

Additionally, the `TunnelAccessTokenProperties` now supports multiple port number claims in the token, that is necessary for scenarios when the client has limited access to only some port(s) but no tunnel-level access.