### PR TITLE
Add tunnel client local address property

### DIFF
--- a/cs/src/Connections/ITunnelClient.cs
+++ b/cs/src/Connections/ITunnelClient.cs
@@ -6,131 +6,148 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DevTunnels.Ssh.Tcp.Events;
 using Microsoft.DevTunnels.Contracts;
 using Microsoft.DevTunnels.Management;
 
-namespace Microsoft.DevTunnels.Connections
+namespace Microsoft.DevTunnels.Connections;
+
+/// <summary>
+/// Interface for a client capable of making a connection to a tunnel and
+/// forwarding ports over the tunnel.
+/// </summary>
+public interface ITunnelClient : IAsyncDisposable
 {
     /// <summary>
-    /// Interface for a client capable of making a connection to a tunnel and
-    /// forwarding ports over the tunnel.
+    /// Gets the list of connection modes that this client supports.
     /// </summary>
-    public interface ITunnelClient : IAsyncDisposable
-    {
-        /// <summary>
-        /// Gets the list of connection modes that this client supports.
-        /// </summary>
-        IReadOnlyCollection<TunnelConnectionMode> ConnectionModes { get; }
+    IReadOnlyCollection<TunnelConnectionMode> ConnectionModes { get; }
 
-        /// <summary>
-        /// Gets list of ports forwarded to client, this collection
-        /// contains events to notify when ports are forwarded
-        /// </summary>
-        ForwardedPortsCollection? ForwardedPorts { get; }
+    /// <summary>
+    /// Gets list of ports forwarded to client, this collection
+    /// contains events to notify when ports are forwarded
+    /// </summary>
+    ForwardedPortsCollection? ForwardedPorts { get; }
 
-        /// <summary>
-        ///  A value indicating whether local connections for forwarded ports are accepted.
-        /// </summary>
-        bool AcceptLocalConnectionsForForwardedPorts { get; set; }
+    /// <summary>
+    /// Gets or sets a value indicating whether local connections for forwarded ports are
+    /// accepted.
+    /// </summary>
+    /// <remarks>
+    /// Default: true
+    /// </remarks>
+    bool AcceptLocalConnectionsForForwardedPorts { get; set; }
 
-        /// <summary>
-        /// Gets the connection status.
-        /// </summary>
-        ConnectionStatus ConnectionStatus { get; }
+    /// <summary>
+    /// Gets or sets the local network interface address that the tunnel client listens on when
+    /// accepting connections for forwarded ports.
+    /// </summary>
+    /// <remarks>
+    /// The default value is the loopback address (127.0.0.1). Applications may set this to the
+    /// address indicating any interface (0.0.0.0) or to the address of a specific interface.
+    /// The tunnel client supports both IPv4 and IPv6 when listening on either loopback or
+    /// any interface.
+    /// </remarks>
+    IPAddress LocalForwardingHostAddress { get; set; }
 
-        /// <summary>
-        /// Gets the exception that caused disconnection.
-        /// Null if not yet connected or disconnection was caused by disposing of this object.
-        /// </summary>
-        Exception? DisconnectException { get; }
+    /// <summary>
+    /// Gets the connection status.
+    /// </summary>
+    ConnectionStatus ConnectionStatus { get; }
 
-        /// <summary>
-        /// Connects to a tunnel.
-        /// </summary>
-        /// <param name="tunnel">Tunnel to connect to.</param>
-        /// <param name="cancellation">Cancellation token.</param>
-        /// <remarks>
-        /// Once connected, tunnel ports are forwarded by the host.
-        /// The client either needs to be logged in as the owner identity, or have
-        /// an access token with "connect" scope for the tunnel.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
-        /// <exception cref="UnauthorizedAccessException">The client does not have
-        /// access to connect to the tunnel.</exception>
-        /// <exception cref="TunnelConnectionException">The client failed to connect to the
-        /// tunnel, or connected but encountered a protocol errror.</exception>
-        Task ConnectAsync(Tunnel tunnel, CancellationToken cancellation)
-            => ConnectAsync(tunnel, hostId: null, cancellation);
+    /// <summary>
+    /// Gets the exception that caused disconnection.
+    /// Null if not yet connected or disconnection was caused by disposing of this object.
+    /// </summary>
+    Exception? DisconnectException { get; }
 
-        /// <summary>
-        /// Connects to a tunnel.
-        /// </summary>
-        /// <param name="tunnel">Tunnel to connect to.</param>
-        /// <param name="hostId">ID of the tunnel host to connect to, if there are multiple
-        /// hosts accepting connections on the tunnel, or null to connect to a single host
-        /// (most common).</param>
-        /// <param name="cancellation">Cancellation token.</param>
-        /// <remarks>
-        /// Once connected, tunnel ports are forwarded by the host.
-        /// The client either needs to be logged in as the owner identity, or have
-        /// an access token with "connect" scope for the tunnel.
-        /// </remarks>
-        /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
-        /// <exception cref="UnauthorizedAccessException">The client does not have
-        /// access to connect to the tunnel.</exception>
-        /// <exception cref="TunnelConnectionException">The client failed to connect to the
-        /// tunnel, or connected but encountered a protocol errror.</exception>
-        Task ConnectAsync(Tunnel tunnel, string? hostId, CancellationToken cancellation);
+    /// <summary>
+    /// Connects to a tunnel.
+    /// </summary>
+    /// <param name="tunnel">Tunnel to connect to.</param>
+    /// <param name="cancellation">Cancellation token.</param>
+    /// <remarks>
+    /// Once connected, tunnel ports are forwarded by the host.
+    /// The client either needs to be logged in as the owner identity, or have
+    /// an access token with "connect" scope for the tunnel.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
+    /// <exception cref="UnauthorizedAccessException">The client does not have
+    /// access to connect to the tunnel.</exception>
+    /// <exception cref="TunnelConnectionException">The client failed to connect to the
+    /// tunnel, or connected but encountered a protocol errror.</exception>
+    Task ConnectAsync(Tunnel tunnel, CancellationToken cancellation)
+        => ConnectAsync(tunnel, hostId: null, cancellation);
 
-        /// <summary>
-        /// Waits for the specified port to be forwarded by the remote host.
-        /// </summary>
-        /// <param name="forwardedPort">Remote port to wait for.</param>
-        /// <param name="cancellation">Cancellation token for the request</param>
-        /// <exception cref="InvalidOperationException">Throws if called before the client has connected.</exception>
-        Task WaitForForwardedPortAsync(int forwardedPort, CancellationToken cancellation);
+    /// <summary>
+    /// Connects to a tunnel.
+    /// </summary>
+    /// <param name="tunnel">Tunnel to connect to.</param>
+    /// <param name="hostId">ID of the tunnel host to connect to, if there are multiple
+    /// hosts accepting connections on the tunnel, or null to connect to a single host
+    /// (most common).</param>
+    /// <param name="cancellation">Cancellation token.</param>
+    /// <remarks>
+    /// Once connected, tunnel ports are forwarded by the host.
+    /// The client either needs to be logged in as the owner identity, or have
+    /// an access token with "connect" scope for the tunnel.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
+    /// <exception cref="UnauthorizedAccessException">The client does not have
+    /// access to connect to the tunnel.</exception>
+    /// <exception cref="TunnelConnectionException">The client failed to connect to the
+    /// tunnel, or connected but encountered a protocol errror.</exception>
+    Task ConnectAsync(Tunnel tunnel, string? hostId, CancellationToken cancellation);
 
-        /// <summary>
-        /// Opens a stream connected to a remote port for clients which cannot or do not want to forward local TCP ports.
-        /// Returns null if the session gets closed, or the port is no longer forwarded by the host.
-        /// </summary>
-        /// <remarks>
-        /// Set <see cref="AcceptLocalConnectionsForForwardedPorts"/> to <c>false</c> before calling <see cref="ConnectAsync(Tunnel, CancellationToken)"/> to ensure
-        /// that forwarded tunnel ports won't get local TCP listeners.
-        /// </remarks>
-        /// <param name="forwardedPort">Remote port to connect to.</param>
-        /// <param name="cancellation">Cancellation token for the request.</param>
-        /// <returns>A <see cref="Task{Stream}"/> representing the result of the asynchronous operation.</returns>
-        /// <exception cref="InvalidOperationException">If the tunnel is not yet connected and hasn't started connecting.</exception>
-        Task<Stream?> ConnectToForwardedPortAsync(int forwardedPort, CancellationToken cancellation);
+    /// <summary>
+    /// Waits for the specified port to be forwarded by the remote host.
+    /// </summary>
+    /// <param name="forwardedPort">Remote port to wait for.</param>
+    /// <param name="cancellation">Cancellation token for the request</param>
+    /// <exception cref="InvalidOperationException">Throws if called before the client has connected.</exception>
+    Task WaitForForwardedPortAsync(int forwardedPort, CancellationToken cancellation);
 
-        /// <summary>
-        /// Sends a request to the host to refresh ports that were updated using the management API,
-        /// and waits for the refresh to complete.
-        /// </summary>
-        /// <param name="cancellation">Cancellation token.</param>
-        /// <remarks>
-        /// After calling <see cref="ITunnelManagementClient.CreateTunnelPortAsync"/> or
-        /// <see cref="ITunnelManagementClient.DeleteTunnelPortAsync"/>, call this method to have a
-        /// connected client notify the host to update its cached list of ports. Any added or
-        /// removed ports will then propagate back to the set of ports forwarded by the current
-        /// client. After the returned task has completed, any newly added ports are usable from
-        /// the current client.
-        /// </remarks>
-        Task RefreshPortsAsync(CancellationToken cancellation);
+    /// <summary>
+    /// Opens a stream connected to a remote port for clients which cannot or do not want to forward local TCP ports.
+    /// Returns null if the session gets closed, or the port is no longer forwarded by the host.
+    /// </summary>
+    /// <remarks>
+    /// Set <see cref="AcceptLocalConnectionsForForwardedPorts"/> to <c>false</c> before calling <see cref="ConnectAsync(Tunnel, CancellationToken)"/> to ensure
+    /// that forwarded tunnel ports won't get local TCP listeners.
+    /// </remarks>
+    /// <param name="forwardedPort">Remote port to connect to.</param>
+    /// <param name="cancellation">Cancellation token for the request.</param>
+    /// <returns>A <see cref="Task{Stream}"/> representing the result of the asynchronous operation.</returns>
+    /// <exception cref="InvalidOperationException">If the tunnel is not yet connected and hasn't started connecting.</exception>
+    Task<Stream?> ConnectToForwardedPortAsync(int forwardedPort, CancellationToken cancellation);
 
-        /// <summary>
-        /// Event handler for refreshing the tunnel access token.
-        /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
-        /// </summary>
-        event EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken;
+    /// <summary>
+    /// Sends a request to the host to refresh ports that were updated using the management API,
+    /// and waits for the refresh to complete.
+    /// </summary>
+    /// <param name="cancellation">Cancellation token.</param>
+    /// <remarks>
+    /// After calling <see cref="ITunnelManagementClient.CreateTunnelPortAsync"/> or
+    /// <see cref="ITunnelManagementClient.DeleteTunnelPortAsync"/>, call this method to have a
+    /// connected client notify the host to update its cached list of ports. Any added or
+    /// removed ports will then propagate back to the set of ports forwarded by the current
+    /// client. After the returned task has completed, any newly added ports are usable from
+    /// the current client.
+    /// </remarks>
+    Task RefreshPortsAsync(CancellationToken cancellation);
 
-        /// <summary>
-        /// Connection status changed event.
-        /// </summary>
-        event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
-    }
+    /// <summary>
+    /// Event handler for refreshing the tunnel access token.
+    /// The tunnel client will fire this event when it is not able to use the access token it got from the tunnel.
+    /// </summary>
+    event EventHandler<RefreshingTunnelAccessTokenEventArgs>? RefreshingTunnelAccessToken;
+
+    /// <summary>
+    /// Connection status changed event.
+    /// </summary>
+    event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
 }
+

--- a/cs/src/Connections/MultiModeTunnelClient.cs
+++ b/cs/src/Connections/MultiModeTunnelClient.cs
@@ -8,114 +8,127 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DevTunnels.Ssh.Tcp.Events;
 using Microsoft.DevTunnels.Contracts;
 using Microsoft.DevTunnels.Management;
 
-namespace Microsoft.DevTunnels.Connections
+namespace Microsoft.DevTunnels.Connections;
+
+/// <summary>
+/// Tunnel client implementation that selects one of multiple available connection modes.
+/// </summary>
+public class MultiModeTunnelClient : TunnelConnection, ITunnelClient
 {
     /// <summary>
-    /// Tunnel client implementation that selects one of multiple available connection modes.
+    /// Creates a new instance of the <see cref="MultiModeTunnelClient" /> class
+    /// that can select from among multiple single-mode clients.
     /// </summary>
-    public class MultiModeTunnelClient : TunnelConnection, ITunnelClient
+    public MultiModeTunnelClient(IEnumerable<ITunnelClient> clients, ITunnelManagementClient managementClient, TraceSource trace) : base(managementClient, trace)
     {
-        /// <summary>
-        /// Creates a new instance of the <see cref="MultiModeTunnelClient" /> class
-        /// that can select from among multiple single-mode clients.
-        /// </summary>
-        public MultiModeTunnelClient(IEnumerable<ITunnelClient> clients, ITunnelManagementClient managementClient, TraceSource trace) : base(managementClient, trace)
+        Clients = new List<ITunnelClient>(Requires.NotNull(clients, nameof(clients)));
+        Requires.Argument(
+            Clients.Count() > 0,
+            nameof(clients),
+            "At least one tunnel client is required.");
+
+        // TODO: Subscribe to clients RefreshingTunnelAccessToken event and call TunnelBase.RefreshTunnelAccessTokenAsync() to get the tunnel access token.
+    }
+
+    /// <summary>
+    /// Gets the list of clients that may be used to connect to the tunnel.
+    /// </summary>
+    public IEnumerable<ITunnelClient> Clients { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<TunnelConnectionMode> ConnectionModes
+        => Clients.SelectMany((c) => c.ConnectionModes).Distinct().ToArray();
+
+    /// <inheritdoc />
+    public ForwardedPortsCollection? ForwardedPorts => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public bool AcceptLocalConnectionsForForwardedPorts
+    {
+        get => Clients.Any(c => c.AcceptLocalConnectionsForForwardedPorts);
+        set
         {
-            Clients = new List<ITunnelClient>(Requires.NotNull(clients, nameof(clients)));
-            Requires.Argument(
-                Clients.Count() > 0,
-                nameof(clients),
-                "At least one tunnel client is required.");
-
-            // TODO: Subscribe to clients RefreshingTunnelAccessToken event and call TunnelBase.RefreshTunnelAccessTokenAsync() to get the tunnel access token.
-        }
-
-        /// <summary>
-        /// Gets the list of clients that may be used to connect to the tunnel.
-        /// </summary>
-        public IEnumerable<ITunnelClient> Clients { get; }
-
-        /// <inheritdoc />
-        public IReadOnlyCollection<TunnelConnectionMode> ConnectionModes
-            => Clients.SelectMany((c) => c.ConnectionModes).Distinct().ToArray();
-
-        /// <inheritdoc />
-        public ForwardedPortsCollection? ForwardedPorts => throw new NotImplementedException();
-
-        /// <inheritdoc />
-        public bool AcceptLocalConnectionsForForwardedPorts
-        {
-            get => Clients.Any(c => c.AcceptLocalConnectionsForForwardedPorts);
-            set
-            {
-                foreach (var client in Clients)
-                {
-                    client.AcceptLocalConnectionsForForwardedPorts = value;
-                }
-            }
-        }
-
-        /// <inheritdoc />
-        protected override string TunnelAccessScope => TunnelAccessScopes.Connect;
-
-        /// <inheritdoc />
-        public async Task ConnectAsync(
-            Tunnel tunnel,
-            string? hostId,
-            CancellationToken cancellation)
-        {
-            Requires.NotNull(tunnel, nameof(tunnel));
-
-            // TODO: Filter tunnel endpoints by host ID, if specified.
-            // TODO: Match tunnel endpoints to client connection modes.
-
-            await Task.CompletedTask;
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
-        public Task WaitForForwardedPortAsync(int forwardedPort, CancellationToken cancellation)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
-        public override async ValueTask DisposeAsync()
-        {
-            await base.DisposeAsync();
-
-            var disposeTasks = new List<Task>();
-
             foreach (var client in Clients)
             {
-                disposeTasks.Add(client.DisposeAsync().AsTask());
+                client.AcceptLocalConnectionsForForwardedPorts = value;
             }
-
-            await Task.WhenAll(disposeTasks);
         }
+    }
 
-        /// <inheritdoc />
-        public Task<Stream?> ConnectToForwardedPortAsync(int forwardedPort, CancellationToken cancellation)
+    /// <inheritdoc />
+    public IPAddress LocalForwardingHostAddress
+    {
+        get => Clients.FirstOrDefault()?.LocalForwardingHostAddress ?? IPAddress.Loopback;
+        set
         {
-            throw new NotImplementedException();
+            foreach (var client in Clients)
+            {
+                client.LocalForwardingHostAddress = value;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override string TunnelAccessScope => TunnelAccessScopes.Connect;
+
+    /// <inheritdoc />
+    public async Task ConnectAsync(
+        Tunnel tunnel,
+        string? hostId,
+        CancellationToken cancellation)
+    {
+        Requires.NotNull(tunnel, nameof(tunnel));
+
+        // TODO: Filter tunnel endpoints by host ID, if specified.
+        // TODO: Match tunnel endpoints to client connection modes.
+
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task WaitForForwardedPortAsync(int forwardedPort, CancellationToken cancellation)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+
+        var disposeTasks = new List<Task>();
+
+        foreach (var client in Clients)
+        {
+            disposeTasks.Add(client.DisposeAsync().AsTask());
         }
 
-        /// <inheritdoc />
-        protected override Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
-        {
-            throw new NotImplementedException();
-        }
+        await Task.WhenAll(disposeTasks);
+    }
 
-        /// <inheritdoc />
-        public Task RefreshPortsAsync(CancellationToken cancellation)
-        {
-            throw new NotImplementedException();
-        }
+    /// <inheritdoc />
+    public Task<Stream?> ConnectToForwardedPortAsync(int forwardedPort, CancellationToken cancellation)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    protected override Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task RefreshPortsAsync(CancellationToken cancellation)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/cs/src/Connections/RetryTcpListenerFactory.cs
+++ b/cs/src/Connections/RetryTcpListenerFactory.cs
@@ -11,52 +11,84 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DevTunnels.Ssh.Tcp;
 
-namespace Microsoft.DevTunnels.Connections
+namespace Microsoft.DevTunnels.Connections;
+
+/// <summary>
+/// Implementation of a TCP listener factory that retries forwarding with nearby ports and falls back to a random port.
+/// We make the assumption that the remote port that is being connected to and localPort numbers are the same.
+/// </summary>
+internal class RetryTcpListenerFactory : ITcpListenerFactory
 {
-    /// <summary>
-    /// Implementation of a TCP listener factory that retries forwarding with nearby ports and falls back to a random port.
-    /// We make the assumption that the remote port that is being connected to and localPort numbers are the same.
-    /// </summary>
-    internal class RetryTcpListenerFactory : ITcpListenerFactory
+    public RetryTcpListenerFactory(IPAddress localAddress)
     {
-        /// <inheritdoc />
-        public Task<TcpListener> CreateTcpListenerAsync(
-            IPAddress localIPAddress,
-            int localPort,
-            bool canChangePort,
-            TraceSource trace,
-            CancellationToken cancellation)
+        LocalAddress = localAddress;
+
+        if (localAddress == IPAddress.Loopback)
         {
-            if (localIPAddress == null) throw new ArgumentNullException(nameof(localIPAddress));
+            LocalAddressV6 = IPAddress.IPv6Loopback;
+        }
+        else if (localAddress == IPAddress.Any)
+        {
+            LocalAddressV6 = IPAddress.IPv6Any;
+        }
+    }
 
-            const ushort maxOffet = 10;
-            TcpListener listener;
+    public IPAddress LocalAddress { get; }
 
-            for (ushort offset = 0; ; offset++)
+    public IPAddress? LocalAddressV6 { get; }
+
+    /// <inheritdoc />
+    public Task<TcpListener> CreateTcpListenerAsync(
+        IPAddress localIPAddress,
+        int localPort,
+        bool canChangePort,
+        TraceSource trace,
+        CancellationToken cancellation)
+    {
+        const ushort maxOffet = 10;
+        TcpListener listener;
+
+        // The SSH protocol may specify a local IP address for forwarding, but that is ignored
+        // by tunnels. Instead, the tunnel client can specify the local IP address.
+        if (localIPAddress.AddressFamily == AddressFamily.InterNetwork &&
+            localIPAddress != LocalAddress)
+        {
+            trace.TraceInformation(
+                $"Using local interface address {LocalAddress} instead of {localIPAddress}.");
+            localIPAddress = LocalAddress;
+        }
+        else if (localIPAddress.AddressFamily == AddressFamily.InterNetworkV6 &&
+            LocalAddressV6 != null && localIPAddress != LocalAddressV6)
+        {
+            trace.TraceInformation(
+                $"Using local interface address {LocalAddressV6} instead of {localIPAddress}.");
+            localIPAddress = LocalAddressV6;
+        }
+
+        for (ushort offset = 0; ; offset++)
+        {
+            // After reaching the max offset, pass 0 to pick a random available port.
+            var localPortNumber = offset == maxOffet ? 0 : localPort + offset;
+            try
             {
-                // After reaching the max offset, pass 0 to pick a random available port.
-                var localPortNumber = offset == maxOffet ? 0 : localPort + offset;
-                try
-                {
-                    listener = new TcpListener(localIPAddress, localPortNumber);
-                    listener.Server.SetSocketOption(
-                        SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, false);
+                listener = new TcpListener(localIPAddress, localPortNumber);
+                listener.Server.SetSocketOption(
+                    SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, false);
 
-                    listener.Start();
+                listener.Start();
 
-                    // It is assumed that the localPort passed in is the same as the host port
-                    trace.TraceInformation($"Forwarding from {listener.LocalEndpoint} to host port {localPort}.");
-                    return Task.FromResult(listener);
-                }
-                catch (SocketException sockex)
-                when ((sockex.SocketErrorCode == SocketError.AccessDenied ||
-                    sockex.SocketErrorCode == SocketError.AddressAlreadyInUse) &&
-                    offset < maxOffet && canChangePort)
-                {
-                    trace.TraceEvent(TraceEventType.Verbose, 1, "Listening on port " + localPortNumber + " failed: " + sockex.Message);
-                    trace.TraceEvent(TraceEventType.Verbose, 2, "Incrementing port and trying again");
-                    continue;
-                }
+                // It is assumed that the localPort passed in is the same as the host port
+                trace.TraceInformation($"Forwarding from {listener.LocalEndpoint} to host port {localPort}.");
+                return Task.FromResult(listener);
+            }
+            catch (SocketException sockex)
+            when ((sockex.SocketErrorCode == SocketError.AccessDenied ||
+                sockex.SocketErrorCode == SocketError.AddressAlreadyInUse) &&
+                offset < maxOffet && canChangePort)
+            {
+                trace.TraceEvent(TraceEventType.Verbose, 1, "Listening on port " + localPortNumber + " failed: " + sockex.Message);
+                trace.TraceEvent(TraceEventType.Verbose, 2, "Incrementing port and trying again");
+                continue;
             }
         }
     }

--- a/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelHostAndClientTests.cs
@@ -327,10 +327,13 @@ public class TunnelHostAndClientTests : IClassFixture<LocalPortsFixture>
         await clientConnected.Task;
     }
 
-    [Fact]
-    public async Task ConnectRelayClientAddPort()
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("0.0.0.0")]
+    public async Task ConnectRelayClientAddPort(string localAddress)
     {
         var relayClient = new TunnelRelayTunnelClient(TestTS);
+        relayClient.LocalForwardingHostAddress = IPAddress.Parse(localAddress);
 
         var tunnel = CreateRelayTunnel();
         using var serverSshSession = await ConnectRelayClientAsync(relayClient, tunnel);

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -5109,8 +5109,7 @@
 			"version": "5.3.2",
 			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-node": {
 			"version": "1.8.2",
@@ -6238,8 +6237,7 @@
 			"version": "7.2.0",
 			"resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/NodeRepos/npm/registry/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
 			"integrity": "sha1-9KS9KDLoEOjMfBQR7IWz6FwMU/k=",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-plugin-prettier": {
 			"version": "3.4.1",

--- a/ts/src/connections/multiModeTunnelClient.ts
+++ b/ts/src/connections/multiModeTunnelClient.ts
@@ -34,6 +34,14 @@ export class MultiModeTunnelClient extends TunnelConnectionBase implements Tunne
         this.clients.forEach((c) => (c.acceptLocalConnectionsForForwardedPorts = value));
     }
 
+    public get localForwardingHostAddress(): string {
+        return this.clients[0]?.localForwardingHostAddress;
+    }
+
+    public set localForwardingHostAddress(value: string) {
+        this.clients.forEach((c) => (c.localForwardingHostAddress = value));
+    }
+
     public connect(tunnel: Tunnel, hostId?: string): Promise<void> {
         if (!tunnel) {
             throw new Error('Tunnel cannot be null');

--- a/ts/src/connections/retryTcpListenerFactory.ts
+++ b/ts/src/connections/retryTcpListenerFactory.ts
@@ -11,13 +11,27 @@ import * as net from 'net';
  * We make the assumption that the remote port that is being connected to and localPort numbers are the same.
  */
 export class RetryTcpListenerFactory implements TcpListenerFactory {
+    public constructor(readonly localAddress: string) {}
+
     public async createTcpListener(
         localIPAddress: string,
         localPort: number,
         canChangePort: boolean,
         cancellation?: CancellationToken,
     ): Promise<Server> {
-        if (!localIPAddress) throw new TypeError('Local IP address is required.');
+        // The SSH protocol may specify a local IP address for forwarding, but that is ignored
+        // by tunnels. Instead, the tunnel client can specify the local IP address.
+        if (localIPAddress.indexOf(':') >= 0) {
+            // Convert special local address values from IPv4 to IPv6.
+            if (this.localAddress === '0.0.0.0') {
+                localIPAddress = '::';
+            } else if (this.localAddress === '127.0.0.1') {
+                localIPAddress = '::1';
+            }
+        } else {
+            // IPv4
+            localIPAddress = this.localAddress;
+        }
 
         const maxOffet = 10;
         let listener = net.createServer();

--- a/ts/src/connections/tunnelClient.ts
+++ b/ts/src/connections/tunnelClient.ts
@@ -23,11 +23,20 @@ export interface TunnelClient extends TunnelConnection {
     readonly forwardedPorts: ForwardedPortsCollection | undefined;
 
     /**
-     * A value indicating whether local connections for forwarded ports are accepted.
+     * Gets a value indicating whether local connections for forwarded ports are accepted.
      * Local connections are not accepted if the host process is not NodeJS (e.g. browser).
      * Default: true for NodeJS, false for browser.
      */
     acceptLocalConnectionsForForwardedPorts: boolean;
+
+    /**
+     * Gets or sets the local network interface address that the tunnel client listens on when
+     * accepting connections for forwarded ports. The default value is the loopback address
+     * (127.0.0.1). Applications may set this to the address indicating any interface (0.0.0.0)
+     * or to the address of a specific interface. The tunnel client supports both IPv4 and IPv6
+     * when listening on either loopback or any interface.
+     */
+    localForwardingHostAddress: string;
 
     /**
      * Connects to a tunnel.

--- a/ts/test/tunnels-test/connectTests.ts
+++ b/ts/test/tunnels-test/connectTests.ts
@@ -77,6 +77,7 @@ class MockTunnelClient extends TunnelConnectionBase implements TunnelClient {
     forwardedPorts: ForwardedPortsCollection | undefined;
     public connectionModes: TunnelConnectionMode[] = [];
     public acceptLocalConnectionsForForwardedPorts = true;
+    public localForwardingHostAddress = '127.0.0.1';
     connect(tunnel: Tunnel, hostId?: string): Promise<any> {
         throw new Error('Method not implemented.');
     }

--- a/ts/test/tunnels-test/tunnelHostAndClientTests.ts
+++ b/ts/test/tunnels-test/tunnelHostAndClientTests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as assert from 'assert';
-import { suite, test, slow, timeout } from '@testdeck/mocha';
+import { suite, test, params, slow, timeout } from '@testdeck/mocha';
 import { MockTunnelManagementClient } from './mocks/mockTunnelManagementClient';
 import { PortForwardingService } from '@microsoft/dev-tunnels-ssh-tcp';
 import {
@@ -288,9 +288,12 @@ export class TunnelHostAndClientTests {
         assert.strictEqual(relayClient.connectionStatus, ConnectionStatus.Disconnected);
     }
 
-    @test
-    public async connectRelayClientAddPort() {
-        let relayClient = new TestTunnelRelayTunnelClient();
+    @params({ localAddress: '0.0.0.0' })
+    @params({ localAddress: '127.0.0.1' })
+    @params.naming((params) => 'connectRelayClientAddPort: ' + params.localAddress)
+    public async connectRelayClientAddPort({ localAddress }: { localAddress: string }) {
+        const relayClient = new TestTunnelRelayTunnelClient();
+        relayClient.localForwardingHostAddress = localAddress;
         relayClient.acceptLocalConnectionsForForwardedPorts = false;
 
         let tunnel = this.createRelayTunnel();


### PR DESCRIPTION
Enables applications to override the default local interface (127.0.0.1) used by the tunnel client to listen for forwarded port connections.