### PR TITLE
Fix TunnelConnection.GetFreshAccessToken 

### DIFF
--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TunnelConnection.cs" company="Microsoft">
+// <copyright file="TunnelConnection.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>
@@ -13,6 +13,7 @@ using Microsoft.DevTunnels.Management;
 using Microsoft.DevTunnels.Ssh.Messages;
 using Microsoft.DevTunnels.Ssh.Tcp;
 using Microsoft.DevTunnels.Connections.Messages;
+using System.Collections.Generic;
 
 namespace Microsoft.DevTunnels.Connections;
 
@@ -287,8 +288,26 @@ public abstract class TunnelConnection : IAsyncDisposable, IPortForwardMessageFa
                 TokenScopes = new[] { TunnelAccessScope },
             };
 
-            Tunnel = await ManagementClient.GetTunnelAsync(Tunnel!, options, cancellation);
-            return Tunnel!.AccessTokens?.TryGetValue(TunnelAccessScope, out var result) == true ? result : null;
+            var tunnel = await ManagementClient.GetTunnelAsync(Tunnel, options, cancellation);
+            if (tunnel == null)
+            {
+                // Tunnel doesn't exist
+                return null;
+            }
+
+            // Get the tunnel access token from the fetched tunnel, or the original Tunnal object if the fetched tunnel doesn't have the token,
+            // which may happen when the tunnel was authenticated with a tunnel acccess token from Tunnel.AccessTokens.
+            // Add the tunnel access token to the fetched tunnel's AccessTokens if it is not there.
+            string? result;
+            if (!tunnel.TryGetAccessToken(TunnelAccessScope, out result) &&
+                Tunnel.TryGetAccessToken(TunnelAccessScope, out result))
+            {
+                tunnel.AccessTokens ??= new Dictionary<string, string>();
+                tunnel.AccessTokens[TunnelAccessScope] = result;
+            }
+
+            Tunnel = tunnel;
+            return result;
         }
 
         if (RefreshingTunnelAccessToken == null)

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -96,7 +96,7 @@ public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
             $"The tunnel client relay endpoint URI is missing.");
 
         // The access token might be null if connecting to a tunnel that allows anonymous access.
-        Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken);
+        Tunnel.TryGetAccessToken(TunnelAccessScope, out this.accessToken);
         this.relayUri = new Uri(endpoint.ClientRelayUri, UriKind.Absolute);
 
         ITunnelConnector result = new RelayTunnelConnector(this);

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -109,7 +109,7 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
         Requires.NotNull(Tunnel!, nameof(Tunnel));
 
         this.accessToken = null!;
-        Tunnel.AccessTokens?.TryGetValue(TunnelAccessScope, out this.accessToken!);
+        Tunnel.TryGetAccessToken(TunnelAccessScope, out this.accessToken!);
         Requires.Argument(this.accessToken != null, nameof(Tunnel), $"There is no access token for {TunnelAccessScope} scope on the tunnel.");
 
         var hostPublicKeys = new[]

--- a/cs/src/Management/TunnelExtensions.cs
+++ b/cs/src/Management/TunnelExtensions.cs
@@ -1,0 +1,110 @@
+// <copyright file="TunnelExtensions.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.DevTunnels.Contracts;
+
+namespace Microsoft.DevTunnels.Management;
+
+/// <summary>
+/// Extension methods for working with <see cref="Tunnel"/> objects.
+/// </summary>
+public static class TunnelExtensions
+{
+    /// <summary>
+    /// Try to get an access token from <paramref name="tunnel"/> for <paramref name="accessTokenScope"/>.
+    /// If the token is found, it's validated for expiration.
+    /// </summary>
+    /// <remarks>
+    /// The tokens are searched in <c>Tunnel.AccessTokens</c> dictionary where each
+    /// key may be either a single scope or space-delimited list of scopes.
+    /// </remarks>
+    /// <param name="tunnel">The tunnel to get the access token from.</param>
+    /// <param name="accessTokenScope">Access token scope to get the token for.</param>
+    /// <param name="accessToken">If non-null and non-empty token is found, the token value. <c>null</c> if not found.</param>
+    /// <returns>
+    /// <c>true</c> if <paramref name="tunnel"/> has non-null and non-empty an access token for <paramref name="accessTokenScope"/>;
+    /// <c>false</c> if <paramref name="tunnel"/> has no access token for <paramref name="accessTokenScope"/> or the token is null or empty.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="tunnel"/> or <paramref name="accessTokenScope"/> is null.</exception>
+    /// <exception cref="ArgumentException">If <paramref name="accessTokenScope"/> is empty.</exception>
+    public static bool TryGetAccessToken(this Tunnel tunnel, string accessTokenScope, [NotNullWhen(true)] out string? accessToken)
+    {
+        Requires.NotNull(tunnel, nameof(tunnel));
+        Requires.NotNullOrEmpty(accessTokenScope, nameof(accessTokenScope));
+
+        if (tunnel.AccessTokens?.Count > 0)
+        {
+            var scope = accessTokenScope.AsSpan();
+            foreach (var (key, value) in tunnel.AccessTokens)
+            {
+                // Each key may be either a single scope or space-delimited list of scopes.
+                var index = 0;
+                while (index < key?.Length)
+                {
+                    var spaceIndex = key.IndexOf(' ', index);
+                    if (spaceIndex == -1)
+                    {
+                        spaceIndex = key.Length;
+                    }
+
+                    if (spaceIndex - index == scope.Length &&
+                        key.AsSpan(index, scope.Length).SequenceEqual(scope))
+                    {
+                        if (string.IsNullOrEmpty(value))
+                        {
+                            accessToken = null;
+                            return false;
+                        }
+
+                        accessToken = value;
+                        return true;
+                    }
+
+                    index = spaceIndex + 1;
+                }
+            }
+        }
+
+        accessToken = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Try to get a valid access token from <paramref name="tunnel"/> for <paramref name="accessTokenScope"/>.
+    /// If the token is found and looks like JWT, it's validated for expiration.
+    /// </summary>
+    /// <remarks>
+    /// The tokens are searched in <c>Tunnel.AccessTokens</c> dictionary where each
+    /// key may be either a single scope or space-delimited list of scopes.
+    /// The method only validates token expiration. It doesn't validate if the token is not JWT. It doesn't validate JWT signature or claims.
+    /// </remarks>
+    /// <param name="tunnel">The tunnel to get the access token from.</param>
+    /// <param name="accessTokenScope">Access token scope to get the token for.</param>
+    /// <param name="accessToken">If the token is found and it's valid, the token value. <c>null</c> if not found.</param>
+    /// <returns>
+    /// <c>true</c> if <paramref name="tunnel"/> has a valid token for <paramref name="accessTokenScope"/>;
+    /// <c>false</c> if <paramref name="tunnel"/> has no access token for <paramref name="accessTokenScope"/> or the token is null or empty.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="tunnel"/> or <paramref name="accessTokenScope"/> is null.</exception>
+    /// <exception cref="ArgumentException">If <paramref name="accessTokenScope"/> is empty.</exception>
+    /// <exception cref="UnauthorizedAccessException">If the token for <paramref name="accessTokenScope"/> is expired.</exception>
+    public static bool TryGetValidAccessToken(this Tunnel tunnel, string accessTokenScope, [NotNullWhen(true)] out string? accessToken)
+    {
+        Requires.NotNull(tunnel, nameof(tunnel));
+        Requires.NotNullOrEmpty(accessTokenScope, nameof(accessTokenScope));
+
+        accessToken = null;
+        if (tunnel.TryGetAccessToken(accessTokenScope, out var result))
+        {
+            TunnelAccessTokenProperties.ValidateTokenExpiration(result);
+            accessToken = result;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -744,29 +744,8 @@ namespace Microsoft.DevTunnels.Management
             {
                 foreach (var scope in accessTokenScopes)
                 {
-                    string? accessToken = null;
-                    foreach (var scopeAndToken in tunnel.AccessTokens)
+                    if (tunnel.TryGetValidAccessToken(scope, out string? accessToken))
                     {
-                        // Each key may be either a single scope or space-delimited list of scopes.
-                        if (scopeAndToken.Key.IndexOf(' ') > 0)
-                        {
-                            var scopes = scopeAndToken.Key.Split(' ');
-                            if (scopes.Contains(scope))
-                            {
-                                accessToken = scopeAndToken.Value;
-                                break;
-                            }
-                        }
-                        else if (scopeAndToken.Key == scope)
-                        {
-                            accessToken = scopeAndToken.Value;
-                            break;
-                        }
-                    }
-
-                    if (!string.IsNullOrEmpty(accessToken))
-                    {
-                        TunnelAccessTokenProperties.ValidateTokenExpiration(accessToken);
                         authHeader = new AuthenticationHeaderValue(
                             TunnelAuthenticationScheme, accessToken);
                         break;

--- a/cs/test/TunnelsSDK.Test/TunnelExtensionsTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelExtensionsTests.cs
@@ -1,0 +1,134 @@
+using System.Text;
+using Microsoft.DevTunnels.Contracts;
+using Microsoft.DevTunnels.Management;
+using Xunit;
+using static System.Formats.Asn1.AsnWriter;
+
+namespace Microsoft.DevTunnels.Test;
+
+public class TunnelExtensionsTests
+{
+    private static Tunnel Tunnel { get; } = new Tunnel
+    {
+        AccessTokens = new Dictionary<string, string>
+        {
+            ["scope1"] = "token1",
+            ["scope2 scope3  scope4"] = "token2",
+            [" scope5"] = "token3",
+            ["scope6 "] = "token4",
+            ["scope3"] = "token5",
+            ["scope7"] = "",
+            ["scope8 scope9"] = null,
+        }
+    };
+
+    [Fact]
+    public void TryGetAccessToken_NullTunnel_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ((Tunnel)null).TryGetAccessToken("scope", out var _));
+
+    [Fact]
+    public void TryGetAccessToken_NullScope_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => Tunnel.TryGetAccessToken(null, out var _));
+
+    [Fact]
+    public void TryGetAccessToken_EmptyScope_Throws() =>
+        Assert.Throws<ArgumentException>(() => Tunnel.TryGetAccessToken(string.Empty, out var _));
+
+    [Fact]
+    public void TryGetAccessToken_NullAccessTokens() =>
+        Assert.False(new Tunnel().TryGetAccessToken("scope", out var _));
+
+    [Fact]
+    public void TryGetValidAccessToken_NullTunnel_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ((Tunnel)null).TryGetValidAccessToken("scope", out var _));
+
+    [Fact]
+    public void TryGetValidAccessToken_NullScope_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => Tunnel.TryGetValidAccessToken(null, out var _));
+
+    [Fact]
+    public void TryGetValidAccessToken_EmptyScope_Throws() =>
+        Assert.Throws<ArgumentException>(() => Tunnel.TryGetValidAccessToken(string.Empty, out var _));
+
+    [Fact]
+    public void TryGetValidAccessToken_NullAccessTokens() =>
+        Assert.False(new Tunnel().TryGetValidAccessToken("scope", out var _));
+
+    [Theory]
+    [InlineData("scope1", "token1")]
+    [InlineData("scope2", "token2")]
+    [InlineData("scope3", "token2")]
+    [InlineData("scope4", "token2")]
+    [InlineData("scope5", "token3")]
+    [InlineData("scope6", "token4")]
+    public void TryGetAccessToken(string scope, string expectedToken)
+    {
+        Assert.True(Tunnel.TryGetAccessToken(scope, out var accessToken));
+        Assert.Equal(expectedToken, accessToken);
+
+        // All tokens in the tunnel are not valid JWT, so validation for expiration doesn't trip.
+        Assert.True(Tunnel.TryGetValidAccessToken(scope, out accessToken));
+        Assert.Equal(expectedToken, accessToken);
+    }
+
+    [Theory]
+    [InlineData("scope2 scope3")]
+    [InlineData("token1")]
+    [InlineData("scope7")]
+    [InlineData("scope8")]
+    [InlineData("scope9")]
+    public void TryGetAccessTokenMissingScope(string scope)
+    {
+        Assert.False(Tunnel.TryGetAccessToken(scope, out var accessToken));
+        Assert.Null(accessToken);
+
+        // All tokens in the tunnel are not valid JWT, so validation for expiration doesn't trip.
+        Assert.False(Tunnel.TryGetValidAccessToken(scope, out accessToken));
+        Assert.Null(accessToken);
+    }
+
+    [Fact]
+    public void TryGetValidAccessTokenNotExipred()
+    {
+        var token = GetToken(isExpired: false);
+        var tunnel = new Tunnel
+        {
+            AccessTokens = new Dictionary<string, string>
+            {
+                ["scope"] = token,
+            },
+        };
+
+        Assert.True(tunnel.TryGetValidAccessToken("scope", out var accessToken));
+        Assert.Equal(token, accessToken);
+    }
+
+    [Fact]
+    public void TryGetValidAccessTokenExipred()
+    {
+        var token = GetToken(isExpired: true);
+        var tunnel = new Tunnel
+        {
+            AccessTokens = new Dictionary<string, string>
+            {
+                ["scope"] = token,
+            },
+        };
+
+        string accessToken = string.Empty;
+        Assert.Throws<UnauthorizedAccessException>(() => tunnel.TryGetValidAccessToken("scope", out accessToken));
+        Assert.Null(accessToken);
+    }
+
+    private string GetToken(bool isExpired)
+    {
+        var exp = DateTimeOffset.UtcNow + (isExpired ? -TimeSpan.FromHours(1) : TimeSpan.FromHours(1));
+        var claims = $"{{ \"exp\": {exp.ToUnixTimeSeconds():D} }}";
+        var payload = Convert.ToBase64String(Encoding.UTF8.GetBytes(claims))
+            .TrimEnd('=')
+            .Replace('/', '_')
+            .Replace('+', '-');
+        return $"header.{payload}.signature";
+    }
+
+}


### PR DESCRIPTION
Fix for [#806](https://github.com/microsoft/basis-planning/issues/806)

When refreshing tunnel access token, `TunnelConnection.GetFreshAccessToken()` calls `tunnelManager` if it was set to fetch the current tunnel using `Tunnel` property. If `Tunnel` has a valid access token, then fetching succeeds but the fetched tunnel may not have the access token, and so a valid access token on `Tunnel` object may be ignored.

The fix is to use the access token from `Tunnel` if the fetched tunnel doesn't have one.

Add `TunnelExtensions` class with helper methods to fetch tunnel tokens from `Tunnel` object. 
Add unit tests for it.
