### PR TITLE
Update archived symbol expiry to 3 years

### DIFF
--- a/.pipelines/cs-ci-build.yaml
+++ b/.pipelines/cs-ci-build.yaml
@@ -69,7 +69,7 @@ steps:
     SearchPattern: '**\*.pdb'
     SymbolServerType: TeamServices
     # Expiration parameter: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/symbol-service#how-to-change-the-expiration-date-of-a-symbol-request
-    SymbolExpirationInDays: '30'
+    SymbolExpirationInDays: '1095'
 
 - task: PublishBuildArtifacts@1
   displayName: Publish Build


### PR DESCRIPTION
Fixes # 55

### Changes proposed: 
- Changes the expiry time of archived symbols from the default of 30 days to 3 years.
