### PR TITLE
Bump the version of ssh dependency

### DIFF
--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -48,7 +48,7 @@
     <ReportGeneratorVersion>4.8.13</ReportGeneratorVersion>
     <SystemTextEncodingsWebPackageVersion>4.7.2</SystemTextEncodingsWebPackageVersion>
     <VisualStudioValidationVersion>15.5.31</VisualStudioValidationVersion>
-    <DevTunnelsSshPackageVersion>3.11.3</DevTunnelsSshPackageVersion>
+    <DevTunnelsSshPackageVersion>3.11.4</DevTunnelsSshPackageVersion>
     <XunitRunnerVisualStudioVersion>2.4.0</XunitRunnerVisualStudioVersion>
     <XunitVersion>2.4.0</XunitVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fixes # https://github.com/microsoft/basis-planning/issues/55

### Changes proposed: 
This bumps the version of the SSH dependencies, which have a symbols that expire after 3 years instead of 30 days.