### PR TITLE
Verify host public keys when connecting client

### DIFF
--- a/cs/src/Connections/TunnelClient.cs
+++ b/cs/src/Connections/TunnelClient.cs
@@ -54,6 +54,11 @@ public abstract class TunnelClient : TunnelConnection, ITunnelClient
     protected SshClientSession? SshSession { get; set; }
 
     /// <summary>
+    /// One or more SSH public keys published by the host with the tunnel endpoint.
+    /// </summary>
+    protected string[]? HostPublicKeys { get; set; }
+
+    /// <summary>
     /// Port forwarding service on <see cref="SshSession"/>.
     /// </summary>
     protected PortForwardingService? SshPortForwardingService { get; private set; }
@@ -214,7 +219,13 @@ public abstract class TunnelClient : TunnelConnection, ITunnelClient
         if (this.SshSession.SessionId != null)
         {
             var clientCredentials = new SshClientCredentials("tunnel", password: null);
-            await this.SshSession.AuthenticateAsync(clientCredentials);
+            if (!await this.SshSession.AuthenticateAsync(clientCredentials))
+            {
+                // Server authentication happens first, and if it succeeds then it sets a principal.
+                throw new SshConnectionException(
+                    this.SshSession.Principal == null ?
+                    "SSH server authentication failed." : "SSH client authentication failed.");
+            }
         }
 
         ConnectionStatus = ConnectionStatus.Connected;
@@ -269,11 +280,7 @@ public abstract class TunnelClient : TunnelConnection, ITunnelClient
                     e.Stream,
                     clientCredentials,
                     channel.Trace.WithName(channel.Trace.Name + "." + channel.ChannelId));
-
-                // TODO: Verify the host public key shared via the tunnel service?
-                secureStream.Authenticating += (_, e) =>
-                    e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(
-                        new ClaimsPrincipal());
+                secureStream.Authenticating += OnHostAuthenticating;
 
                 // Do not pass the cancellation token from the connecting event,
                 // because the connection will outlive the event.
@@ -283,6 +290,58 @@ public abstract class TunnelClient : TunnelConnection, ITunnelClient
         }
 
         this.ForwardedPortConnecting?.Invoke(this, e);
+    }
+
+    private void OnHostAuthenticating(object? sender, SshAuthenticatingEventArgs e)
+    {
+        // If this method returns without assigning e.AuthenticationTask, the auth fails.
+
+        if (e.AuthenticationType != SshAuthenticationType.ServerPublicKey || e.PublicKey == null)
+        {
+            this.Trace.Warning("Invalid host authenticating event.");
+            return;
+        }
+
+        // The public key property on this event comes from SSH key-exchange; at this point the
+        // SSH server has cryptographically proven that it holds the corresponding private key.
+        // Convert host key bytes to base64 to match the format in which the keys are published.
+        var hostKey = e.PublicKey.GetPublicKeyBytes(e.PublicKey.KeyAlgorithmName).ToBase64();
+
+        // Host public keys are obtained from the tunnel endpoint record published by the host.
+        if (this.HostPublicKeys == null)
+        {
+            this.Trace.Warning(
+                "Host identity could not be verified because no public keys were provided.");
+            this.Trace.Verbose("Host key: " + hostKey);
+            e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
+        }
+        else if (this.HostPublicKeys.Contains(hostKey))
+        {
+            this.Trace.Verbose("Verified host identity with public key " + hostKey);
+            e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
+        }
+        else
+        {
+            this.Trace.Error("Host public key verificiation failed.");
+            this.Trace.Verbose("Host key: " + hostKey);
+            this.Trace.Verbose("Expected key(s): " + string.Join(", ", this.HostPublicKeys));
+        }
+    }
+
+    private void OnSshServerAuthenticating(object? sender, SshAuthenticatingEventArgs e)
+    {
+        if (this.ConnectionProtocol == TunnelRelayTunnelClient.WebSocketSubProtocol)
+        {
+            // For V1 protocol the SSH server is the host; it should be authenticated with public key.
+            OnHostAuthenticating(sender, e);
+        }
+        else
+        {
+            // For V2 protocol the SSH server is the relay.
+            // Relay server authentication is done via the websocket TLS host certificate.
+            // If SSH encryption/authentication is used anyway, just accept any SSH host key.
+            e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
+        }
     }
 
     /// <summary>
@@ -326,13 +385,6 @@ public abstract class TunnelClient : TunnelConnection, ITunnelClient
     {
         IsSshSessionActive = false;
         SshSessionClosed?.Invoke(this, EventArgs.Empty);
-    }
-
-    private void OnSshServerAuthenticating(object? sender, SshAuthenticatingEventArgs e)
-    {
-        // Relay server authentication is done via the websocket TLS host certificate.
-        // If SSH encryption/authentication is used anyway, just accept any SSH host key.
-        e.AuthenticationTask = Task.FromResult<ClaimsPrincipal?>(new ClaimsPrincipal());
     }
 
     private void OnRequest(object? sender, SshRequestEventArgs<SessionRequestMessage> e)

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -98,6 +98,7 @@ public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
         // The access token might be null if connecting to a tunnel that allows anonymous access.
         Tunnel.TryGetAccessToken(TunnelAccessScope, out this.accessToken);
         this.relayUri = new Uri(endpoint.ClientRelayUri, UriKind.Absolute);
+        this.HostPublicKeys = endpoint.HostPublicKeys;
 
         ITunnelConnector result = new RelayTunnelConnector(this);
         return Task.FromResult(result);
@@ -106,7 +107,11 @@ public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
     /// <summary>
     /// Connect to the clientRelayUri using accessToken.
     /// </summary>
-    protected Task ConnectAsync(string clientRelayUri, string? accessToken, CancellationToken cancellation)
+    protected Task ConnectAsync(
+        string clientRelayUri,
+        string? accessToken,
+        string[]? hostPublicKeys,
+        CancellationToken cancellation)
     {
         Requires.NotNull(clientRelayUri, nameof(clientRelayUri));
         return ConnectTunnelSessionAsync(
@@ -114,6 +119,7 @@ public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
             {
                 this.relayUri = new Uri(clientRelayUri, UriKind.Absolute);
                 this.accessToken = accessToken;
+                this.HostPublicKeys = hostPublicKeys;
                 this.connector = new RelayTunnelConnector(this);
                 return this.connector.ConnectSessionAsync(isReconnect: false, cancellation);
             },


### PR DESCRIPTION
Tunnel hosts have already been publishing their SSH public keys to the management service along with the other tunnel endpoint info. So the missing piece is for tunnel clients to verify the host key when authenticating the SSH session.