### PR TITLE
Add NamedRateStatus

### DIFF
--- a/cs/src/Contracts/NamedRateStatus.cs
+++ b/cs/src/Contracts/NamedRateStatus.cs
@@ -1,0 +1,17 @@
+// <copyright file="NamedRateStatus.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.DevTunnels.Contracts;
+
+/// <summary>
+/// A named <see cref="RateStatus"/>.
+/// </summary>
+public class NamedRateStatus : RateStatus
+{
+
+    /// <summary>
+    /// The name of the rate status.
+    /// </summary>
+    public string? Name { get; set; }
+}

--- a/cs/src/Contracts/RateStatus.cs
+++ b/cs/src/Contracts/RateStatus.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RateStatus.cs" company="Microsoft">
+// <copyright file="RateStatus.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>
@@ -23,7 +23,7 @@ public class RateStatus : ResourceStatus
     public uint? PeriodSeconds { get; set; }
 
     /// <summary>
-    /// Gets or sets the unix time when this status will be reset.
+    /// Gets or sets the unix time in seconds when this status will be reset.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? ResetTime { get; set; }

--- a/go/tunnels/resource_status.go
+++ b/go/tunnels/resource_status.go
@@ -28,6 +28,14 @@ type RateStatus struct {
 	// estimate, since the actual duration may vary by the calendar.
 	PeriodSeconds uint32 `json:"periodSeconds,omitempty"`
 
-	// Gets or sets the unix time when this status will be reset.
+	// Gets or sets the unix time in seconds when this status will be reset.
 	ResetTime     int64 `json:"resetTime,omitempty"`
+
+	NamedRateStatus
+}
+
+// A named `RateStatus`.
+type NamedRateStatus struct {
+	// The name of the rate status.
+	Name string `json:"name"`
 }

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.10"
+const PackageVersion = "0.0.11"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/java/src/main/java/com/microsoft/tunnels/contracts/NamedRateStatus.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/NamedRateStatus.java
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// Generated from ../../../../../../../../cs/src/Contracts/NamedRateStatus.cs
+
+package com.microsoft.tunnels.contracts;
+
+import com.google.gson.annotations.Expose;
+
+/**
+ * A named {@link RateStatus}.
+ */
+public class NamedRateStatus extends RateStatus {
+    /**
+     * The name of the rate status.
+     */
+    @Expose
+    public String name;
+}

--- a/java/src/main/java/com/microsoft/tunnels/contracts/RateStatus.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/RateStatus.java
@@ -22,7 +22,7 @@ public class RateStatus extends ResourceStatus {
     public int periodSeconds;
 
     /**
-     * Gets or sets the unix time when this status will be reset.
+     * Gets or sets the unix time in seconds when this status will be reset.
      */
     @Expose
     public long resetTime;

--- a/rs/src/contracts/mod.rs
+++ b/rs/src/contracts/mod.rs
@@ -4,6 +4,7 @@
 
 mod cluster_details;
 mod local_network_tunnel_endpoint;
+mod named_rate_status;
 mod problem_details;
 mod rate_status;
 mod resource_status;
@@ -30,6 +31,7 @@ mod tunnel_status;
 
 pub use cluster_details::*;
 pub use local_network_tunnel_endpoint::*;
+pub use named_rate_status::*;
 pub use problem_details::*;
 pub use rate_status::*;
 pub use resource_status::*;

--- a/rs/src/contracts/named_rate_status.rs
+++ b/rs/src/contracts/named_rate_status.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// Generated from ../../../cs/src/Contracts/NamedRateStatus.cs
+
+use crate::contracts::RateStatus;
+use serde::{Deserialize, Serialize};
+
+// A named `RateStatus`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]
+pub struct NamedRateStatus {
+    #[serde(flatten)]
+    pub base: RateStatus,
+
+    // The name of the rate status.
+    pub name: Option<String>,
+}

--- a/rs/src/contracts/rate_status.rs
+++ b/rs/src/contracts/rate_status.rs
@@ -20,6 +20,6 @@ pub struct RateStatus {
     // an estimate, since the actual duration may vary by the calendar.
     pub period_seconds: Option<u32>,
 
-    // Gets or sets the unix time when this status will be reset.
+    // Gets or sets the unix time in seconds when this status will be reset.
     pub reset_time: Option<i64>,
 }

--- a/ts/src/contracts/namedRateStatus.ts
+++ b/ts/src/contracts/namedRateStatus.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// Generated from ../../../cs/src/Contracts/NamedRateStatus.cs
+/* eslint-disable */
+
+import { RateStatus } from './rateStatus';
+
+/**
+ * A named {@link RateStatus}.
+ */
+export interface NamedRateStatus extends RateStatus {
+    /**
+     * The name of the rate status.
+     */
+    name?: string;
+}

--- a/ts/src/contracts/rateStatus.ts
+++ b/ts/src/contracts/rateStatus.ts
@@ -20,7 +20,7 @@ export interface RateStatus extends ResourceStatus {
     periodSeconds?: number;
 
     /**
-     * Gets or sets the unix time when this status will be reset.
+     * Gets or sets the unix time in seconds when this status will be reset.
      */
     resetTime?: number;
 }


### PR DESCRIPTION
### Changes proposed: 
- Add a `NamedRateStatus` contract, which is a `RateStatus` with a string name attached.
- Add a note in the `RateStatus` docstring that the expected unix time is in seconds.
