### PR TITLE
Add a LimitSource property to ResourceStatus

### DIFF
--- a/cs/src/Contracts/ResourceStatus.cs
+++ b/cs/src/Contracts/ResourceStatus.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ResourceStatus.cs" company="Microsoft">
+// <copyright file="ResourceStatus.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>
@@ -30,6 +30,12 @@ public class ResourceStatus
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ulong? Limit { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional source of the <see cref="Limit"/>, or null if there is no limit.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LimitSource { get; set; }
 
     /// <summary>
     /// Implicitly converts a number value to a resource status (with unspecified limit).

--- a/go/tunnels/resource_status.go
+++ b/go/tunnels/resource_status.go
@@ -7,14 +7,18 @@ package tunnels
 // Current value and limit for a limited resource related to a tunnel or tunnel port.
 type ResourceStatus struct {
 	// Gets or sets the current value.
-	Current uint64 `json:"current"`
+	Current     uint64 `json:"current"`
 
 	// Gets or sets the limit enforced by the service, or null if there is no limit.
 	//
 	// Any requests that would cause the limit to be exceeded may be denied by the service.
 	// For HTTP requests, the response is generally a 403 Forbidden status, with details
 	// about the limit in the response body.
-	Limit   uint64 `json:"limit,omitempty"`
+	Limit       uint64 `json:"limit,omitempty"`
+
+	// Gets or sets an optional source of the `ResourceStatus.Limit`, or null if there is no
+	// limit.
+	LimitSource string `json:"limitSource,omitempty"`
 
 	RateStatus
 }

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.11"
+const PackageVersion = "0.0.12"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/java/src/main/java/com/microsoft/tunnels/contracts/ResourceStatus.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/ResourceStatus.java
@@ -25,4 +25,11 @@ public class ResourceStatus {
      */
     @Expose
     public long limit;
+
+    /**
+     * Gets or sets an optional source of the {@link ResourceStatus#limit}, or null if
+     * there is no limit.
+     */
+    @Expose
+    public String limitSource;
 }

--- a/rs/src/contracts/resource_status.rs
+++ b/rs/src/contracts/resource_status.rs
@@ -31,4 +31,8 @@ pub struct DetailedResourceStatus {
     // service. For HTTP requests, the response is generally a 403 Forbidden status, with
     // details about the limit in the response body.
     pub limit: Option<u64>,
+
+    // Gets or sets an optional source of the `ResourceStatus.Limit`, or null if there is
+    // no limit.
+    pub limit_source: Option<String>,
 }

--- a/ts/src/contracts/resourceStatus.ts
+++ b/ts/src/contracts/resourceStatus.ts
@@ -20,4 +20,10 @@ export interface ResourceStatus {
      * details about the limit in the response body.
      */
     limit?: number;
+
+    /**
+     * Gets or sets an optional source of the {@link ResourceStatus.limit}, or null if
+     * there is no limit.
+     */
+    limitSource?: string;
 }


### PR DESCRIPTION
### Changes proposed: 
- Adds an optional `LimitSource`  property to `ResourceStatus`, so that we can indicate when a limit has been overridden as a result of applied User Limits.

