### PR TITLE
Add user limits to CS SDK

### DIFF
--- a/cs/src/Management/ITunnelManagementClient.cs
+++ b/cs/src/Management/ITunnelManagementClient.cs
@@ -340,6 +340,13 @@ namespace Microsoft.DevTunnels.Management
             CancellationToken cancellation = default);
 
         /// <summary>
+        /// Lists current consumption status and limits applied to the calling user.
+        /// </summary>
+        /// <param name="cancellation">Cancellation token.</param>
+        /// <returns>Array of <see cref="NamedRateStatus"/>.</returns>
+        Task<NamedRateStatus[]> ListUserLimitsAsync(CancellationToken cancellation = default);
+
+        /// <summary>
         /// Lists details of tunneling service clusters in all supported Azure regions.
         /// </summary>
         /// <param name="cancellation">Cancellation token.</param>

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -4,7 +4,9 @@
 // </copyright>
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -29,6 +31,7 @@ namespace Microsoft.DevTunnels.Management
         private const string ApiV1Path = "/api/v1";
         private const string TunnelsApiPath = ApiV1Path + "/tunnels";
         private const string SubjectsApiPath = ApiV1Path + "/subjects";
+        private const string UserLimitsApiPath = ApiV1Path + "/userlimits";
         private const string EndpointsApiSubPath = "/endpoints";
         private const string PortsApiSubPath = "/ports";
         private const string ClustersPath = ApiV1Path + "/clusters";
@@ -1206,6 +1209,19 @@ namespace Microsoft.DevTunnels.Management
                 subjects,
                 cancellation);
             return resolvedSubjects!;
+        }
+
+        /// <inheritdoc/>
+        public async Task<NamedRateStatus[]> ListUserLimitsAsync(CancellationToken cancellation = default)
+        {
+            var userLimits = await SendRequestAsync<NamedRateStatus[]>(
+                HttpMethod.Get,
+                clusterId: null,
+                UserLimitsApiPath,
+                query: null,
+                options: null,
+                cancellation);
+            return userLimits!;
         }
 
         /// <inheritdoc/>

--- a/cs/test/TunnelsSDK.Test/Mocks/MockTunnelManagementClient.cs
+++ b/cs/test/TunnelsSDK.Test/Mocks/MockTunnelManagementClient.cs
@@ -339,4 +339,9 @@ public class MockTunnelManagementClient : ITunnelManagementClient
     {
         throw new NotImplementedException();
     }
+
+    public Task<NamedRateStatus[]> ListUserLimitsAsync(CancellationToken cancellation = default)
+    {
+        throw new NotImplementedException();
+    }
 }


### PR DESCRIPTION
### Changes proposed: 
- This adds a method to the ITunnelManagementClient to fetch user limits from the `/userlimits` endpoint.

