### PR TITLE
Dev/jarober/update cluster id regex

### DIFF
--- a/cs/src/Contracts/TunnelConstraints.cs
+++ b/cs/src/Contracts/TunnelConstraints.cs
@@ -137,7 +137,7 @@ public static class TunnelConstraints
     /// Cluster IDs are alphanumeric; hyphens are not permitted.
     /// </remarks>
     /// <seealso cref="Tunnel.ClusterId"/>
-    public const string ClusterIdPattern = "[a-z][a-z0-9]{2,11}";
+    public const string ClusterIdPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$";
 
     /// <summary>
     /// Regular expression that can match or validate tunnel cluster ID strings.

--- a/cs/src/Contracts/TunnelConstraints.cs
+++ b/cs/src/Contracts/TunnelConstraints.cs
@@ -137,7 +137,7 @@ public static class TunnelConstraints
     /// Cluster IDs are alphanumeric; hyphens are not permitted.
     /// </remarks>
     /// <seealso cref="Tunnel.ClusterId"/>
-    public const string ClusterIdPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$";
+    public const string ClusterIdPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use)$";
 
     /// <summary>
     /// Regular expression that can match or validate tunnel cluster ID strings.

--- a/go/tunnels/tunnel_constraints.go
+++ b/go/tunnels/tunnel_constraints.go
@@ -67,7 +67,7 @@ const (
 	// Regular expression that can match or validate tunnel cluster ID strings.
 	//
 	// Cluster IDs are alphanumeric; hyphens are not permitted.
-	TunnelConstraintsClusterIDPattern = "[a-z][a-z0-9]{2,11}"
+	TunnelConstraintsClusterIDPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$"
 
 	// Characters that are valid in tunnel IDs. Includes numbers and lowercase letters,
 	// excluding vowels and 'y' (to avoid accidentally generating any random words).

--- a/go/tunnels/tunnel_constraints.go
+++ b/go/tunnels/tunnel_constraints.go
@@ -67,7 +67,7 @@ const (
 	// Regular expression that can match or validate tunnel cluster ID strings.
 	//
 	// Cluster IDs are alphanumeric; hyphens are not permitted.
-	TunnelConstraintsClusterIDPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$"
+	TunnelConstraintsClusterIDPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use)$"
 
 	// Characters that are valid in tunnel IDs. Includes numbers and lowercase letters,
 	// excluding vowels and 'y' (to avoid accidentally generating any random words).

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.12"
+const PackageVersion = "0.0.13"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
@@ -104,7 +104,7 @@ public class TunnelConstraints {
      *
      * Cluster IDs are alphanumeric; hyphens are not permitted.
      */
-    public static final String clusterIdPattern = "[a-z][a-z0-9]{2,11}";
+    public static final String clusterIdPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$";
 
     /**
      * Regular expression that can match or validate tunnel cluster ID strings.

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
@@ -104,7 +104,7 @@ public class TunnelConstraints {
      *
      * Cluster IDs are alphanumeric; hyphens are not permitted.
      */
-    public static final String clusterIdPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$";
+    public static final String clusterIdPattern = "^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use)$";
 
     /**
      * Regular expression that can match or validate tunnel cluster ID strings.

--- a/rs/src/contracts/tunnel_constraints.rs
+++ b/rs/src/contracts/tunnel_constraints.rs
@@ -62,7 +62,7 @@ pub const ACCESS_CONTROL_MAX_SCOPES: i32 = 10;
 // Regular expression that can match or validate tunnel cluster ID strings.
 //
 // Cluster IDs are alphanumeric; hyphens are not permitted.
-pub const CLUSTER_ID_PATTERN: &str = r#"^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$"#;
+pub const CLUSTER_ID_PATTERN: &str = r#"^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use)$"#;
 
 // Characters that are valid in tunnel IDs. Includes numbers and lowercase letters,
 // excluding vowels and 'y' (to avoid accidentally generating any random words).

--- a/rs/src/contracts/tunnel_constraints.rs
+++ b/rs/src/contracts/tunnel_constraints.rs
@@ -62,7 +62,7 @@ pub const ACCESS_CONTROL_MAX_SCOPES: i32 = 10;
 // Regular expression that can match or validate tunnel cluster ID strings.
 //
 // Cluster IDs are alphanumeric; hyphens are not permitted.
-pub const CLUSTER_ID_PATTERN: &str = r#"[a-z][a-z0-9]{2,11}"#;
+pub const CLUSTER_ID_PATTERN: &str = r#"^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$"#;
 
 // Characters that are valid in tunnel IDs. Includes numbers and lowercase letters,
 // excluding vowels and 'y' (to avoid accidentally generating any random words).

--- a/ts/src/contracts/tunnelConstraints.ts
+++ b/ts/src/contracts/tunnelConstraints.ts
@@ -101,7 +101,7 @@ namespace TunnelConstraints {
      *
      * Cluster IDs are alphanumeric; hyphens are not permitted.
      */
-    export const clusterIdPattern: string = '^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$';
+    export const clusterIdPattern: string = '^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use)$';
 
     /**
      * Regular expression that can match or validate tunnel cluster ID strings.

--- a/ts/src/contracts/tunnelConstraints.ts
+++ b/ts/src/contracts/tunnelConstraints.ts
@@ -101,7 +101,7 @@ namespace TunnelConstraints {
      *
      * Cluster IDs are alphanumeric; hyphens are not permitted.
      */
-    export const clusterIdPattern: string = '[a-z][a-z0-9]{2,11}';
+    export const clusterIdPattern: string = '^(([a-z]{3,4}[0-9]{1,3})|asse|aue|brs|euw|use|localhost1|localhost2)$';
 
     /**
      * Regular expression that can match or validate tunnel cluster ID strings.


### PR DESCRIPTION
### Changes proposed: 
- Update cluster ID regex to accurately represent dev tunnels cluster IDs

### Other Tasks:
- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
