### PR TITLE
[Contracts] Allow empty string in name & domain validation.

### DIFF
--- a/cs/src/Contracts/TunnelConstraints.cs
+++ b/cs/src/Contracts/TunnelConstraints.cs
@@ -183,7 +183,7 @@ public static class TunnelConstraints
     /// allows an empty string because tunnels may be unnamed.
     /// </remarks>
     /// <seealso cref="Tunnel.Name"/>
-    public const string TunnelNamePattern = "([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|";
+    public const string TunnelNamePattern = "([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|(^$)";
 
     /// <summary>
     /// Regular expression that can match or validate tunnel names.
@@ -216,7 +216,7 @@ public static class TunnelConstraints
     /// is registered.
     /// </remarks>
     /// <seealso cref="Tunnel.Domain"/>
-    public const string TunnelDomainPattern = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]";
+    public const string TunnelDomainPattern = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]|(^$)";
 
     /// <summary>
     /// Regular expression that can match or validate tunnel domains.

--- a/cs/test/TunnelsSDK.Test/TunnelConstraintsTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelConstraintsTests.cs
@@ -48,6 +48,7 @@ public class TunnelConstraintsTests
     [InlineData("bcd-ghjk")]
     [InlineData("jfullerton44-name-with-special-char--jrw9q5vrfjpwx")]
     [InlineData("012345678901234567890123456789012345678901234567890123456789")]
+    [InlineData("")]
     public void IsValidTunnelName_Valid(string tunnelName)
     {
         Assert.True(IsValidTunnelName(tunnelName));

--- a/cs/test/TunnelsSDK.Test/TunnelConstraintsTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelConstraintsTests.cs
@@ -48,7 +48,6 @@ public class TunnelConstraintsTests
     [InlineData("bcd-ghjk")]
     [InlineData("jfullerton44-name-with-special-char--jrw9q5vrfjpwx")]
     [InlineData("012345678901234567890123456789012345678901234567890123456789")]
-    [InlineData("")]
     public void IsValidTunnelName_Valid(string tunnelName)
     {
         Assert.True(IsValidTunnelName(tunnelName));

--- a/go/tunnels/tunnel_constraints.go
+++ b/go/tunnels/tunnel_constraints.go
@@ -83,7 +83,7 @@ const (
 	//
 	// Tunnel names are alphanumeric and may contain hyphens. The pattern also allows an
 	// empty string because tunnels may be unnamed.
-	TunnelConstraintsTunnelNamePattern = "([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|"
+	TunnelConstraintsTunnelNamePattern = "([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|(^$)"
 
 	// Regular expression that can match or validate tunnel or port tags.
 	TunnelConstraintsTagPattern = "[\\w-=]{1,50}"
@@ -92,7 +92,7 @@ const (
 	//
 	// The tunnel service may perform additional contextual validation at the time the domain
 	// is registered.
-	TunnelConstraintsTunnelDomainPattern = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]"
+	TunnelConstraintsTunnelDomainPattern = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]|(^$)"
 
 	// Regular expression that can match or validate an access control subject or
 	// organization ID.

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.13"
+const PackageVersion = "0.0.14"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
@@ -141,7 +141,7 @@ public class TunnelConstraints {
      * Tunnel names are alphanumeric and may contain hyphens. The pattern also allows an
      * empty string because tunnels may be unnamed.
      */
-    public static final String tunnelNamePattern = "([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|";
+    public static final String tunnelNamePattern = "([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|(^$)";
 
     /**
      * Regular expression that can match or validate tunnel names.
@@ -167,7 +167,7 @@ public class TunnelConstraints {
      * The tunnel service may perform additional contextual validation at the time the
      * domain is registered.
      */
-    public static final String tunnelDomainPattern = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]";
+    public static final String tunnelDomainPattern = "[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]|(^$)";
 
     /**
      * Regular expression that can match or validate tunnel domains.

--- a/rs/src/contracts/tunnel_constraints.rs
+++ b/rs/src/contracts/tunnel_constraints.rs
@@ -78,7 +78,7 @@ pub const TUNNEL_ID_PATTERN: &str = r#"[0123456789bcdfghjklmnpqrstvwxz]{8}"#;
 //
 // Tunnel names are alphanumeric and may contain hyphens. The pattern also allows an empty
 // string because tunnels may be unnamed.
-pub const TUNNEL_NAME_PATTERN: &str = r#"([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|"#;
+pub const TUNNEL_NAME_PATTERN: &str = r#"([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|(^$)"#;
 
 // Regular expression that can match or validate tunnel or port tags.
 pub const TAG_PATTERN: &str = r#"[\w-=]{1,50}"#;
@@ -87,7 +87,7 @@ pub const TAG_PATTERN: &str = r#"[\w-=]{1,50}"#;
 //
 // The tunnel service may perform additional contextual validation at the time the domain
 // is registered.
-pub const TUNNEL_DOMAIN_PATTERN: &str = r#"[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]"#;
+pub const TUNNEL_DOMAIN_PATTERN: &str = r#"[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]|(^$)"#;
 
 // Regular expression that can match or validate an access control subject or organization
 // ID.

--- a/ts/src/contracts/tunnelConstraints.ts
+++ b/ts/src/contracts/tunnelConstraints.ts
@@ -138,7 +138,7 @@ namespace TunnelConstraints {
      * Tunnel names are alphanumeric and may contain hyphens. The pattern also allows an
      * empty string because tunnels may be unnamed.
      */
-    export const tunnelNamePattern: string = '([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|';
+    export const tunnelNamePattern: string = '([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|(^$)';
 
     /**
      * Regular expression that can match or validate tunnel names.
@@ -164,7 +164,7 @@ namespace TunnelConstraints {
      * The tunnel service may perform additional contextual validation at the time the
      * domain is registered.
      */
-    export const tunnelDomainPattern: string = '[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]';
+    export const tunnelDomainPattern: string = '[0-9a-z][0-9a-z-.]{1,158}[0-9a-z]|(^$)';
 
     /**
      * Regular expression that can match or validate tunnel domains.


### PR DESCRIPTION
Fixes # https://github.com/microsoft/basis-planning/issues/925

### Changes proposed: 
- Allow empty string in tunnel name & domain pattern
- Tested consuming the change in the CLI

### Other Tasks:
- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
