### PR TITLE
C# and node client can refresh host public keys on connection.

### DIFF
--- a/cs/src/Connections/ConnectionStatus.cs
+++ b/cs/src/Connections/ConnectionStatus.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ConnectionStatus.cs" company="Microsoft">
+// <copyright file="ConnectionStatus.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>
@@ -34,4 +34,9 @@ public enum ConnectionStatus
     /// Disconnected from the service and could not reconnect either due to disposal, service down, tunnel deleted, or token expiration. This is the final status.
     /// </summary>
     Disconnected,
+
+    /// <summary>
+    /// Refreshing tunnel host public key.
+    /// </summary>
+    RefreshingTunnelHostPublicKey,
 }

--- a/cs/src/Connections/ITunnelHost.cs
+++ b/cs/src/Connections/ITunnelHost.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DevTunnels.Contracts;
 using Microsoft.DevTunnels.Management;
-using Microsoft.DevTunnels.Ssh;
 using Microsoft.DevTunnels.Ssh.Tcp.Events;
 
 namespace Microsoft.DevTunnels.Connections;

--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -88,6 +88,8 @@ public abstract class TunnelConnection : IAsyncDisposable, IPortForwardMessageFa
                 // Get the tunnel access token from the new tunnel, or the original Tunnal object if the new tunnel doesn't have the token,
                 // which may happen when the tunnel was authenticated with a tunnel access token from Tunnel.AccessTokens.
                 // Add the tunnel access token to the new tunnel's AccessTokens if it is not there.
+
+                // TODO: remove this access token preservation logic when https://github.com/microsoft/basis-planning/issues/990 is fixed.
                 string? accessToken;
                 if (value != null &&
                     !value.TryGetAccessToken(TunnelAccessScope, out var _) &&
@@ -278,7 +280,7 @@ public abstract class TunnelConnection : IAsyncDisposable, IPortForwardMessageFa
     {
         var previousStatus = ConnectionStatus;
         ConnectionStatus = ConnectionStatus.RefreshingTunnelAccessToken;
-        Trace.TraceInformation(
+        Trace.Verbose(
             "Refreshing tunnel access token. Current token: {0}",
             TunnelAccessTokenProperties.GetTokenTrace(this.accessToken));
         try
@@ -294,7 +296,7 @@ public abstract class TunnelConnection : IAsyncDisposable, IPortForwardMessageFa
                 TunnelAccessTokenProperties.ValidateTokenExpiration(this.accessToken);
             }
 
-            Trace.TraceInformation(
+            Trace.Verbose(
                 "Refreshed tunnel access token. New token: {0}",
                 TunnelAccessTokenProperties.GetTokenTrace(this.accessToken));
 

--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -89,7 +89,7 @@ public abstract class TunnelConnection : IAsyncDisposable, IPortForwardMessageFa
                 // which may happen when the tunnel was authenticated with a tunnel access token from Tunnel.AccessTokens.
                 // Add the tunnel access token to the new tunnel's AccessTokens if it is not there.
 
-                // TODO: remove this access token preservation logic when https://github.com/microsoft/basis-planning/issues/990 is fixed.
+                // TODO: remove this access token preservation logic when #990 is fixed.
                 string? accessToken;
                 if (value != null &&
                     !value.TryGetAccessToken(TunnelAccessScope, out var _) &&

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -107,9 +107,6 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
     protected override async Task<ITunnelConnector> CreateTunnelConnectorAsync(CancellationToken cancellation)
     {
         Requires.NotNull(Tunnel!, nameof(Tunnel));
-
-        this.accessToken = null!;
-        Tunnel.TryGetAccessToken(TunnelAccessScope, out this.accessToken!);
         Requires.Argument(this.accessToken != null, nameof(Tunnel), $"There is no access token for {TunnelAccessScope} scope on the tunnel.");
 
         var hostPublicKeys = new[]

--- a/cs/test/TunnelsSDK.Test/Mocks/MockTunnelManagementClient.cs
+++ b/cs/test/TunnelsSDK.Test/Mocks/MockTunnelManagementClient.cs
@@ -1,9 +1,3 @@
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.DevTunnels.Contracts;
 using Microsoft.DevTunnels.Management;
 

--- a/ts/src/connections/connectionStatus.ts
+++ b/ts/src/connections/connectionStatus.ts
@@ -29,4 +29,10 @@ export enum ConnectionStatus {
      * Disconnected from the tunnel and could not reconnect either due to disposal, service down, tunnel deleted, or token expiration. This is the final status.
      */
     Disconnected = 'disconnected',
+
+    /**
+     * Refreshing tunnel host public key. 
+     * This may happen when a client is connecting to a tunnel with a stale host public key. SDK client will try to fetch a fresh tunnel from the tunnelManagementClient.
+     */
+    RefreshingTunnelHostPublicKey = 'refreshingTunnelHostPublicKey',
 }

--- a/ts/src/connections/relayTunnelConnector.ts
+++ b/ts/src/connections/relayTunnelConnector.ts
@@ -47,7 +47,6 @@ export class RelayTunnelConnector implements TunnelConnector {
     public async connectSession(
         isReconnect: boolean,
         cancellation: CancellationToken,
-        httpAgent : http.Agent,
     ): Promise<void> {
         let disconnectReason: SshDisconnectReason | undefined;
         let error: Error | undefined;
@@ -127,7 +126,7 @@ export class RelayTunnelConnector implements TunnelConnector {
             error = undefined;
             try {
                 const streamAndProtocol = await this.tunnelSession.createSessionStream(
-                    cancellation, httpAgent);
+                    cancellation);
                 stream = streamAndProtocol.stream;
 
                 await this.tunnelSession.configureSession(

--- a/ts/src/connections/tunnelConnectionSession.ts
+++ b/ts/src/connections/tunnelConnectionSession.ts
@@ -82,7 +82,7 @@ export class TunnelConnectionSession extends TunnelConnectionBase implements Tun
             // which may happen when the tunnel was authenticated with a tunnel access token from Tunnel.AccessTokens.
             // Add the tunnel access token to the new tunnel's AccessTokens if it is not there.
 
-            // TODO: remove this access token preservation logic when https://github.com/microsoft/basis-planning/issues/990 is fixed.
+            // TODO: remove this access token preservation logic when #990 is fixed.
             if (value &&
                 !TunnelAccessTokenProperties.getTunnelAccessToken(value, this.tunnelAccessScope)) {
 

--- a/ts/src/connections/tunnelConnectionSession.ts
+++ b/ts/src/connections/tunnelConnectionSession.ts
@@ -81,6 +81,8 @@ export class TunnelConnectionSession extends TunnelConnectionBase implements Tun
             // Get the tunnel access token from the new tunnel, or the original Tunnal object if the new tunnel doesn't have the token,
             // which may happen when the tunnel was authenticated with a tunnel access token from Tunnel.AccessTokens.
             // Add the tunnel access token to the new tunnel's AccessTokens if it is not there.
+
+            // TODO: remove this access token preservation logic when https://github.com/microsoft/basis-planning/issues/990 is fixed.
             if (value &&
                 !TunnelAccessTokenProperties.getTunnelAccessToken(value, this.tunnelAccessScope)) {
 
@@ -179,7 +181,7 @@ export class TunnelConnectionSession extends TunnelConnectionBase implements Tun
         const previousStatus = this.connectionStatus;
         this.connectionStatus = ConnectionStatus.RefreshingTunnelAccessToken;
         try {
-            this.traceInfo(
+            this.traceVerbose(
                 `Refreshing tunnel access token. Current token: ${TunnelAccessTokenProperties.getTokenTrace(
                     this.accessToken,
                 )}`,
@@ -195,7 +197,7 @@ export class TunnelConnectionSession extends TunnelConnectionBase implements Tun
                 TunnelAccessTokenProperties.validateTokenExpiration(this.accessToken);
             }
 
-            this.traceInfo(
+            this.traceVerbose(
                 `Refreshed tunnel access token. New token: ${TunnelAccessTokenProperties.getTokenTrace(
                     this.accessToken,
                 )}`,

--- a/ts/src/connections/tunnelConnector.ts
+++ b/ts/src/connections/tunnelConnector.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { CancellationToken } from '@microsoft/dev-tunnels-ssh';
-import * as http from 'http';
 
 /**
  * Tunnel connector.
@@ -13,5 +12,5 @@ export interface TunnelConnector {
      * @param isReconnect A value indicating if this is a reconnect (true) or regular connect (false).
      * @param cancellation Cancellation token.
      */
-    connectSession(isReconnect: boolean, cancellation: CancellationToken, httpAgent?: http.Agent): Promise<void>;
+    connectSession(isReconnect: boolean, cancellation: CancellationToken): Promise<void>;
 }

--- a/ts/src/connections/tunnelHostBase.ts
+++ b/ts/src/connections/tunnelHostBase.ts
@@ -121,18 +121,15 @@ export class TunnelHostBase
     }
 
     /**
-     * Validate the tunnel and get data needed to connect to it, if the tunnel is provided;
+     * Validate the {@link tunnel} and get data needed to connect to it, if the tunnel is provided;
      * otherwise, ensure that there is already sufficient data to connect to a tunnel.
-     * @param tunnel Tunnel to use for the connection.
-     *     Tunnel object to get the connection data if defined.
-     *     Undefined if the connection data is already known.
      * @internal
      */
-    public async onConnectingToTunnel(tunnel?: Tunnel): Promise<void> {
+    public async onConnectingToTunnel(): Promise<void> {
         if (this.hostPrivateKey && this.hostPublicKeys) {
             return;
         }
-        if (!tunnel) {
+        if (!this.tunnel) {
             throw new Error('Tunnel is required');
         }
 

--- a/ts/src/connections/tunnelRelaySessionClass.ts
+++ b/ts/src/connections/tunnelRelaySessionClass.ts
@@ -16,7 +16,7 @@ type Constructor<T = object> = new (...args: any[]) => T;
 /**
  * Tunnel relay mixin class that adds relay connection capability to descendants of TunnelSession.
  * @param base Base class constructor.
- * @param webSocketSubProtocol Web socket sub-protocol.
+ * @param protocols Web socket sub-protocols.
  * @returns A class where createSessionStream() connects to tunnel relay.
  */
 export function tunnelRelaySessionClass<TBase extends Constructor<TunnelSession>>(
@@ -39,10 +39,7 @@ export function tunnelRelaySessionClass<TBase extends Constructor<TunnelSession>
          * Creates a stream to the tunnel.
          * @internal
          */
-        public async createSessionStream(
-            cancellation: CancellationToken,
-            httpAgent?: http.Agent
-        ): Promise<{ stream: Stream, protocol: string }> {
+        public async createSessionStream(cancellation: CancellationToken): Promise<{ stream: Stream, protocol: string }> {
             if (!this.relayUri) {
                 throw new Error(
                     'Cannot create tunnel session stream. Tunnel relay endpoint URI is missing',
@@ -60,7 +57,7 @@ export function tunnelRelaySessionClass<TBase extends Constructor<TunnelSession>
 
             const clientConfig: IClientConfig = {
                 tlsOptions: {
-                    agent: httpAgent,
+                    agent: this.httpAgent,
                 },
             };
 
@@ -91,32 +88,6 @@ export function tunnelRelaySessionClass<TBase extends Constructor<TunnelSession>
             } catch (ex) {
                 throw new Error('Failed to connect to tunnel relay. ' + ex);
             }
-        }
-
-        /**
-         * Validate the tunnel and get data needed to connect to it, if the tunnel is provided;
-         * otherwise, ensure that there is already sufficient data to connect to a tunnel.
-         * @param tunnel Tunnel to use for the connection.
-         *     Tunnel object to get the connection data if defined.
-         *     Undefined if the connection data is already known.
-         * @internal
-         */
-        public async onConnectingToTunnel(tunnel?: Tunnel): Promise<void> {
-            await super.onConnectingToTunnel(tunnel);
-            if (!this.relayUri) {
-                this.relayUri = await this.getTunnelRelayUri(tunnel);
-                if (!this.relayUri) {
-                    throw new Error('The tunnel relay endpoint URI is missing.');
-                }
-            }
-        }
-
-        /**
-         * Gets the tunnel relay URI.
-         * @internal
-         */
-        public async getTunnelRelayUri(tunnel?: Tunnel): Promise<string> {
-            throw new Error('getTunnelRelayUri() is not implemented');
         }
     };
 }

--- a/ts/src/connections/tunnelSession.ts
+++ b/ts/src/connections/tunnelSession.ts
@@ -3,13 +3,19 @@
 
 import { Tunnel } from '@microsoft/dev-tunnels-contracts';
 import { Stream, Trace } from '@microsoft/dev-tunnels-ssh';
-import { CancellationToken, Disposable } from 'vscode-jsonrpc';
+import { CancellationToken } from 'vscode-jsonrpc';
 import { RetryingTunnelConnectionEventArgs } from './retryingTunnelConnectionEventArgs';
 import * as http from 'http';
 /**
  * Tunnel session.
  */
 export interface TunnelSession {
+
+    /**
+     * Gets the tunnel.
+     */
+    tunnel: Tunnel | null;
+
     /**
      * Gets the trace source.
      */
@@ -19,6 +25,11 @@ export interface TunnelSession {
      * Gets tunnel access scope for this tunnel session.
      */
     tunnelAccessScope: string;
+
+    /**
+     * Gets the http agent for http requests.
+     */
+    httpAgent?: http.Agent;
 
     /**
      * Validates tunnel access token if it's present. Returns the token.
@@ -31,13 +42,10 @@ export interface TunnelSession {
     onRetrying(event: RetryingTunnelConnectionEventArgs): void;
 
     /**
-     * Validate the tunnel and get data needed to connect to it, if the tunnel is provided;
+     * Validate {@link tunnel} and get data needed to connect to it, if the tunnel is provided;
      * otherwise, ensure that there is already sufficient data to connect to a tunnel.
-     * @param tunnel Tunnel to use for the connection.
-     *     Tunnel object to get the connection data if defined.
-     *     Undefined if the connection data is already known.
      */
-    onConnectingToTunnel(tunnel?: Tunnel): Promise<void>;
+    onConnectingToTunnel(): Promise<void>;
 
     /**
      * Connect to the tunnel session by running the provided {@link action}.
@@ -57,7 +65,6 @@ export interface TunnelSession {
      */
     createSessionStream(
         cancellation: CancellationToken,
-        httpAgent?: http.Agent,
     ): Promise<{ stream: Stream, protocol: string }>;
 
     /**

--- a/ts/src/connections/tunnelSshSessionClass.ts
+++ b/ts/src/connections/tunnelSshSessionClass.ts
@@ -11,7 +11,6 @@ import {
 import { TunnelSession } from './tunnelSession';
 import { TunnelConnection } from './tunnelConnection';
 import { TunnelConnectionSession } from './tunnelConnectionSession';
-import { Tunnel } from '@microsoft/dev-tunnels-contracts';
 
 type Constructor<T = object> = new (...args: any[]) => T;
 type CloseableSshSession = {

--- a/ts/src/management/tunnelAccessTokenProperties.ts
+++ b/ts/src/management/tunnelAccessTokenProperties.ts
@@ -132,7 +132,7 @@ export class TunnelAccessTokenProperties {
      * @returns Tunnel access token if found; otherwise, undefined.
      */
     public static getTunnelAccessToken(
-        tunnel?: Tunnel,
+        tunnel?: Tunnel | null,
         accessTokenScopes?: string | string[],
     ): string | undefined {
         if (!tunnel?.accessTokens || !accessTokenScopes) {

--- a/ts/test/tunnels-test/connection.ts
+++ b/ts/test/tunnels-test/connection.ts
@@ -72,7 +72,7 @@ async function startTunnelRelayConnection() {
     let tunnelInstance = await tunnelManagementClient.getTunnel(tunnel, tunnelRequestOptions);
 
     let tunnelRelayTunnelClient = new TunnelRelayTunnelClient();
-    await tunnelRelayTunnelClient.connectClient(tunnelInstance!, tunnelInstance!.endpoints!);
+    await tunnelRelayTunnelClient.connect(tunnelInstance!);
     // Wait indefinitely so the connection does not close
     await new Promise((resolve) => {});
     return 0;

--- a/ts/test/tunnels-test/mocks/mockTunnelManagementClient.ts
+++ b/ts/test/tunnels-test/mocks/mockTunnelManagementClient.ts
@@ -55,8 +55,8 @@ export class MockTunnelManagementClient implements TunnelManagementClient {
             return null;
         }
 
-        this.issueMockTokens(tunnel, options);
-        return tunnel;
+        this.issueMockTokens(t, options);
+        return t;
     }
 
     async createTunnel(tunnel: Tunnel, options?: TunnelRequestOptions): Promise<Tunnel> {

--- a/ts/test/tunnels-test/mocks/mockTunnelRelayStreamFactory.ts
+++ b/ts/test/tunnels-test/mocks/mockTunnelRelayStreamFactory.ts
@@ -36,7 +36,7 @@ export class MockTunnelRelayStreamFactory implements TunnelRelayStreamFactory {
         if (!relayUri || !accessToken || !protocols.includes(this.connectionType)) {
             throw new Error('Invalid params');
         }
-        return Promise.resolve({ stream: this.stream, protocol: protocols[0] });
+        return Promise.resolve({ stream: this.stream, protocol: this.connectionType });
     };
 
     public static from(

--- a/ts/test/tunnels-test/testTunnelRelayTunnelClient.ts
+++ b/ts/test/tunnels-test/testTunnelRelayTunnelClient.ts
@@ -2,13 +2,14 @@
 // Licensed under the MIT license.
 
 import { TunnelRelayTunnelClient } from "@microsoft/dev-tunnels-connections";
+import { TunnelManagementClient } from "@microsoft/dev-tunnels-management";
 
 /**
  * Test TunnelRelayTunnelClient that exposes protected members for testing.
  */
 export class TestTunnelRelayTunnelClient extends TunnelRelayTunnelClient {
-    constructor() {
-        super();
+    constructor(managementClient?: TunnelManagementClient) {
+        super(undefined, managementClient);
     }
 
     public get isSshSessionActiveProperty(): boolean {


### PR DESCRIPTION
Fix for [#979](https://github.com/microsoft/basis-planning/issues/979).

When the client fails to authenticate the host SSH session, it must refresh the tunnel from the service and get the new endpoint public key if possible, then retry.

* Add new connection status when the client refreshes the tunnel to get the new host public keys.
* Refactor various places where the tunnel object properties are used for tunnel host and client.
* Make authentication callback in the client handle host public key mismatch by fetching the tunnel and retrying.
* Add unit tests.
* Change how `httpAgent` is passed to ts SDK clients.
* Fix ts mock tunnel management client getTunnel() not returning the right tunnel.
* Fix ts SDK unit tests incorrectly using v2 connection protocol.
