### PR TITLE
Fix bug where api-version query param was not included in clusters requests

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -1287,6 +1287,7 @@ namespace Microsoft.DevTunnels.Management
             var baseAddress = this.httpClient.BaseAddress!;
             var builder = new UriBuilder(baseAddress);
             builder.Path = ClustersPath;
+            builder.Query = GetApiQuery();
             var clusterDetails = await SendRequestAsync<object, ClusterDetails[]>(
                 HttpMethod.Get,
                 builder.Uri,


### PR DESCRIPTION
Fixes https://github.com/microsoft/basis-planning/issues/991

### Changes proposed: 
- Fixes clusters get request to include api-version query param

