### PR TITLE
change Client ssh info logs  to verbose.

### DIFF
--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -162,7 +162,7 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
         };
 
         ValidateAccessToken();
-        Trace.TraceInformation("Connecting to host tunnel relay {0}", this.relayUri!.AbsoluteUri);
+        Trace.Verbose("Connecting to host tunnel relay {0}", this.relayUri!.AbsoluteUri);
         var (stream, subprotocol) = await this.StreamFactory.CreateRelayStreamAsync(
             this.relayUri!,
             this.accessToken,
@@ -495,11 +495,12 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
             // Reconnecting client session may cause the new session close with 'None' reason and null exception.
             if (cancellation.IsCancellationRequested)
             {
-                Trace.TraceInformation("Client ssh session cancelled.");
+                Trace.WithName("ClientSSH").Verbose("Session cancelled verbose.");
             }
             else if (e.Reason == SshDisconnectReason.ByApplication)
             {
-                Trace.TraceInformation("Client ssh session closed.");
+                Trace.WithName("ClientSSH").Verbose("Session closed verbose.");
+
             }
             else if (e.Reason != SshDisconnectReason.None || e.Exception != null)
             {

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -495,11 +495,11 @@ public class TunnelRelayTunnelHost : TunnelHost, IRelayClient
             // Reconnecting client session may cause the new session close with 'None' reason and null exception.
             if (cancellation.IsCancellationRequested)
             {
-                Trace.WithName("ClientSSH").Verbose("Session cancelled verbose.");
+                Trace.WithName("ClientSSH").Verbose("Session cancelled.");
             }
             else if (e.Reason == SshDisconnectReason.ByApplication)
             {
-                Trace.WithName("ClientSSH").Verbose("Session closed verbose.");
+                Trace.WithName("ClientSSH").Verbose("Session closed.");
 
             }
             else if (e.Reason != SshDisconnectReason.None || e.Exception != null)


### PR DESCRIPTION
Fixes #840

### Changes proposed: 
- This Pr  makes some ClientSSH logs verbose. So will be cleaner for non-verbose logs in CLI. 
- Session closed and cancelled information should start with Client SSH for consistency


### Other Tasks:
- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
