### PR TITLE
Add ownedTunnelsOnly option and tunnelPlan redirection

### DIFF
--- a/cs/src/Management/ITunnelManagementClient.cs
+++ b/cs/src/Management/ITunnelManagementClient.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DevTunnels.Management
         /// <param name="clusterId">A tunnel cluster ID, or null to list tunnels globally.</param>
         /// <param name="domain">Tunnel domain, or null for the default domain.</param>
         /// <param name="options">Request options.</param>
+        /// <param name="ownedTunnelsOnly">If authenticated with a tunnel plan token, only show the tunnels the user owns.</param>
         /// <param name="cancellation">Cancellation token.</param>
         /// <returns>Array of tunnel objects.</returns>
         /// <exception cref="UnauthorizedAccessException">The client access token was missing,
@@ -36,6 +37,7 @@ namespace Microsoft.DevTunnels.Management
             string? clusterId = null,
             string? domain = null,
             TunnelRequestOptions? options = null,
+            bool? ownedTunnelsOnly = null,
             CancellationToken cancellation = default);
 
         /// <summary>

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -477,6 +477,16 @@ namespace Microsoft.DevTunnels.Management
             CancellationToken cancellation)
             where TRequest : class
         {
+            if (authHeader?.Scheme == TunnelAuthenticationSchemes.TunnelPlan)
+            {
+                var token = TunnelPlanTokenProperties.TryParse(authHeader.Parameter ?? string.Empty);
+                if (!string.IsNullOrEmpty(token?.ClusterId))
+                {
+                    var uriStr = uri.ToString().Replace("global.", $"{token.ClusterId}.");
+                    uri = new Uri(uriStr);
+                }
+            }
+
             var request = new HttpRequestMessage(method, uri);
             request.Headers.Authorization = authHeader;
 

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -820,13 +820,15 @@ namespace Microsoft.DevTunnels.Management
             string? clusterId,
             string? domain,
             TunnelRequestOptions? options,
-            CancellationToken cancellation)
+            CancellationToken cancellation,
+            bool ownedTunnelsOnly = false)
         {
             var queryParams = new string?[]
             {
                 string.IsNullOrEmpty(clusterId) ? "global=true" : null,
                 !string.IsNullOrEmpty(domain) ? $"domain={HttpUtility.UrlEncode(domain)}" : null,
                 !string.IsNullOrEmpty(ApiVersion) ? GetApiQuery() : null,
+                ownedTunnelsOnly ? "ownedTunnelsOnly=true" : null,
             };
             var query = string.Join("&", queryParams.Where((p) => p != null));
             var result = await this.SendRequestAsync<Tunnel[]>(

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -820,15 +820,15 @@ namespace Microsoft.DevTunnels.Management
             string? clusterId,
             string? domain,
             TunnelRequestOptions? options,
-            CancellationToken cancellation,
-            bool ownedTunnelsOnly = false)
+            bool? ownedTunnelsOnly,
+            CancellationToken cancellation)
         {
             var queryParams = new string?[]
             {
                 string.IsNullOrEmpty(clusterId) ? "global=true" : null,
                 !string.IsNullOrEmpty(domain) ? $"domain={HttpUtility.UrlEncode(domain)}" : null,
                 !string.IsNullOrEmpty(ApiVersion) ? GetApiQuery() : null,
-                ownedTunnelsOnly ? "ownedTunnelsOnly=true" : null,
+                ownedTunnelsOnly == true ? "ownedTunnelsOnly=true" : null,
             };
             var query = string.Join("&", queryParams.Where((p) => p != null));
             var result = await this.SendRequestAsync<Tunnel[]>(

--- a/cs/src/Management/TunnelPlanTokenProperties.cs
+++ b/cs/src/Management/TunnelPlanTokenProperties.cs
@@ -1,0 +1,190 @@
+// <copyright file="TunnelPlanTokenProperties.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.DevTunnels.Management;
+
+/// <summary>
+/// Supports parsing tunnelPlan token JWT properties to allow for some pre-validation
+/// and diagnostics.
+/// </summary>
+public class TunnelPlanTokenProperties
+{
+    private const string ClusterIdClaimName = "clusterId";
+    private const string IssuerClaimName = "iss";
+    private const string ExpirationClaimName = "exp";
+    private const string UserEmailClaimName = "userEmail";
+    private const string TunnelPlanIdClaimName = "tunnelPlanId";
+    private const string SubscriptionIdClaimName = "subscriptionId";
+    private const string ScopeClaimName = "scp";
+
+
+    /// <summary>
+    /// Gets the token cluster ID claim.
+    /// </summary>
+    public string? ClusterId { get; private set; }
+
+    /// <summary>
+    /// Gets the subscription ID claim.
+    /// </summary>
+    public string? SubscriptionId { get; private set; }
+
+    /// <summary>
+    /// Gets the token user email claim.
+    /// </summary>
+    public string? UserEmail { get; private set; }
+
+    /// <summary>
+    /// Gets the token scopes claim.
+    /// </summary>
+    public string[]? Scopes { get; private set; }
+
+    /// <summary>
+    /// Gets the token issuer URI.
+    /// </summary>
+    public string? Issuer { get; private set; }
+
+    /// <summary>
+    /// Gets the token expiration.
+    /// </summary>
+    [JsonIgnore]
+    public DateTime? Expiration { get; private set; }
+
+    /// <summary>
+    /// Gets the token tunnel plan id claim.
+    /// </summary>
+    public string? TunnelPlanId { get; private set; }
+
+    /// <summary>
+    /// Checks if the tunnel access token expiration claim is in the past.
+    /// </summary>
+    /// <exception cref="UnauthorizedAccessException">The token is expired.</exception>
+    /// <remarks>Note this does not throw if the token is an invalid format.</remarks>
+    public static void ValidateTokenExpiration(string token)
+    {
+        var t = TryParse(token);
+        if (t?.Expiration <= DateTime.UtcNow)
+        {
+            throw new UnauthorizedAccessException("The access token is expired: " + t);
+        }
+    }
+
+    /// <summary>
+    /// Gets token representation for tracing.
+    /// </summary>
+    public static string GetTokenTrace(string? token)
+    {
+        if (token == null)
+        {
+            return "<null>";
+        }
+
+        if (token == string.Empty)
+        {
+            return "<empty>";
+        }
+
+        return TryParse(token) is TunnelPlanTokenProperties t ? $"<JWT: {t}>" : "<token>";
+    }
+
+    /// <summary>
+    /// Attempts to parse a tunnel access token (JWT). This does NOT validate the token
+    /// signature or any claims.
+    /// </summary>
+    /// <returns>The parsed token properties, or null if the token is an invalid format.</returns>
+    /// <remarks>
+    /// Applications generally should not attempt to interpret or rely on any token properties
+    /// other than <see cref="Expiration" />, because the service may change or omit those claims
+    /// in the future. Other claims are exposed here only for diagnostic purposes.
+    /// </remarks>
+    public static TunnelPlanTokenProperties? TryParse(string token)
+    {
+        Requires.NotNullOrEmpty(token, nameof(token));
+
+        // JWTs are encoded in 3 parts: header, body, and signature.
+        var tokenParts = token.Split('.');
+        if (tokenParts.Length != 3)
+        {
+            return null;
+        }
+
+        var tokenBodyJson = Base64UrlDecode(tokenParts[1]);
+        if (tokenBodyJson == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var tokenElement = JsonSerializer.Deserialize<JsonElement>(tokenBodyJson)!;
+            var tokenProperties = new TunnelPlanTokenProperties();
+
+            if (tokenElement.TryGetProperty(ClusterIdClaimName, out var clusterIdElement))
+            {
+                tokenProperties.ClusterId = clusterIdElement.GetString();
+            }
+
+            if (tokenElement.TryGetProperty(SubscriptionIdClaimName, out var subscriptionId))
+            {
+                tokenProperties.SubscriptionId = subscriptionId.GetString();
+            }
+
+            if (tokenElement.TryGetProperty(TunnelPlanIdClaimName, out var tunnelPlanId))
+            {
+                tokenProperties.TunnelPlanId = tunnelPlanId.GetString();
+            }
+
+            if (tokenElement.TryGetProperty(UserEmailClaimName, out var userEmail))
+            {
+                tokenProperties.UserEmail = userEmail.GetString();
+            }
+
+            if (tokenElement.TryGetProperty(ScopeClaimName, out var scopeElement))
+            {
+                var scopes = scopeElement.GetString();
+                tokenProperties.Scopes = string.IsNullOrEmpty(scopes) ? null : scopes.Split(' ');
+            }
+
+            if (tokenElement.TryGetProperty(IssuerClaimName, out var issuerElement))
+            {
+                tokenProperties.Issuer = issuerElement.GetString();
+            }
+
+            if (tokenElement.TryGetProperty(ExpirationClaimName, out var expirationElement) &&
+                expirationElement.ValueKind == JsonValueKind.Number)
+            {
+                var exp = expirationElement.GetInt64();
+                tokenProperties.Expiration = DateTimeOffset.FromUnixTimeSeconds(exp).UtcDateTime;
+            }
+
+            return tokenProperties;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? Base64UrlDecode(string encodedString)
+    {
+        // Convert from base64url encoding to base64 encoding: replace chars and add padding.
+        encodedString = encodedString.Replace('-', '+').Replace('_', '/');
+        encodedString += new string('=', 3 - ((encodedString.Length - 1) % 4));
+
+        try
+        {
+            var bytes = Convert.FromBase64String(encodedString);
+            var result = Encoding.UTF8.GetString(bytes);
+            return result;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+}

--- a/cs/test/TunnelsSDK.Test/Mocks/MockTunnelManagementClient.cs
+++ b/cs/test/TunnelsSDK.Test/Mocks/MockTunnelManagementClient.cs
@@ -19,6 +19,7 @@ public class MockTunnelManagementClient : ITunnelManagementClient
         string clusterId,
         string domain,
         TunnelRequestOptions options,
+        bool? ownedTunnelsOnly,
         CancellationToken cancellation)
     {
         IEnumerable<Tunnel> tunnels = Tunnels;

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -583,11 +583,11 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         query?: string,
         options?: TunnelRequestOptions,
     ) {
-        if (!clusterId && this.userTokenCallback) {
-            var token = await this.userTokenCallback();
+        if (clusterId === undefined && this.userTokenCallback) {
+            let token = await this.userTokenCallback();
             if (token && token.startsWith("tunnelplan")) {
                 token = token.replace("tunnelplan ", "");
-                var parsedToken = TunnelPlanTokenProperties.tryParse(token)
+                let parsedToken = TunnelPlanTokenProperties.tryParse(token)
                 if (parsedToken != undefined && parsedToken.clusterId) {
                     clusterId = parsedToken.clusterId
                 }

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -587,8 +587,8 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             let token = await this.userTokenCallback();
             if (token && token.startsWith("tunnelplan")) {
                 token = token.replace("tunnelplan ", "");
-                let parsedToken = TunnelPlanTokenProperties.tryParse(token)
-                if (parsedToken != undefined && parsedToken.clusterId) {
+                const parsedToken = TunnelPlanTokenProperties.tryParse(token)
+                if (parsedToken !== null && parsedToken.clusterId) {
                     clusterId = parsedToken.clusterId
                 }
             }

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -495,7 +495,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         body?: object,
         allowNotFound?: boolean,
     ): Promise<NullableIfNotBoolean<TResult>> {
-        const uri = this.buildUriForTunnel(tunnel, path, query, options);
+        const uri = await this.buildUriForTunnel(tunnel, path, query, options);
         const config = await this.getAxiosRequestConfig(tunnel, options, accessTokenScopes);
         const result = await this.request<TResult>(method, uri, body, config, allowNotFound);
         return result;
@@ -524,7 +524,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         body?: object,
         allowNotFound?: boolean,
     ): Promise<NullableIfNotBoolean<TResult>> {
-        const uri = this.buildUri(clusterId, path, query, options);
+        const uri = await this.buildUri(clusterId, path, query, options);
         const config = await this.getAxiosRequestConfig(undefined, options);
         const result = await this.request<TResult>(method, uri, body, config, allowNotFound);
         return result;
@@ -532,7 +532,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
 
     public async checkNameAvailablility(tunnelName: string): Promise<boolean> {
         tunnelName = encodeURI(tunnelName);
-        const uri = this.buildUri(
+        const uri = await this.buildUri(
             undefined,
             `${tunnelsApiPath}/${tunnelName}${checkAvailablePath}`,
         );

--- a/ts/src/management/tunnelPlanTokenProperties.ts
+++ b/ts/src/management/tunnelPlanTokenProperties.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Tunnel } from '@microsoft/dev-tunnels-contracts';
+
+/**
+ * Supports parsing tunnel access token JWT properties to allow for some pre-validation
+ * and diagnostics.
+ *
+ * Applications generally should not attempt to interpret or rely on any token properties
+ * other than `expiration`, because the service may change or omit those claims in the future.
+ * Other claims are exposed here only for diagnostic purposes.
+ */
+export class TunnelPlanTokenProperties {
+    private constructor(
+        public readonly clusterId?: string,
+        public readonly issuer?: string,
+        public readonly expiration?: Date,
+        public readonly userEmail?: string,
+        public readonly tunnelPlanId?: string,
+        public readonly subscriptionId?: string,
+        public readonly scopes?: string[],
+    ) {}
+
+    /**
+     * Checks if the tunnel access token expiration claim is in the past.
+     *
+     * (Does not throw if the token is an invalid format.)
+     */
+    public static validateTokenExpiration(token: string): void {
+        const t = TunnelPlanTokenProperties.tryParse(token);
+        if (t?.expiration) {
+            if (t.expiration < new Date()) {
+                throw new Error('The access token is expired: ' + t);
+            }
+        }
+    }
+
+    /**
+     * Attempts to parse a tunnel access token (JWT). This does NOT validate the token
+     * signature or any claims.
+     */
+    public static tryParse(token: string): TunnelPlanTokenProperties | null {
+        if (typeof token !== 'string') throw new TypeError('Token string expected.');
+
+        // JWTs are encoded in 3 parts: header, body, and signature.
+        const tokenParts = token.split('.');
+        if (tokenParts.length !== 3) {
+            return null;
+        }
+
+        const tokenBodyJson = TunnelPlanTokenProperties.base64UrlDecode(tokenParts[1]);
+        if (!tokenBodyJson) {
+            return null;
+        }
+
+        try {
+            const tokenJson = JSON.parse(tokenBodyJson);
+            const clusterId: string | undefined = tokenJson.clusterId;
+            const subscriptionId: string | undefined = tokenJson.subscriptionId;
+            const tunnelPlanId: string | undefined = tokenJson.tunnelPlanId;
+            const userEmail: string | undefined = tokenJson.userEmail;
+            const scp: string | undefined = tokenJson.scp;
+            const iss: string | undefined = tokenJson.iss;
+            const exp: number | undefined = tokenJson.exp;
+
+            return new TunnelPlanTokenProperties(
+                clusterId,
+                iss,
+                typeof exp === 'number' ? new Date(exp * 1000) : undefined,
+                userEmail,
+                tunnelPlanId,
+                subscriptionId,
+                scp?.split(' '),
+            );
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the tunnal access token trace string.
+     * 'none' if null or undefined, parsed token info if can be parsed, or 'token' if cannot be parsed.
+     */
+    public static getTokenTrace(token?: string | null | undefined): string {
+        return !token ? 'none' : TunnelPlanTokenProperties.tryParse(token)?.toString() ?? 'token';
+    }
+
+    private static base64UrlDecode(encodedString: string): string | null {
+        // Convert from base64url encoding to base64 encoding: replace chars and add padding.
+        encodedString = encodedString.replace('-', '+');
+        while (encodedString.length % 4 !== 0) {
+            encodedString += '=';
+        }
+
+        try {
+            const result = atob(encodedString);
+            return result;
+        } catch {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### Changes proposed: 
- Adds option for list tunnels that only lists tunnels owned by the user instead of all tunnels in the tunnel plan
- If a tunnel plan is used for auth, always use a cluster specific url