### PR TITLE
Preserve access tokens when refreshing tunnel

### DIFF
--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -85,23 +85,6 @@ public abstract class TunnelConnection : IAsyncDisposable, IPortForwardMessageFa
         {
             if (value != this.tunnel)
             {
-                // Get the tunnel access token from the new tunnel, or the original Tunnal object if the new tunnel doesn't have the token,
-                // which may happen when the tunnel was authenticated with a tunnel access token from Tunnel.AccessTokens.
-                // Add the tunnel access token to the new tunnel's AccessTokens if it is not there.
-
-                // TODO: remove this access token preservation logic when #990 is fixed.
-                string? accessToken;
-                if (value != null &&
-                    !value.TryGetAccessToken(TunnelAccessScope, out var _) &&
-                    this.tunnel?.TryGetAccessToken(TunnelAccessScope, out accessToken) == true &&
-                    !string.IsNullOrEmpty(accessToken) &&
-                    TunnelAccessTokenProperties.TryParse(accessToken) is TunnelAccessTokenProperties tokenProperties &&
-                    (tokenProperties.Expiration == null || tokenProperties.Expiration > DateTime.UtcNow))
-                {
-                    value.AccessTokens ??= new Dictionary<string, string>();
-                    value.AccessTokens[TunnelAccessScope] = accessToken;
-                }
-
                 this.tunnel = value;
                 OnTunnelChanged();
             }

--- a/cs/test/TunnelsSDK.Test/TunnelManagementClientTests.cs
+++ b/cs/test/TunnelsSDK.Test/TunnelManagementClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Microsoft.DevTunnels.Contracts;
@@ -14,14 +14,9 @@ public class TunnelManagementClientTests
     private readonly CancellationToken timeout = System.Diagnostics.Debugger.IsAttached ? default : new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token;
     private readonly ProductInfoHeaderValue userAgent = TunnelUserAgent.GetUserAgent(typeof(TunnelManagementClientTests).Assembly);
     private readonly Uri tunnelServiceUri = new Uri("https://localhost:3000/");
-    private readonly Tunnel tunnel = new Tunnel
-    {
-        TunnelId = TunnelId,
-        ClusterId = ClusterId,
-    };
 
     [Fact]
-    public async Task TunnelRequestOptions_SetRequestOption()
+    public async Task HttpRequestOptions()
     {
         var options = new TunnelRequestOptions()
         {
@@ -32,33 +27,86 @@ public class TunnelManagementClientTests
             }
         };
 
+        var tunnel = new Tunnel
+        {
+            TunnelId = TunnelId,
+            ClusterId = ClusterId,
+        };
+
         var handler = new MockHttpMessageHandler(
-            (message, ct) => 
+            (message, ct) =>
             {
                 Assert.True(message.Options.TryGetValue(new HttpRequestOptionsKey<string>("foo"), out string strValue) && strValue == "bar");
                 Assert.True(message.Options.TryGetValue(new HttpRequestOptionsKey<int>("bazz"), out int intValue) && intValue == 100);
-                return GetTunnelResponseAsync();
+
+                var result = new HttpResponseMessage(HttpStatusCode.OK);
+                result.Content = JsonContent.Create(tunnel);
+                return Task.FromResult(result);
             });
 
         var client = new TunnelManagementClient(this.userAgent, null, this.tunnelServiceUri, handler);
-        var tunnel = await client.GetTunnelAsync(this.tunnel, options, this.timeout);
+
+        tunnel = await client.GetTunnelAsync(tunnel, options, this.timeout);
         Assert.NotNull(tunnel);
         Assert.Equal(TunnelId, tunnel.TunnelId);
         Assert.Equal(ClusterId, tunnel.ClusterId);
     }
 
-    private Task<HttpResponseMessage> GetTunnelResponseAsync()
+    [Fact]
+    public async Task PreserveAccessTokens()
     {
-        var result = new HttpResponseMessage(HttpStatusCode.OK);
-        result.Content = JsonContent.Create(this.tunnel);
-        return Task.FromResult(result);
+        var requestTunnel = new Tunnel
+        {
+            TunnelId = TunnelId,
+            ClusterId = ClusterId,
+            AccessTokens = new Dictionary<string, string>
+            {
+                [TunnelAccessScopes.Manage] = "manage-token-1",
+                [TunnelAccessScopes.Connect] = "connect-token-1",
+            },
+        };
+
+        var handler = new MockHttpMessageHandler(
+            (message, ct) =>
+            {
+                var responseTunnel = new Tunnel
+                {
+                    TunnelId = TunnelId,
+                    ClusterId = ClusterId,
+                    AccessTokens = new Dictionary<string, string>
+                    {
+                        [TunnelAccessScopes.Manage] = "manage-token-2",
+                        [TunnelAccessScopes.Host] = "host-token-2",
+                    },
+                };
+
+                var result = new HttpResponseMessage(HttpStatusCode.OK);
+                result.Content = JsonContent.Create(responseTunnel);
+                return Task.FromResult(result);
+            });
+        var client = new TunnelManagementClient(this.userAgent, null, this.tunnelServiceUri, handler);
+
+        var resultTunnel = await client.GetTunnelAsync(requestTunnel, options: null, this.timeout);
+        Assert.NotNull(resultTunnel);
+        Assert.NotNull(resultTunnel.AccessTokens);
+
+        // Tokens in the request tunnel should be preserved, unless updated by the response.
+        Assert.Collection(
+            resultTunnel.AccessTokens.OrderBy((item) => item.Key),
+            (item) => Assert.Equal(new KeyValuePair<string, string>(
+                TunnelAccessScopes.Connect, "connect-token-1"), item), // preserved
+            (item) => Assert.Equal(new KeyValuePair<string, string>(
+                TunnelAccessScopes.Host, "host-token-2"), item),       // added
+            (item) => Assert.Equal(new KeyValuePair<string, string>(
+                TunnelAccessScopes.Manage, "manage-token-2"), item));  // updated
+
     }
 
     private sealed class MockHttpMessageHandler : DelegatingHandler
     {
         private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler;
 
-        public MockHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) 
+        public MockHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
             : base(new HttpClientHandler
             {
                 AllowAutoRedirect = false,

--- a/ts/src/connections/tunnelConnectionSession.ts
+++ b/ts/src/connections/tunnelConnectionSession.ts
@@ -77,26 +77,6 @@ export class TunnelConnectionSession extends TunnelConnectionBase implements Tun
 
     private set tunnel(value: Tunnel | null) {
         if (value !== this.connectedTunnel) {
-
-            // Get the tunnel access token from the new tunnel, or the original Tunnal object if the new tunnel doesn't have the token,
-            // which may happen when the tunnel was authenticated with a tunnel access token from Tunnel.AccessTokens.
-            // Add the tunnel access token to the new tunnel's AccessTokens if it is not there.
-
-            // TODO: remove this access token preservation logic when #990 is fixed.
-            if (value &&
-                !TunnelAccessTokenProperties.getTunnelAccessToken(value, this.tunnelAccessScope)) {
-
-                const accessToken = TunnelAccessTokenProperties.getTunnelAccessToken(
-                    this.tunnel,
-                    this.tunnelAccessScope,
-                );
-
-                if (accessToken) {
-                    value.accessTokens ??= {};
-                    value.accessTokens[this.tunnelAccessScope] = accessToken;
-                }
-            }
-
             this.connectedTunnel = value;
             this.tunnelChanged();
         }


### PR DESCRIPTION
When calling management APIs like `getTunnel()` or `updateTunnel()`, if the input Tunnel object has one or more tokens inn its `accessTokens` property, those tokens should be preserved in the returned Tunnel object if not refreshed by the request.