### PR TITLE
Custom expiration cli changes

### DIFF
--- a/cs/src/Contracts/Tunnel.cs
+++ b/cs/src/Contracts/Tunnel.cs
@@ -138,4 +138,10 @@ public class Tunnel
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? Expiration { get; set; }
+
+    /// <summary>
+    /// Gets or the custom amount of time the tunnel will be valid if it is not used or updated.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public uint? CustomExpiration { get; set; }
 }

--- a/cs/src/Contracts/Tunnel.cs
+++ b/cs/src/Contracts/Tunnel.cs
@@ -140,7 +140,7 @@ public class Tunnel
     public DateTime? Expiration { get; set; }
 
     /// <summary>
-    /// Gets or the custom amount of time the tunnel will be valid if it is not used or updated.
+    /// Gets or the custom amount of time the tunnel will be valid if it is not used or updated in seconds.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public uint? CustomExpiration { get; set; }

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -1178,6 +1178,7 @@ namespace Microsoft.DevTunnels.Management
                 Domain = tunnel.Domain,
                 Description = tunnel.Description,
                 Tags = tunnel.Tags,
+                CustomExpiration = tunnel.CustomExpiration,
                 Options = tunnel.Options,
                 AccessControl = tunnel.AccessControl == null ? null : new TunnelAccessControl(
                     tunnel.AccessControl.Where((ace) => !ace.IsInherited)),

--- a/go/tunnels/tunnel.go
+++ b/go/tunnels/tunnel.go
@@ -66,6 +66,6 @@ type Tunnel struct {
 	Expiration       *time.Time `json:"expiration,omitempty"`
 
 	// Gets or the custom amount of time the tunnel will be valid if it is not used or
-	// updated.
+	// updated in seconds.
 	CustomExpiration uint32 `json:"customExpiration,omitempty"`
 }

--- a/go/tunnels/tunnel.go
+++ b/go/tunnels/tunnel.go
@@ -11,44 +11,44 @@ import (
 // Data contract for tunnel objects managed through the tunnel service REST API.
 type Tunnel struct {
 	// Gets or sets the ID of the cluster the tunnel was created in.
-	ClusterID     string `json:"clusterId,omitempty"`
+	ClusterID        string `json:"clusterId,omitempty"`
 
 	// Gets or sets the generated ID of the tunnel, unique within the cluster.
-	TunnelID      string `json:"tunnelId,omitempty"`
+	TunnelID         string `json:"tunnelId,omitempty"`
 
 	// Gets or sets the optional short name (alias) of the tunnel.
 	//
 	// The name must be globally unique within the parent domain, and must be a valid
 	// subdomain.
-	Name          string `json:"name,omitempty"`
+	Name             string `json:"name,omitempty"`
 
 	// Gets or sets the description of the tunnel.
-	Description   string `json:"description,omitempty"`
+	Description      string `json:"description,omitempty"`
 
 	// Gets or sets the tags of the tunnel.
-	Tags          []string `json:"tags,omitempty"`
+	Tags             []string `json:"tags,omitempty"`
 
 	// Gets or sets the optional parent domain of the tunnel, if it is not using the default
 	// parent domain.
-	Domain        string `json:"domain,omitempty"`
+	Domain           string `json:"domain,omitempty"`
 
 	// Gets or sets a dictionary mapping from scopes to tunnel access tokens.
-	AccessTokens  map[TunnelAccessScope]string `json:"accessTokens,omitempty"`
+	AccessTokens     map[TunnelAccessScope]string `json:"accessTokens,omitempty"`
 
 	// Gets or sets access control settings for the tunnel.
 	//
 	// See `TunnelAccessControl` documentation for details about the access control model.
-	AccessControl *TunnelAccessControl `json:"accessControl,omitempty"`
+	AccessControl    *TunnelAccessControl `json:"accessControl,omitempty"`
 
 	// Gets or sets default options for the tunnel.
-	Options       *TunnelOptions `json:"options,omitempty"`
+	Options          *TunnelOptions `json:"options,omitempty"`
 
 	// Gets or sets current connection status of the tunnel.
-	Status        *TunnelStatus `json:"status,omitempty"`
+	Status           *TunnelStatus `json:"status,omitempty"`
 
 	// Gets or sets an array of endpoints where hosts are currently accepting client
 	// connections to the tunnel.
-	Endpoints     []TunnelEndpoint `json:"endpoints,omitempty"`
+	Endpoints        []TunnelEndpoint `json:"endpoints,omitempty"`
 
 	// Gets or sets a list of ports in the tunnel.
 	//
@@ -57,11 +57,15 @@ type Tunnel struct {
 	// creating a tunnel. It is omitted when listing (multiple) tunnels, or when updating
 	// tunnel properties. (For the latter, use APIs to create/update/delete individual ports
 	// instead.)
-	Ports         []TunnelPort `json:"ports,omitempty"`
+	Ports            []TunnelPort `json:"ports,omitempty"`
 
 	// Gets or sets the time in UTC of tunnel creation.
-	Created       *time.Time `json:"created,omitempty"`
+	Created          *time.Time `json:"created,omitempty"`
 
 	// Gets or the time the tunnel will be deleted if it is not used or updated.
-	Expiration    *time.Time `json:"expiration,omitempty"`
+	Expiration       *time.Time `json:"expiration,omitempty"`
+
+	// Gets or the custom amount of time the tunnel will be valid if it is not used or
+	// updated.
+	CustomExpiration uint32 `json:"customExpiration,omitempty"`
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/Tunnel.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/Tunnel.java
@@ -109,4 +109,11 @@ public class Tunnel {
      */
     @Expose
     public Date expiration;
+
+    /**
+     * Gets or the custom amount of time the tunnel will be valid if it is not used or
+     * updated.
+     */
+    @Expose
+    public int customExpiration;
 }

--- a/java/src/main/java/com/microsoft/tunnels/contracts/Tunnel.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/Tunnel.java
@@ -112,7 +112,7 @@ public class Tunnel {
 
     /**
      * Gets or the custom amount of time the tunnel will be valid if it is not used or
-     * updated.
+     * updated in seconds.
      */
     @Expose
     public int customExpiration;

--- a/rs/src/contracts/tunnel.rs
+++ b/rs/src/contracts/tunnel.rs
@@ -74,6 +74,6 @@ pub struct Tunnel {
     pub expiration: Option<DateTime<Utc>>,
 
     // Gets or the custom amount of time the tunnel will be valid if it is not used or
-    // updated.
+    // updated in seconds.
     pub custom_expiration: Option<u32>,
 }

--- a/rs/src/contracts/tunnel.rs
+++ b/rs/src/contracts/tunnel.rs
@@ -72,4 +72,8 @@ pub struct Tunnel {
 
     // Gets or the time the tunnel will be deleted if it is not used or updated.
     pub expiration: Option<DateTime<Utc>>,
+
+    // Gets or the custom amount of time the tunnel will be valid if it is not used or
+    // updated.
+    pub custom_expiration: Option<u32>,
 }

--- a/ts/src/contracts/tunnel.ts
+++ b/ts/src/contracts/tunnel.ts
@@ -99,7 +99,7 @@ export interface Tunnel {
 
     /**
      * Gets or the custom amount of time the tunnel will be valid if it is not used or
-     * updated.
+     * updated in seconds.
      */
     customExpiration?: number;
 }

--- a/ts/src/contracts/tunnel.ts
+++ b/ts/src/contracts/tunnel.ts
@@ -96,4 +96,10 @@ export interface Tunnel {
      * Gets or the time the tunnel will be deleted if it is not used or updated.
      */
     expiration?: Date;
+
+    /**
+     * Gets or the custom amount of time the tunnel will be valid if it is not used or
+     * updated.
+     */
+    customExpiration?: number;
 }


### PR DESCRIPTION
Fixes #

### Changes proposed: 
For the new feature `CustomTunnelExpiration` we are adding a property to the Tunnel object that stores the value a user inputs if they want a custom tunnel expiration. This is currently being added as a command line option in both `create` and `host` in tunnels, and these are the associated SDK changes needed to make sure that the value the user specifies in the CLI is reflected when the tunnel is created

### Other Tasks:
- [ ] Added all the associated SDK contracts after adding that new property