### PR TITLE
Improve host & client connect options and cancellation

### DIFF
--- a/cs/src/Connections/ITunnelClient.cs
+++ b/cs/src/Connections/ITunnelClient.cs
@@ -83,9 +83,9 @@ public interface ITunnelClient : IAsyncDisposable
     /// <exception cref="UnauthorizedAccessException">The client does not have
     /// access to connect to the tunnel.</exception>
     /// <exception cref="TunnelConnectionException">The client failed to connect to the
-    /// tunnel, or connected but encountered a protocol errror.</exception>
-    Task ConnectAsync(Tunnel tunnel, CancellationToken cancellation)
-        => ConnectAsync(tunnel, hostId: null, cancellation);
+    /// tunnel, or connected but encountered a protocol error.</exception>
+    Task ConnectAsync(Tunnel tunnel, CancellationToken cancellation = default)
+        => ConnectAsync(tunnel, options: null, cancellation);
 
     /// <summary>
     /// Connects to a tunnel.
@@ -104,8 +104,33 @@ public interface ITunnelClient : IAsyncDisposable
     /// <exception cref="UnauthorizedAccessException">The client does not have
     /// access to connect to the tunnel.</exception>
     /// <exception cref="TunnelConnectionException">The client failed to connect to the
-    /// tunnel, or connected but encountered a protocol errror.</exception>
-    Task ConnectAsync(Tunnel tunnel, string? hostId, CancellationToken cancellation);
+    /// tunnel, or connected but encountered a protocol error.</exception>
+    [Obsolete("Use ConnectAsync(Tunnel, TunnelConnectionOptions, CancellationToken) instead.")]
+    Task ConnectAsync(Tunnel tunnel, string? hostId, CancellationToken cancellation)
+        => ConnectAsync(
+            tunnel,
+            new TunnelConnectionOptions { HostId = hostId }, cancellation);
+
+    /// <summary>
+    /// Connects to a tunnel.
+    /// </summary>
+    /// <param name="tunnel">Tunnel to connect to.</param>
+    /// <param name="options">Options for the connection.</param>
+    /// <param name="cancellation">Cancellation token.</param>
+    /// <remarks>
+    /// Once connected, tunnel ports are forwarded by the host.
+    /// The client either needs to be logged in as the owner identity, or have
+    /// an access token with "connect" scope for the tunnel.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
+    /// <exception cref="UnauthorizedAccessException">The client does not have
+    /// access to connect to the tunnel.</exception>
+    /// <exception cref="TunnelConnectionException">The client failed to connect to the
+    /// tunnel, or connected but encountered a protocol error.</exception>
+    Task ConnectAsync(
+        Tunnel tunnel,
+        TunnelConnectionOptions? options,
+        CancellationToken cancellation = default);
 
     /// <summary>
     /// Waits for the specified port to be forwarded by the remote host.

--- a/cs/src/Connections/ITunnelConnector.cs
+++ b/cs/src/Connections/ITunnelConnector.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ITunnelRelayConnector.cs" company="Microsoft">
+// <copyright file="ITunnelRelayConnector.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>
@@ -16,5 +16,8 @@ public interface ITunnelConnector
     /// <summary>
     /// Connect or reconnect tunnel SSH session.
     /// </summary>
-    Task ConnectSessionAsync(bool isReconnect, CancellationToken cancellation);
+    Task ConnectSessionAsync(
+        TunnelConnectionOptions? options,
+        bool isReconnect,
+        CancellationToken cancellation);
 }

--- a/cs/src/Connections/ITunnelHost.cs
+++ b/cs/src/Connections/ITunnelHost.cs
@@ -51,8 +51,49 @@ public interface ITunnelHost : IAsyncDisposable
     /// <exception cref="UnauthorizedAccessException">The host does not have
     /// access to host the tunnel.</exception>
     /// <exception cref="TunnelConnectionException">The host failed to connect to the
-    /// tunnel, or connected but encountered a protocol errror.</exception>
-    Task StartAsync(Tunnel tunnel, CancellationToken cancellation);
+    /// tunnel, or connected but encountered a protocol error.</exception>
+    [Obsolete("Use ConnectAsync() instead.")]
+    Task StartAsync(Tunnel tunnel, CancellationToken cancellation)
+        => ConnectAsync(tunnel, options: null, cancellation);
+
+    /// <summary>
+    /// Connects to a tunnel as a host and starts accepting incoming connections
+    /// to local ports as defined on the tunnel.
+    /// </summary>
+    /// <param name="tunnel">Information about the tunnel to connect to.</param>
+    /// <param name="cancellation">Cancellation token.</param>
+    /// <remarks>
+    /// The host either needs to be logged in as the owner identity, or have
+    /// an access token with "host" scope for the tunnel.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
+    /// <exception cref="UnauthorizedAccessException">The host does not have
+    /// access to host the tunnel.</exception>
+    /// <exception cref="TunnelConnectionException">The host failed to connect to the
+    /// tunnel, or connected but encountered a protocol error.</exception>
+    Task ConnectAsync(Tunnel tunnel, CancellationToken cancellation = default)
+        => ConnectAsync(tunnel, options: null, cancellation);
+
+    /// <summary>
+    /// Connects to a tunnel as a host and starts accepting incoming connections
+    /// to local ports as defined on the tunnel.
+    /// </summary>
+    /// <param name="tunnel">Information about the tunnel to connect to.</param>
+    /// <param name="options">Options for the connection.</param>
+    /// <param name="cancellation">Cancellation token.</param>
+    /// <remarks>
+    /// The host either needs to be logged in as the owner identity, or have
+    /// an access token with "host" scope for the tunnel.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The tunnel was not found.</exception>
+    /// <exception cref="UnauthorizedAccessException">The host does not have
+    /// access to host the tunnel.</exception>
+    /// <exception cref="TunnelConnectionException">The host failed to connect to the
+    /// tunnel, or connected but encountered a protocol error.</exception>
+    Task ConnectAsync(
+        Tunnel tunnel,
+        TunnelConnectionOptions? options,
+        CancellationToken cancellation = default);
 
     /// <summary>
     /// Refreshes ports that were updated using the management API.

--- a/cs/src/Connections/MultiModeTunnelClient.cs
+++ b/cs/src/Connections/MultiModeTunnelClient.cs
@@ -84,10 +84,10 @@ public class MultiModeTunnelClient : TunnelConnection, ITunnelClient
     protected override string TunnelAccessScope => TunnelAccessScopes.Connect;
 
     /// <inheritdoc />
-    public async Task ConnectAsync(
+    public override async Task ConnectAsync(
         Tunnel tunnel,
-        string? hostId,
-        CancellationToken cancellation)
+        TunnelConnectionOptions? options,
+        CancellationToken cancellation = default)
     {
         Requires.NotNull(tunnel, nameof(tunnel));
 

--- a/cs/src/Connections/MultiModeTunnelHost.cs
+++ b/cs/src/Connections/MultiModeTunnelHost.cs
@@ -67,9 +67,10 @@ namespace Microsoft.DevTunnels.Connections
 #pragma warning restore CS0067
 
         /// <inheritdoc />
-        public async Task StartAsync(
+        public override async Task ConnectAsync(
             Tunnel tunnel,
-            CancellationToken cancellation)
+            TunnelConnectionOptions? options,
+            CancellationToken cancellation = default)
         {
             Requires.NotNull(tunnel, nameof(tunnel));
 
@@ -77,7 +78,7 @@ namespace Microsoft.DevTunnels.Connections
 
             foreach (var host in Hosts)
             {
-                startTasks.Add(host.StartAsync(tunnel, cancellation));
+                startTasks.Add(host.ConnectAsync(tunnel, options, cancellation));
             }
 
             await Task.WhenAll(startTasks);

--- a/cs/src/Connections/RelayTunnelConnector.cs
+++ b/cs/src/Connections/RelayTunnelConnector.cs
@@ -35,6 +35,7 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
 
     /// <inheritdoc/>
     public async Task ConnectSessionAsync(
+        TunnelConnectionOptions? options,
         bool isReconnect,
         CancellationToken cancellation)
     {
@@ -190,6 +191,11 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
 
             if (exception != null)
             {
+                if (options?.EnableRetry == false)
+                {
+                    throw exception;
+                }
+
                 var retryDelay = TimeSpan.FromMilliseconds(isDelayNeeded ? attemptDelayMs : 0);
                 var retryingArgs = new RetryingTunnelConnectionEventArgs(exception, retryDelay);
                 this.relayClient.OnRetrying(retryingArgs);

--- a/cs/src/Connections/TunnelClient.cs
+++ b/cs/src/Connections/TunnelClient.cs
@@ -632,8 +632,11 @@ public abstract class TunnelClient : TunnelConnection, ITunnelClient
             sshSession.Closed -= OnSshSessionClosed;
         }
 
-        ConnectionStatus = ConnectionStatus.Disconnected;
+        // Clear the SSH session before setting the status to Disconnected, in case the
+        // status-changed event handler immediately triggers annother connection attempt.
         this.SshSession = null;
+
+        ConnectionStatus = ConnectionStatus.Disconnected;
 
         OnSshSessionClosed(e.Exception);
         if (e.Reason == SshDisconnectReason.ConnectionLost)

--- a/cs/src/Connections/TunnelClient.cs
+++ b/cs/src/Connections/TunnelClient.cs
@@ -184,7 +184,7 @@ public abstract class TunnelClient : TunnelConnection, ITunnelClient
             // Unsubscribe event handler from the previous session.
             this.SshSession.Authenticating -= OnSshServerAuthenticating;
             this.SshSession.Disconnected -= OnSshSessionDisconnected;
-            this.SshSession.Closed -= SshSession_Closed;
+            this.SshSession.Closed -= OnSshSessionClosed;
             this.SshSession.Request -= OnRequest;
         }
 

--- a/cs/src/Connections/TunnelConnectionOptions.cs
+++ b/cs/src/Connections/TunnelConnectionOptions.cs
@@ -1,0 +1,63 @@
+// <copyright file="TunnelConnectionOptions.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System.Threading;
+using Microsoft.DevTunnels.Contracts;
+
+namespace Microsoft.DevTunnels.Connections;
+
+/// <summary>
+/// Options for a tunnel host or client connection.
+/// </summary>
+/// <seealso cref="ITunnelHost.ConnectAsync(Tunnel, TunnelConnectionOptions?, CancellationToken)"/>
+public class TunnelConnectionOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the connection will be automatically retried after
+    /// a connection failure.
+    /// </summary>
+    /// <remarks>
+    /// The default value is true. When enabled, retries continue until the connection is
+    /// successful, the cancellation token is cancelled, or an unrecoverable error is encountered.
+    ///
+    /// Recoverable errors include network connectivity issues, authentication issues (e.g. expired
+    /// access token which may be refreshed before retrying), and service temporarily unavailable
+    /// (HTTP 503). For rate-limiting errors (HTTP 429) only a limited number of retries are
+    /// attempted before giving up.
+    ///
+    /// Retries are performed with exponential backoff, starting with a 100ms delay and doubling
+    /// up to a maximum 12s delay, with further retries using the same max delay.
+    ///
+    /// Note after the initial connection succeeds, the host or client may still become disconnected
+    /// at any time after that. In that case the <see cref="EnableReconnect" /> option controls
+    /// whether an automatic reconnect will be attempted. Reconnection has the same retry behavior.
+    ///
+    /// Listen to the <see cref="TunnelConnection.RetryingTunnelConnection" /> event to be notified
+    /// when the connection is retrying.
+    /// </remarks>
+    public bool EnableRetry { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the connection will attempt to automatically
+    /// reconnect (with no data loss) after a disconnection. 
+    /// </summary>
+    /// <remarks>
+    /// The default value is true.
+    ///
+    /// If reconnection fails, or is not enabled, the application may still attempt to connect
+    /// the client again, however in that case no state is preserved.
+    ///
+    /// Listen to the <see cref="TunnelConnection.ConnectionStatusChanged" /> event to be notified
+    /// when reconnection or disconnection occurs.
+    /// </remarks>
+    public bool EnableReconnect { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the ID of the tunnel host to connect to, if there are multiple
+    /// hosts accepting connections on the tunnel, or null to connect to a single host
+    /// (most common). This option applies only to client connections.
+    /// </summary>
+    public string? HostId { get; set; }
+}

--- a/cs/src/Connections/TunnelConnectionOptions.cs
+++ b/cs/src/Connections/TunnelConnectionOptions.cs
@@ -31,8 +31,9 @@ public class TunnelConnectionOptions
     /// up to a maximum 12s delay, with further retries using the same max delay.
     ///
     /// Note after the initial connection succeeds, the host or client may still become disconnected
-    /// at any time after that. In that case the <see cref="EnableReconnect" /> option controls
-    /// whether an automatic reconnect will be attempted. Reconnection has the same retry behavior.
+    /// at any time after that due to a network disruption or a relay service upgrade. When that
+    /// happens, the <see cref="EnableReconnect" /> option controls whether an automatic reconnect
+    /// will be attempted. Reconnection has the same retry behavior.
     ///
     /// Listen to the <see cref="TunnelConnection.RetryingTunnelConnection" /> event to be notified
     /// when the connection is retrying.

--- a/cs/src/Connections/TunnelHost.cs
+++ b/cs/src/Connections/TunnelHost.cs
@@ -91,18 +91,19 @@ public abstract class TunnelHost : TunnelConnection, ITunnelHost
     }
 
     /// <inheritdoc />
-    public async Task StartAsync(Tunnel tunnel, CancellationToken cancellation)
+    [Obsolete("Use ConnectAsync() instead.")]
+    public Task StartAsync(Tunnel tunnel, CancellationToken cancellation)
+        => ConnectAsync(tunnel, cancellation);
+
+    /// <inheritdoc />
+    public override async Task ConnectAsync(
+        Tunnel tunnel,
+        TunnelConnectionOptions? options,
+        CancellationToken cancellation = default)
     {
         Requires.NotNull(tunnel, nameof(tunnel));
-
-        if (Tunnel != null)
-        {
-            throw new InvalidOperationException(
-                "Already hosting a tunnel. Use separate instances to host multiple tunnels.");
-        }
-
         Requires.NotNull(tunnel.Ports!, nameof(tunnel.Ports));
-        await ConnectTunnelSessionAsync(tunnel, cancellation);
+        await ConnectTunnelSessionAsync(tunnel, options, cancellation);
     }
 
     internal async Task ForwardPortAsync(

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -171,9 +171,10 @@ public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
     /// </summary>
     protected virtual async Task ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
     {
-        if (isReconnect && SshSession != null && !SshSession.IsClosed)
+        var session = SshSession;
+        if (isReconnect && session != null && !session.IsClosed)
         {
-            await SshSession.ReconnectAsync(stream, cancellation);
+            await session.ReconnectAsync(stream, cancellation);
         }
         else
         {

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -117,6 +117,30 @@ public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
     }
 
     /// <summary>
+    /// Connect to the clientRelayUri using accessToken.
+    /// </summary>
+    protected Task ConnectAsync(
+        string clientRelayUri,
+        string? accessToken,
+        string[]? hostPublicKeys,
+        TunnelConnectionOptions options,
+        CancellationToken cancellation)
+    {
+        Requires.NotNull(clientRelayUri, nameof(clientRelayUri));
+        return ConnectTunnelSessionAsync(
+            (cancellation) =>
+            {
+                this.relayUri = new Uri(clientRelayUri, UriKind.Absolute);
+                this.accessToken = accessToken;
+                this.HostPublicKeys = hostPublicKeys;
+                this.connector = new RelayTunnelConnector(this);
+                return this.connector.ConnectSessionAsync(
+                    options, isReconnect: false, cancellation);
+            },
+            cancellation);
+    }
+
+    /// <summary>
     /// Create stream to the tunnel.
     /// </summary>
     protected virtual async Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)
@@ -166,7 +190,7 @@ public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
     TraceSource IRelayClient.Trace => Trace;
 
     /// <inheritdoc />
-    Task<Stream> IRelayClient.CreateSessionStreamAsync(CancellationToken cancellation) => 
+    Task<Stream> IRelayClient.CreateSessionStreamAsync(CancellationToken cancellation) =>
         CreateSessionStreamAsync(cancellation);
 
     /// <inheritdoc />

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -117,28 +117,6 @@ public class TunnelRelayTunnelClient : TunnelClient, IRelayClient
     }
 
     /// <summary>
-    /// Connect to the clientRelayUri using accessToken.
-    /// </summary>
-    protected Task ConnectAsync(
-        string clientRelayUri,
-        string? accessToken,
-        string[]? hostPublicKeys,
-        CancellationToken cancellation)
-    {
-        Requires.NotNull(clientRelayUri, nameof(clientRelayUri));
-        return ConnectTunnelSessionAsync(
-            (cancellation) =>
-            {
-                this.relayUri = new Uri(clientRelayUri, UriKind.Absolute);
-                this.accessToken = accessToken;
-                this.HostPublicKeys = hostPublicKeys;
-                this.connector = new RelayTunnelConnector(this);
-                return this.connector.ConnectSessionAsync(isReconnect: false, cancellation);
-            },
-            cancellation);
-    }
-
-    /// <summary>
     /// Create stream to the tunnel.
     /// </summary>
     protected virtual async Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation)

--- a/ts/src/connections/multiModeTunnelClient.ts
+++ b/ts/src/connections/multiModeTunnelClient.ts
@@ -6,6 +6,7 @@ import { CancellationToken, SshStream } from '@microsoft/dev-tunnels-ssh';
 import { ForwardedPortsCollection } from '@microsoft/dev-tunnels-ssh-tcp';
 import { TunnelClient } from '.';
 import { TunnelConnectionBase } from './tunnelConnectionBase';
+import { TunnelConnectionOptions } from './tunnelConnectionOptions';
 
 /**
  * Tunnel client implementation that selects one of multiple available connection modes.
@@ -42,7 +43,11 @@ export class MultiModeTunnelClient extends TunnelConnectionBase implements Tunne
         this.clients.forEach((c) => (c.localForwardingHostAddress = value));
     }
 
-    public connect(tunnel: Tunnel, hostId?: string): Promise<void> {
+    public connect(
+        tunnel: Tunnel,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
+    ): Promise<void> {
         if (!tunnel) {
             throw new Error('Tunnel cannot be null');
         }

--- a/ts/src/connections/multiModeTunnelHost.ts
+++ b/ts/src/connections/multiModeTunnelHost.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CancellationToken } from '@microsoft/dev-tunnels-ssh';
 import { Tunnel, TunnelAccessScopes, TunnelPort } from '@microsoft/dev-tunnels-contracts';
 import { TunnelHost } from '.';
 import { v4 as uuidv4 } from 'uuid';
 import { TunnelConnectionBase } from './tunnelConnectionBase';
+import { TunnelConnectionOptions } from './tunnelConnectionOptions';
 
 /**
  * Aggregation of multiple tunnel hosts.
@@ -18,11 +20,21 @@ export class MultiModeTunnelHost extends TunnelConnectionBase implements TunnelH
         this.hosts = [];
     }
 
+    /**
+     * @deprecated Use `connect()` instead.
+     */
     public async start(tunnel: Tunnel): Promise<void> {
+        await this.connect(tunnel);
+    }
+
+    public async connect(
+        tunnel: Tunnel,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken): Promise<void> {
         const startTasks: Promise<void>[] = [];
 
         this.hosts.forEach((host) => {
-            startTasks.push(host.start(tunnel));
+            startTasks.push(host.connect(tunnel, options, cancellation));
         });
 
         await Promise.all(startTasks);

--- a/ts/src/connections/tunnelClient.ts
+++ b/ts/src/connections/tunnelClient.ts
@@ -6,6 +6,7 @@ import { TunnelConnectionMode, Tunnel } from '@microsoft/dev-tunnels-contracts';
 import { CancellationToken } from '@microsoft/dev-tunnels-ssh';
 import { ForwardedPortsCollection } from '@microsoft/dev-tunnels-ssh-tcp';
 import { TunnelConnection } from './tunnelConnection';
+import { TunnelConnectionOptions } from './tunnelConnectionOptions';
 
 /**
  * Interface for a client capable of making a connection
@@ -41,10 +42,20 @@ export interface TunnelClient extends TunnelConnection {
 
     /**
      * Connects to a tunnel.
-     * @param tunnel
-     * @param hostId
+     * 
+     * Once connected, tunnel ports are forwarded by the host.
+     * The client either needs to be logged in as the owner identity, or have
+     * an access token with "connect" scope for the tunnel.
+     *
+     * @param tunnel Tunnel to connect to.
+     * @param options Options for the connection.
+     * @param cancellation Optional cancellation token for the connection.
      */
-    connect(tunnel: Tunnel, hostId?: string): Promise<void>;
+    connect(
+        tunnel: Tunnel,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
+    ): Promise<void>;
 
     /**
      * Opens a stream connected to a remote port for clients which cannot forward local TCP ports, such as browsers.

--- a/ts/src/connections/tunnelClientBase.ts
+++ b/ts/src/connections/tunnelClientBase.ts
@@ -36,6 +36,7 @@ import { TunnelManagementClient } from '@microsoft/dev-tunnels-management';
 import { tunnelSshSessionClass } from './tunnelSshSessionClass';
 import { PortRelayConnectResponseMessage } from './messages/portRelayConnectResponseMessage';
 import { ConnectionStatus } from './connectionStatus';
+import { TunnelConnectionOptions } from './tunnelConnectionOptions';
 
 export const webSocketSubProtocol = 'tunnel-relay-client';
 export const webSocketSubProtocolv2 = 'tunnel-relay-client-v2-dev';
@@ -134,9 +135,13 @@ export class TunnelClientBase
         super(TunnelAccessScopes.Connect, trace, managementClient);
     }
 
-    public async connect(tunnel: Tunnel, hostId?: string): Promise<void> {
-        this.hostId = hostId;
-        await this.connectTunnelSession(tunnel);
+    public async connect(
+        tunnel: Tunnel,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
+    ): Promise<void> {
+        this.hostId = options?.hostId;
+        await this.connectTunnelSession(tunnel, options, cancellation);
     }
 
     protected tunnelChanged() {

--- a/ts/src/connections/tunnelConnectionBase.ts
+++ b/ts/src/connections/tunnelConnectionBase.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CancellationError } from '@microsoft/dev-tunnels-ssh';
+import { CancellationError, ObjectDisposedError } from '@microsoft/dev-tunnels-ssh';
 import { CancellationToken, CancellationTokenSource, Emitter } from 'vscode-jsonrpc';
 import { ConnectionStatus } from './connectionStatus';
 import { ConnectionStatusChangedEventArgs } from './connectionStatusChangedEventArgs';
@@ -174,7 +174,7 @@ export class TunnelConnectionBase implements TunnelConnection {
      */
     protected throwIfDisposed() {
         if (this.isDisposed) {
-            throw new CancellationError('The tunnel connection is disposed.');
+            throw new ObjectDisposedError('The tunnel connection is disposed.');
         }
     }
 }

--- a/ts/src/connections/tunnelConnectionOptions.ts
+++ b/ts/src/connections/tunnelConnectionOptions.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as http from 'http';
+
+/**
+ * Options for a tunnel host or client connection.
+ */
+export interface TunnelConnectionOptions {
+    /**
+     * Gets or sets a value indicating whether the connection will be automatically retried after
+     * a connection failure.
+     *
+     * The default value is true. When enabled, retries continue until the connection is
+     * successful, the cancellation token is cancelled, or an unrecoverable error is encountered.
+     *
+     * Recoverable errors include network connectivity issues, authentication issues (e.g. expired
+     * access token which may be refreshed before retrying), and service temporarily unavailable
+     * (HTTP 503). For rate-limiting errors (HTTP 429) only a limited number of retries are
+     * attempted before giving up.
+     *
+     * Retries are performed with exponential backoff, starting with a 100ms delay and doubling
+     * up to a maximum 12s delay, with further retries using the same max delay.
+     *
+     * Note after the initial connection succeeds, the host or client may still become disconnected
+     * at any time after that. In that case the `enableReconnect` option controls whether an
+     * automatic reconnect will be attempted. Reconnection has the same retry behavior.
+     *
+     * Listen to the `retryingTunnelConnection` event to be notified when the connection is
+     * retrying.
+     */
+    enableRetry?: boolean;
+
+    /**
+     * Gets or sets a value indicating whether the connection will attempt to automatically
+     * reconnect (with no data loss) after a disconnection.
+     * 
+     * The default value is true.
+     *
+     * If reconnection fails, or is not enabled, the application may still attempt to connect
+     * the client again, however in that case no state is preserved.
+     *
+     * Listen to the `connectionStatusChanged` event to be notified when reconnection or
+     * disconnection occurs.
+     */
+    enableReconnect?: boolean;
+
+    /**
+     * Gets or sets the HTTP agent to use for the connection.
+     */
+    httpAgent?: http.Agent;
+
+    /**
+     * Gets or sets the ID of the tunnel host to connect to, if there are multiple
+     * hosts accepting connections on the tunnel, or null to connect to a single host
+     * (most common). This option applies only to client connections.
+     */
+    hostId?: string;
+}

--- a/ts/src/connections/tunnelConnector.ts
+++ b/ts/src/connections/tunnelConnector.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { CancellationToken } from '@microsoft/dev-tunnels-ssh';
+import { TunnelConnectionOptions } from './tunnelConnectionOptions';
 
 /**
  * Tunnel connector.
@@ -12,5 +13,9 @@ export interface TunnelConnector {
      * @param isReconnect A value indicating if this is a reconnect (true) or regular connect (false).
      * @param cancellation Cancellation token.
      */
-    connectSession(isReconnect: boolean, cancellation: CancellationToken): Promise<void>;
+    connectSession(
+        isReconnect: boolean,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
+    ): Promise<void>;
 }

--- a/ts/src/connections/tunnelHost.ts
+++ b/ts/src/connections/tunnelHost.ts
@@ -3,6 +3,8 @@
 
 import { Tunnel, TunnelPort } from '@microsoft/dev-tunnels-contracts';
 import { TunnelConnection } from './tunnelConnection';
+import { TunnelConnectionOptions } from './tunnelConnectionOptions';
+import { CancellationToken } from '@microsoft/dev-tunnels-ssh';
 
 /**
  * Interface for a host capable of sharing local ports via
@@ -12,9 +14,26 @@ export interface TunnelHost extends TunnelConnection {
     /**
      * Connects to a tunnel as a host and starts accepting incoming connections
      * to local ports as defined on the tunnel.
-     * @param tunnel
+     * @deprecated Use `connect()` instead. 
      */
     start(tunnel: Tunnel): Promise<void>;
+
+    /**
+     * Connects to a tunnel as a host and starts accepting incoming connections
+     * to local ports as defined on the tunnel.
+     * 
+     * The host either needs to be logged in as the owner identity, or have
+     * an access token with "host" scope for the tunnel.
+     * 
+     * @param tunnel Tunnel to connect to.
+     * @param options Options for the connection.
+     * @param cancellation Optional cancellation token for the connection.
+     */
+    connect(
+        tunnel: Tunnel,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
+    ): Promise<void>;
 
     /**
      * Refreshes ports that were updated using the management API.

--- a/ts/src/connections/tunnelHostBase.ts
+++ b/ts/src/connections/tunnelHostBase.ts
@@ -4,6 +4,7 @@
 import { TunnelPort, Tunnel, TunnelAccessScopes } from '@microsoft/dev-tunnels-contracts';
 import { TunnelManagementClient } from '@microsoft/dev-tunnels-management';
 import {
+    CancellationToken,
     KeyPair,
     SshAlgorithms,
     SshClientSession,
@@ -16,6 +17,7 @@ import { TunnelConnectionSession } from './tunnelConnectionSession';
 import { TunnelHost } from './tunnelHost';
 import { tunnelSshSessionClass } from './tunnelSshSessionClass';
 import { isNode } from './sshHelpers';
+import { TunnelConnectionOptions } from './tunnelConnectionOptions';
 
 /**
  * Base class for Hosts that host one tunnel and use SSH to connect to the tunnel host service.
@@ -86,9 +88,22 @@ export class TunnelHostBase
     /**
      * Connects to a tunnel as a host and starts accepting incoming connections
      * to local ports as defined on the tunnel.
+     * @deprecated Use `connect()` instead.
      */
     public async start(tunnel: Tunnel): Promise<void> {
-        await this.connectTunnelSession(tunnel);
+        await this.connect(tunnel);
+    }
+
+    /**
+     * Connects to a tunnel as a host and starts accepting incoming connections
+     * to local ports as defined on the tunnel.
+     */
+    public async connect(
+        tunnel: Tunnel,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
+    ): Promise<void> {
+        await this.connectTunnelSession(tunnel, options, cancellation);
     }
 
     public refreshPorts(): Promise<void> {

--- a/ts/src/connections/tunnelSession.ts
+++ b/ts/src/connections/tunnelSession.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT license.
 
 import { Tunnel } from '@microsoft/dev-tunnels-contracts';
-import { Stream, Trace } from '@microsoft/dev-tunnels-ssh';
-import { CancellationToken } from 'vscode-jsonrpc';
+import { Stream, Trace, CancellationToken } from '@microsoft/dev-tunnels-ssh';
 import { RetryingTunnelConnectionEventArgs } from './retryingTunnelConnectionEventArgs';
+import { TunnelConnectionOptions } from './tunnelConnectionOptions';
 import * as http from 'http';
+
 /**
  * Tunnel session.
  */
@@ -58,13 +59,18 @@ export interface TunnelSession {
      *     Undefined if the connection information is already known and the tunnel is not needed.
      *     Tunnel object to get the connection information from that tunnel.
      */
-    connectTunnelSession(tunnel?: Tunnel, httpAgent?: http.Agent): Promise<void>;
+    connectTunnelSession(
+        tunnel?: Tunnel,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
+    ): Promise<void>;
 
     /**
      * Creates a stream to the tunnel for the tunnel session.
      */
     createSessionStream(
-        cancellation: CancellationToken,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
     ): Promise<{ stream: Stream, protocol: string }>;
 
     /**
@@ -74,7 +80,7 @@ export interface TunnelSession {
         stream: Stream,
         protocol: string,
         isReconnect: boolean,
-        cancellation: CancellationToken,
+        cancellation?: CancellationToken,
     ): Promise<void>;
 
     /**
@@ -85,5 +91,5 @@ export interface TunnelSession {
     /**
      * Refreshes the tunnel access token. This may be useful when the tunnel service responds with 401 Unauthorized.
      */
-    refreshTunnelAccessToken(cancellation: CancellationToken): Promise<boolean>;
+    refreshTunnelAccessToken(cancellation?: CancellationToken): Promise<boolean>;
 }

--- a/ts/test/tunnels-test/connectTests.ts
+++ b/ts/test/tunnels-test/connectTests.ts
@@ -12,6 +12,7 @@ import { Tunnel, TunnelPort, TunnelConnectionMode } from '@microsoft/dev-tunnels
 import { TunnelManagementClient } from '@microsoft/dev-tunnels-management';
 import { TunnelClient, TunnelConnectionBase, TunnelHost } from '@microsoft/dev-tunnels-connections';
 import { CancellationToken, SshStream } from '@microsoft/dev-tunnels-ssh';
+import { TunnelConnectionOptions } from 'src/connections/tunnelConnectionOptions';
 
 @suite
 @slow(3000)
@@ -78,7 +79,11 @@ class MockTunnelClient extends TunnelConnectionBase implements TunnelClient {
     public connectionModes: TunnelConnectionMode[] = [];
     public acceptLocalConnectionsForForwardedPorts = true;
     public localForwardingHostAddress = '127.0.0.1';
-    connect(tunnel: Tunnel, hostId?: string): Promise<any> {
+    connect(
+        tunnel: Tunnel,
+        options?: TunnelConnectionOptions,
+        cancellation?: CancellationToken,
+    ): Promise<any> {
         throw new Error('Method not implemented.');
     }
     forwardPort(tunnelPort: TunnelPort): Promise<LocalPortForwarder> {


### PR DESCRIPTION
 - Introduce `TunnelConnectionOptions` as an optional parameter to the client and host `Connect` API.
   - It allows the application to specify retry and reconnect behavior, and will make it easier to add more connection options in the future without breaking changes.
 - Rename host's `Start` to `Connect` for consistency.
   - `Start` is still available for now, but marked as obsolete/deprecated.
 - Fix and test issues related to retry and cancellation of both C# and TS connections.
   - Add missing cancellation token parameter to TS `connect`.
   - Ensure the correct exception type is thrown if the token is cancelled or the client/host is disposed during the connection or retries.
   - Ensure the client or host instance can be re-used after a failed or cancelled connection attempt.

Above changes apply only to C# and TS code. Other language SDKs may be improved later based on feedback.