### PR TITLE
Insert NuGet SSH v3.11.28

### DIFF
--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -48,7 +48,7 @@
     <ReportGeneratorVersion>4.8.13</ReportGeneratorVersion>
     <SystemTextEncodingsWebPackageVersion>4.7.2</SystemTextEncodingsWebPackageVersion>
     <VisualStudioValidationVersion>15.5.31</VisualStudioValidationVersion>
-    <DevTunnelsSshPackageVersion>3.11.26</DevTunnelsSshPackageVersion>
+    <DevTunnelsSshPackageVersion>3.11.28</DevTunnelsSshPackageVersion>
     <XunitRunnerVisualStudioVersion>2.4.0</XunitRunnerVisualStudioVersion>
     <XunitVersion>2.4.0</XunitVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/microsoft/basis-planning/issues/733

### Changes proposed: 
- Insert NuGet SSH v3.11.28 that has two fixes for memory leaks in SSH API objects.
