### PR TITLE
Add extensions needed for ControlPlanManagementClient in relay

### DIFF
--- a/cs/src/Management/TunnelExtensions.cs
+++ b/cs/src/Management/TunnelExtensions.cs
@@ -73,6 +73,64 @@ public static class TunnelExtensions
     }
 
     /// <summary>
+    /// Try to get an access token from <paramref name="tunnel"/> for <paramref name="accessTokenScope"/>.
+    /// </summary>
+    /// <remarks>
+    /// The tokens are searched in <c>Tunnel.AccessTokens</c> dictionary where each
+    /// key may be either a single scope or space-delimited list of scopes.
+    /// </remarks>
+    /// <param name="tunnel">The tunnel to get the access token from.</param>
+    /// <param name="accessTokenScope">Access token scope to get the token for.</param>
+    /// <param name="accessToken">If non-null and non-empty token is found, the token value. <c>null</c> if not found.</param>
+    /// <returns>
+    /// <c>true</c> if <paramref name="tunnel"/> has non-null and non-empty an access token for <paramref name="accessTokenScope"/>;
+    /// <c>false</c> if <paramref name="tunnel"/> has no access token for <paramref name="accessTokenScope"/> or the token is null or empty.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="tunnel"/> or <paramref name="accessTokenScope"/> is null.</exception>
+    /// <exception cref="ArgumentException">If <paramref name="accessTokenScope"/> is empty.</exception>
+    public static bool TryGetAccessTokenV2(this TunnelV2 tunnel, string accessTokenScope, [NotNullWhen(true)] out string? accessToken)
+    {
+        Requires.NotNull(tunnel, nameof(tunnel));
+        Requires.NotNullOrEmpty(accessTokenScope, nameof(accessTokenScope));
+
+        if (tunnel.AccessTokens?.Count > 0)
+        {
+            var scope = accessTokenScope.AsSpan();
+            foreach (var (key, value) in tunnel.AccessTokens)
+            {
+                // Each key may be either a single scope or space-delimited list of scopes.
+                var index = 0;
+                while (index < key?.Length)
+                {
+                    var spaceIndex = key.IndexOf(' ', index);
+                    if (spaceIndex == -1)
+                    {
+                        spaceIndex = key.Length;
+                    }
+
+                    if (spaceIndex - index == scope.Length &&
+                        key.AsSpan(index, scope.Length).SequenceEqual(scope))
+                    {
+                        if (string.IsNullOrEmpty(value))
+                        {
+                            accessToken = null;
+                            return false;
+                        }
+
+                        accessToken = value;
+                        return true;
+                    }
+
+                    index = spaceIndex + 1;
+                }
+            }
+        }
+
+        accessToken = null;
+        return false;
+    }
+
+    /// <summary>
     /// Try to get a valid access token from <paramref name="tunnel"/> for <paramref name="accessTokenScope"/>.
     /// If the token is found and looks like JWT, it's validated for expiration.
     /// </summary>
@@ -98,6 +156,41 @@ public static class TunnelExtensions
 
         accessToken = null;
         if (tunnel.TryGetAccessToken(accessTokenScope, out var result))
+        {
+            TunnelAccessTokenProperties.ValidateTokenExpiration(result);
+            accessToken = result;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Try to get a valid access token from <paramref name="tunnel"/> for <paramref name="accessTokenScope"/>.
+    /// If the token is found and looks like JWT, it's validated for expiration.
+    /// </summary>
+    /// <remarks>
+    /// The tokens are searched in <c>Tunnel.AccessTokens</c> dictionary where each
+    /// key may be either a single scope or space-delimited list of scopes.
+    /// The method only validates token expiration. It doesn't validate if the token is not JWT. It doesn't validate JWT signature or claims.
+    /// </remarks>
+    /// <param name="tunnel">The tunnel to get the access token from.</param>
+    /// <param name="accessTokenScope">Access token scope to get the token for.</param>
+    /// <param name="accessToken">If the token is found and it's valid, the token value. <c>null</c> if not found.</param>
+    /// <returns>
+    /// <c>true</c> if <paramref name="tunnel"/> has a valid token for <paramref name="accessTokenScope"/>;
+    /// <c>false</c> if <paramref name="tunnel"/> has no access token for <paramref name="accessTokenScope"/> or the token is null or empty.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">If <paramref name="tunnel"/> or <paramref name="accessTokenScope"/> is null.</exception>
+    /// <exception cref="ArgumentException">If <paramref name="accessTokenScope"/> is empty.</exception>
+    /// <exception cref="UnauthorizedAccessException">If the token for <paramref name="accessTokenScope"/> is expired.</exception>
+    public static bool TryGetValidAccessTokenV2(this TunnelV2 tunnel, string accessTokenScope, [NotNullWhen(true)] out string? accessToken)
+    {
+        Requires.NotNull(tunnel, nameof(tunnel));
+        Requires.NotNullOrEmpty(accessTokenScope, nameof(accessTokenScope));
+
+        accessToken = null;
+        if (tunnel.TryGetAccessTokenV2(accessTokenScope, out var result))
         {
             TunnelAccessTokenProperties.ValidateTokenExpiration(result);
             accessToken = result;

--- a/cs/src/Management/TunnelExtensions.cs
+++ b/cs/src/Management/TunnelExtensions.cs
@@ -88,7 +88,7 @@ public static class TunnelExtensions
     /// </returns>
     /// <exception cref="ArgumentNullException">If <paramref name="tunnel"/> or <paramref name="accessTokenScope"/> is null.</exception>
     /// <exception cref="ArgumentException">If <paramref name="accessTokenScope"/> is empty.</exception>
-    public static bool TryGetAccessTokenV2(this TunnelV2 tunnel, string accessTokenScope, [NotNullWhen(true)] out string? accessToken)
+    public static bool TryGetAccessToken(this TunnelV2 tunnel, string accessTokenScope, [NotNullWhen(true)] out string? accessToken)
     {
         Requires.NotNull(tunnel, nameof(tunnel));
         Requires.NotNullOrEmpty(accessTokenScope, nameof(accessTokenScope));
@@ -184,13 +184,13 @@ public static class TunnelExtensions
     /// <exception cref="ArgumentNullException">If <paramref name="tunnel"/> or <paramref name="accessTokenScope"/> is null.</exception>
     /// <exception cref="ArgumentException">If <paramref name="accessTokenScope"/> is empty.</exception>
     /// <exception cref="UnauthorizedAccessException">If the token for <paramref name="accessTokenScope"/> is expired.</exception>
-    public static bool TryGetValidAccessTokenV2(this TunnelV2 tunnel, string accessTokenScope, [NotNullWhen(true)] out string? accessToken)
+    public static bool TryGetValidAccessToken(this TunnelV2 tunnel, string accessTokenScope, [NotNullWhen(true)] out string? accessToken)
     {
         Requires.NotNull(tunnel, nameof(tunnel));
         Requires.NotNullOrEmpty(accessTokenScope, nameof(accessTokenScope));
 
         accessToken = null;
-        if (tunnel.TryGetAccessTokenV2(accessTokenScope, out var result))
+        if (tunnel.TryGetAccessToken(accessTokenScope, out var result))
         {
             TunnelAccessTokenProperties.ValidateTokenExpiration(result);
             accessToken = result;

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -408,7 +408,7 @@ namespace Microsoft.DevTunnels.Management
         ///   - token in <paramref name="tunnel"/> <see cref="Tunnel.AccessTokens"/> that matches
         ///     one of the scopes in <paramref name="accessTokenScopes"/>
         /// </remarks>
-        protected async Task<TResult?> SendTunnelV2RequestAsync<TRequest, TResult>(
+        protected async Task<TResult?> SendTunnelRequestAsync<TRequest, TResult>(
             HttpMethod method,
             TunnelV2 tunnel,
             string[] accessTokenScopes,
@@ -419,8 +419,8 @@ namespace Microsoft.DevTunnels.Management
             CancellationToken cancellation)
             where TRequest : class
         {
-            var uri = BuildTunnelV2Uri(tunnel, path, query, options);
-            var authHeader = await GetV2AuthenticationHeaderAsync(tunnel, accessTokenScopes, options);
+            var uri = BuildTunnelUri(tunnel, path, query, options);
+            var authHeader = await GetAuthenticationHeaderAsync(tunnel, accessTokenScopes, options);
             return await SendRequestAsync<TRequest, TResult>(
                 method, uri, options, authHeader, body, cancellation);
         }
@@ -507,8 +507,9 @@ namespace Microsoft.DevTunnels.Management
             where TRequest : class
         {
             var uri = BuildUri(clusterId, path, query, options);
+            Tunnel? tunnel = null;
             var authHeader = await GetAuthenticationHeaderAsync(
-                tunnel: null, accessTokenScopes: null, options);
+                tunnel: tunnel, accessTokenScopes: null, options);
             return await SendRequestAsync<TRequest, TResult>(
                 method, uri, options, authHeader, body, cancellation);
         }
@@ -839,7 +840,7 @@ namespace Microsoft.DevTunnels.Management
                 options);
         }
 
-        private Uri BuildTunnelV2Uri(
+        private Uri BuildTunnelUri(
             TunnelV2 tunnel,
             string? path,
             string? query,
@@ -914,7 +915,7 @@ namespace Microsoft.DevTunnels.Management
             return authHeader;
         }
 
-        private async Task<AuthenticationHeaderValue?> GetV2AuthenticationHeaderAsync(
+        private async Task<AuthenticationHeaderValue?> GetAuthenticationHeaderAsync(
             TunnelV2? tunnel,
             string[]? accessTokenScopes,
             TunnelRequestOptions? options)
@@ -937,7 +938,7 @@ namespace Microsoft.DevTunnels.Management
             {
                 foreach (var scope in accessTokenScopes)
                 {
-                    if (tunnel.TryGetValidAccessTokenV2(scope, out string? accessToken))
+                    if (tunnel.TryGetValidAccessToken(scope, out string? accessToken))
                     {
                         authHeader = new AuthenticationHeaderValue(
                             TunnelAuthenticationScheme, accessToken);


### PR DESCRIPTION
Since the Relay needs to make calls to the service we need to support some tunnelV2 calls in the SDK for now. These will be deleted when the SDKS moves fully to TunnelV2