### PR TITLE
Fix connecting to local TCP port in Go SDK

### DIFF
--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.17"
+const PackageVersion = "0.0.18"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{


### PR DESCRIPTION
### Changes proposed: 
Uses the TCP listener passed into the `ConnectToForwardedPort` function to actually connect to the port via a local TCP port. This is the same logic that is used by the [GH CLI](https://github.com/cli/cli/blob/c5f88bb551e22b04a3799561f3abea4892012eff/pkg/liveshare/port_forwarder.go#L78C27-L78C44) which is what much of this connection code seems to be based on.

cc. @jfullerton44

### Other Tasks:
- [X] If you updated the Go SDK did you update the PackageVersion in tunnels.go
