### PR TITLE
Add custom expiration to ts , java, and go tunnel sdk creation

### DIFF
--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.21"
+const PackageVersion = "0.0.22"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -20,6 +20,7 @@ func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 		Tags:        tunnel.Tags,
 		Options:     tunnel.Options,
 		Endpoints:   tunnel.Endpoints,
+		CustomExpiration: tunnel.CustomExpiration,
 	}
 	if tunnel.AccessControl != nil {
 		var newEntries []TunnelAccessControlEntry

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -385,6 +385,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
     converted.tags = tunnel.tags;
     converted.options = tunnel.options;
     converted.accessControl = tunnel.accessControl;
+    converted.customExpiration = tunnel.customExpiration;
     converted.endpoints = tunnel.endpoints;
     if (tunnel.accessControl != null && tunnel.accessControl.entries != null) {
       List<TunnelAccessControlEntry> entries = Arrays.asList(tunnel.accessControl.entries);

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -740,6 +740,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             description: tunnel.description,
             tags: tunnel.tags,
             options: tunnel.options,
+            customExpiration: tunnel.customExpiration,
             accessControl: !tunnel.accessControl
                 ? undefined
                 : { entries: tunnel.accessControl.entries.filter((ace) => !ace.isInherited) },


### PR DESCRIPTION
### Changes proposed: 
- For the custom expiration feature, you can set the custom expiration via the SDK for cs. This PR lets you set the expiration via ts, java, and go SDK

### Other Tasks:
- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
