### PR TITLE
Allow endpoint id to be nullable

### DIFF
--- a/cs/src/Contracts/TunnelEndpoint.cs
+++ b/cs/src/Contracts/TunnelEndpoint.cs
@@ -28,7 +28,8 @@ public abstract class TunnelEndpoint
     /// <summary>
     /// Gets or sets the ID of this endpoint.
     /// </summary>
-    public string Id { get; set; } = null!;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Id { get; set; }
 
     /// <summary>
     /// Gets or sets the connection mode of the endpoint.

--- a/go/tunnels/tunnel_endpoint.go
+++ b/go/tunnels/tunnel_endpoint.go
@@ -13,7 +13,7 @@ package tunnels
 // environment or client capabilities.
 type TunnelEndpoint struct {
 	// Gets or sets the ID of this endpoint.
-	ID                   string `json:"id"`
+	ID                   string `json:"id,omitempty"`
 
 	// Gets or sets the connection mode of the endpoint.
 	//

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,16 +10,16 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.22"
+const PackageVersion = "0.0.23"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{
-		Name:        tunnel.Name,
-		Domain:      tunnel.Domain,
-		Description: tunnel.Description,
-		Tags:        tunnel.Tags,
-		Options:     tunnel.Options,
-		Endpoints:   tunnel.Endpoints,
+		Name:             tunnel.Name,
+		Domain:           tunnel.Domain,
+		Description:      tunnel.Description,
+		Tags:             tunnel.Tags,
+		Options:          tunnel.Options,
+		Endpoints:        tunnel.Endpoints,
 		CustomExpiration: tunnel.CustomExpiration,
 	}
 	if tunnel.AccessControl != nil {

--- a/rs/src/contracts/tunnel_endpoint.rs
+++ b/rs/src/contracts/tunnel_endpoint.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]
 pub struct TunnelEndpoint {
     // Gets or sets the ID of this endpoint.
-    pub id: String,
+    pub id: Option<String>,
 
     // Gets or sets the connection mode of the endpoint.
     //

--- a/ts/src/contracts/tunnelEndpoint.ts
+++ b/ts/src/contracts/tunnelEndpoint.ts
@@ -18,7 +18,7 @@ export interface TunnelEndpoint {
     /**
      * Gets or sets the ID of this endpoint.
      */
-    id: string;
+    id?: string;
 
     /**
      * Gets or sets the connection mode of the endpoint.


### PR DESCRIPTION
Fixes #

### Changes proposed: 
- This allows the endpoint id to be nullable to continue to support older api-versions
-
-

### Other Tasks:
- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
