### PR TITLE
Allow direct port connection in Go SDK

### DIFF
--- a/go/tunnels/client_test.go
+++ b/go/tunnels/client_test.go
@@ -237,7 +237,22 @@ func TestPortForwarding(t *testing.T) {
 			done <- fmt.Errorf("wait for forwarded port failed: %v", err)
 			return
 		}
-		err = c.ConnectToForwardedPort(ctx, listen, streamPort)
+
+		// Test connecting with a listener
+		err = c.ConnectListenerToForwardedPort(ctx, listen, streamPort)
+		if err != nil {
+			done <- fmt.Errorf("connect to forwarded port failed: %v", err)
+			return
+		}
+
+		// Connect to the listener and and test connecting with the given connection
+		conn, err := listen.Accept()
+		if err != nil {
+			done <- fmt.Errorf("accept connection failed: %v", err)
+			return
+		}
+
+		err = c.ConnectToForwardedPort(ctx, conn, streamPort)
 		if err != nil {
 			done <- fmt.Errorf("connect to forwarded port failed: %v", err)
 			return

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.24"
+const PackageVersion = "0.0.25"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{


### PR DESCRIPTION
The main goal of this PR is to unblock the `gh cs ssh --stdio` command in the GitHub CLI. This command redirects stdin/stdout to the stream rather than opening up a local TCP port which was previously supported in Live Share but was not implemented when the Dev Tunnels Go SDK was created. This is done by updating the `ConnectToForwardedPort` to allow for direct connection to an `io.ReadWriteCloser` when connecting to a forwarded port. The previous functionality to pass in a local port listener was migrated to `ConnectListenerToForwardedPort`.

### Changes proposed: 
- Update `ConnectToForwardedPort` to accept an `io.ReadWriteCloser`
- Create `ConnectListenerToForwarded` that accepts a `net.Listener`
- Update tests

### Other Tasks:
- [X] If you updated the Go SDK did you update the PackageVersion in tunnels.go
