### PR TITLE
Access Control Entry Expiration

### DIFF
--- a/cs/src/Contracts/TunnelAccessControlEntry.cs
+++ b/cs/src/Contracts/TunnelAccessControlEntry.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Text;
@@ -157,15 +156,6 @@ public class TunnelAccessControlEntry
     [MaxLength(AccessControlMaxScopes)]
     [ArrayStringLength(TunnelAccessScopes.MaxLength)]
     public string[] Scopes { get; set; }
-
-    /// <summary>
-    /// Gets or sets the expiration for an access control.
-    /// </summary>
-    /// <remarks>
-    /// If no value is set then this value is null.
-    /// </remarks>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-     public DateTime? Expiration { get; set; } 
 
     /// <summary>
     /// Gets a compact textual representation of the access control entry.

--- a/cs/src/Contracts/TunnelAccessControlEntry.cs
+++ b/cs/src/Contracts/TunnelAccessControlEntry.cs
@@ -158,6 +158,15 @@ public class TunnelAccessControlEntry
     public string[] Scopes { get; set; }
 
     /// <summary>
+    /// Gets or sets the expiration for an access control entry.
+    /// </summary>
+    /// <remarks>
+    /// If no value is set then this value is null.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? Expiration { get; set; }
+
+    /// <summary>
     /// Gets a compact textual representation of the access control entry.
     /// </summary>
     public override string ToString()

--- a/cs/src/Contracts/TunnelAccessControlEntry.cs
+++ b/cs/src/Contracts/TunnelAccessControlEntry.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Text;
@@ -156,6 +157,15 @@ public class TunnelAccessControlEntry
     [MaxLength(AccessControlMaxScopes)]
     [ArrayStringLength(TunnelAccessScopes.MaxLength)]
     public string[] Scopes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the expiration for an access control.
+    /// </summary>
+    /// <remarks>
+    /// If no value is set then this value is null.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+     public DateTime? Expiration { get; set; } 
 
     /// <summary>
     /// Gets a compact textual representation of the access control entry.

--- a/go/tunnels/tunnel_access_control_entry.go
+++ b/go/tunnels/tunnel_access_control_entry.go
@@ -4,6 +4,10 @@
 
 package tunnels
 
+import (
+	"time"
+)
+
 // Data contract for an access control entry on a `Tunnel` or `TunnelPort`.
 //
 // An access control entry (ACE) grants or denies one or more access scopes to one or more
@@ -68,6 +72,11 @@ type TunnelAccessControlEntry struct {
 	//
 	// These must be one or more values from `TunnelAccessScopes`.
 	Scopes       []string `json:"scopes"`
+
+	// Gets or sets the expiration for an access control.
+	//
+	// If no value is set then this value is null.
+	Expiration   *time.Time `json:"expiration,omitempty"`
 }
 
 // Constants for well-known identity providers.

--- a/go/tunnels/tunnel_access_control_entry.go
+++ b/go/tunnels/tunnel_access_control_entry.go
@@ -4,6 +4,10 @@
 
 package tunnels
 
+import (
+	"time"
+)
+
 // Data contract for an access control entry on a `Tunnel` or `TunnelPort`.
 //
 // An access control entry (ACE) grants or denies one or more access scopes to one or more
@@ -68,6 +72,11 @@ type TunnelAccessControlEntry struct {
 	//
 	// These must be one or more values from `TunnelAccessScopes`.
 	Scopes       []string `json:"scopes"`
+
+	// Gets or sets the expiration for an access control entry.
+	//
+	// If no value is set then this value is null.
+	Expiration   *time.Time `json:"expiration,omitempty"`
 }
 
 // Constants for well-known identity providers.

--- a/go/tunnels/tunnel_access_control_entry.go
+++ b/go/tunnels/tunnel_access_control_entry.go
@@ -4,10 +4,6 @@
 
 package tunnels
 
-import (
-	"time"
-)
-
 // Data contract for an access control entry on a `Tunnel` or `TunnelPort`.
 //
 // An access control entry (ACE) grants or denies one or more access scopes to one or more
@@ -72,11 +68,6 @@ type TunnelAccessControlEntry struct {
 	//
 	// These must be one or more values from `TunnelAccessScopes`.
 	Scopes       []string `json:"scopes"`
-
-	// Gets or sets the expiration for an access control.
-	//
-	// If no value is set then this value is null.
-	Expiration   *time.Time `json:"expiration,omitempty"`
 }
 
 // Constants for well-known identity providers.

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.0.24"
+const PackageVersion = "0.0.25"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlEntry.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlEntry.java
@@ -5,7 +5,6 @@
 package com.microsoft.tunnels.contracts;
 
 import com.google.gson.annotations.Expose;
-import java.util.Date;
 
 /**
  * Data contract for an access control entry on a {@link Tunnel} or {@link TunnelPort}.
@@ -99,14 +98,6 @@ public class TunnelAccessControlEntry {
      */
     @Expose
     public String[] scopes;
-
-    /**
-     * Gets or sets the expiration for an access control.
-     *
-     * If no value is set then this value is null.
-     */
-    @Expose
-    public Date expiration;
 
     /**
      * Constants for well-known identity providers.

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlEntry.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlEntry.java
@@ -5,6 +5,7 @@
 package com.microsoft.tunnels.contracts;
 
 import com.google.gson.annotations.Expose;
+import java.util.Date;
 
 /**
  * Data contract for an access control entry on a {@link Tunnel} or {@link TunnelPort}.
@@ -98,6 +99,14 @@ public class TunnelAccessControlEntry {
      */
     @Expose
     public String[] scopes;
+
+    /**
+     * Gets or sets the expiration for an access control.
+     *
+     * If no value is set then this value is null.
+     */
+    @Expose
+    public Date expiration;
 
     /**
      * Constants for well-known identity providers.

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlEntry.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelAccessControlEntry.java
@@ -5,6 +5,7 @@
 package com.microsoft.tunnels.contracts;
 
 import com.google.gson.annotations.Expose;
+import java.util.Date;
 
 /**
  * Data contract for an access control entry on a {@link Tunnel} or {@link TunnelPort}.
@@ -98,6 +99,14 @@ public class TunnelAccessControlEntry {
      */
     @Expose
     public String[] scopes;
+
+    /**
+     * Gets or sets the expiration for an access control entry.
+     *
+     * If no value is set then this value is null.
+     */
+    @Expose
+    public Date expiration;
 
     /**
      * Constants for well-known identity providers.

--- a/rs/src/contracts/tunnel_access_control_entry.rs
+++ b/rs/src/contracts/tunnel_access_control_entry.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/TunnelAccessControlEntry.cs
 
-use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControlEntryType;
 use serde::{Deserialize, Serialize};
 
@@ -78,11 +77,6 @@ pub struct TunnelAccessControlEntry {
     //
     // These must be one or more values from `TunnelAccessScopes`.
     pub scopes: Vec<String>,
-
-    // Gets or sets the expiration for an access control.
-    //
-    // If no value is set then this value is null.
-    pub expiration: Option<DateTime<Utc>>,
 }
 
 // Constants for well-known identity providers.

--- a/rs/src/contracts/tunnel_access_control_entry.rs
+++ b/rs/src/contracts/tunnel_access_control_entry.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/TunnelAccessControlEntry.cs
 
+use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControlEntryType;
 use serde::{Deserialize, Serialize};
 
@@ -77,6 +78,11 @@ pub struct TunnelAccessControlEntry {
     //
     // These must be one or more values from `TunnelAccessScopes`.
     pub scopes: Vec<String>,
+
+    // Gets or sets the expiration for an access control entry.
+    //
+    // If no value is set then this value is null.
+    pub expiration: Option<DateTime<Utc>>,
 }
 
 // Constants for well-known identity providers.

--- a/rs/src/contracts/tunnel_access_control_entry.rs
+++ b/rs/src/contracts/tunnel_access_control_entry.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/TunnelAccessControlEntry.cs
 
+use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControlEntryType;
 use serde::{Deserialize, Serialize};
 
@@ -77,6 +78,11 @@ pub struct TunnelAccessControlEntry {
     //
     // These must be one or more values from `TunnelAccessScopes`.
     pub scopes: Vec<String>,
+
+    // Gets or sets the expiration for an access control.
+    //
+    // If no value is set then this value is null.
+    pub expiration: Option<DateTime<Utc>>,
 }
 
 // Constants for well-known identity providers.

--- a/ts/src/contracts/tunnelAccessControlEntry.ts
+++ b/ts/src/contracts/tunnelAccessControlEntry.ts
@@ -89,6 +89,13 @@ export interface TunnelAccessControlEntry {
      * These must be one or more values from {@link TunnelAccessScopes}.
      */
     scopes: string[];
+
+    /**
+     * Gets or sets the expiration for an access control entry.
+     *
+     * If no value is set then this value is null.
+     */
+    expiration?: Date;
 }
 
 namespace TunnelAccessControlEntry {

--- a/ts/src/contracts/tunnelAccessControlEntry.ts
+++ b/ts/src/contracts/tunnelAccessControlEntry.ts
@@ -89,13 +89,6 @@ export interface TunnelAccessControlEntry {
      * These must be one or more values from {@link TunnelAccessScopes}.
      */
     scopes: string[];
-
-    /**
-     * Gets or sets the expiration for an access control.
-     *
-     * If no value is set then this value is null.
-     */
-    expiration?: Date;
 }
 
 namespace TunnelAccessControlEntry {

--- a/ts/src/contracts/tunnelAccessControlEntry.ts
+++ b/ts/src/contracts/tunnelAccessControlEntry.ts
@@ -89,6 +89,13 @@ export interface TunnelAccessControlEntry {
      * These must be one or more values from {@link TunnelAccessScopes}.
      */
     scopes: string[];
+
+    /**
+     * Gets or sets the expiration for an access control.
+     *
+     * If no value is set then this value is null.
+     */
+    expiration?: Date;
 }
 
 namespace TunnelAccessControlEntry {


### PR DESCRIPTION
Fixes #

### Changes proposed: 
- These are the SDK changes needed to add expiration dates to access control entries. This change can be used in the different SDKs by adding the `expiration` property to their `TunnelAccessControlEntry` objects

### Other Tasks:
- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
