### PR TITLE
Add forceCreate and forceUpdate query params

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -933,7 +933,7 @@ namespace Microsoft.DevTunnels.Management
                        tunnel,
                        ManageAccessTokenScope,
                        path: null,
-                       query: GetApiQuery(),
+                       query: GetApiQuery() + "&forceCreate=true",
                        options,
                        ConvertTunnelForRequest(tunnel),
                        cancellation,
@@ -973,7 +973,7 @@ namespace Microsoft.DevTunnels.Management
                 tunnel,
                 ManageAccessTokenScope,
                 path: null,
-                query: GetApiQuery(),
+                query: GetApiQuery() + "&forceUpdate=true",
                 options,
                 ConvertTunnelForRequest(tunnel),
                 cancellation);
@@ -1117,7 +1117,7 @@ namespace Microsoft.DevTunnels.Management
                 tunnel,
                 ManagePortsAccessTokenScopes,
                 path,
-                query: GetApiQuery(),
+                query: GetApiQuery() + "&forceCreate=true",
                 options,
                 ConvertTunnelPortForRequest(tunnel, tunnelPort),
                 cancellation))!;
@@ -1159,7 +1159,7 @@ namespace Microsoft.DevTunnels.Management
                 tunnel,
                 ManagePortsAccessTokenScopes,
                 path,
-                query: GetApiQuery(),
+                query: GetApiQuery() + "&forceUpdate=true",
                 options,
                 ConvertTunnelPortForRequest(tunnel, tunnelPort),
                 cancellation))!;

--- a/go/tunnels/manager.go
+++ b/go/tunnels/manager.go
@@ -183,7 +183,7 @@ func (m *Manager) CreateTunnel(ctx context.Context, tunnel *Tunnel, options *Tun
 	if tunnel.TunnelID == "" {
 		tunnel.TunnelID = generateTunnelId()
 	}
-	url, err := m.buildTunnelSpecificUri(tunnel, "", options, "", true)
+	url, err := m.buildTunnelSpecificUri(tunnel, "", options, "forceCreate=true", true)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request url: %w", err)
 	}
@@ -221,7 +221,7 @@ func (m *Manager) UpdateTunnel(ctx context.Context, tunnel *Tunnel, updateFields
 		return nil, fmt.Errorf("tunnel must be provided")
 	}
 
-	url, err := m.buildTunnelSpecificUri(tunnel, "", options, "", false)
+	url, err := m.buildTunnelSpecificUri(tunnel, "", options, "forceUpdate=true", false)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request url: %w", err)
 	}
@@ -384,7 +384,7 @@ func (m *Manager) CreateTunnelPort(
 	ctx context.Context, tunnel *Tunnel, port *TunnelPort, options *TunnelRequestOptions,
 ) (tp *TunnelPort, err error) {
 	path := fmt.Sprintf("%s/%d", portsApiSubPath, port.PortNumber)
-	url, err := m.buildTunnelSpecificUri(tunnel, path, options, "", false)
+	url, err := m.buildTunnelSpecificUri(tunnel, path, options, "forceCreate=true", false)
 	if err != nil {
 		return nil, fmt.Errorf("error creating tunnel url: %w", err)
 	}
@@ -427,7 +427,7 @@ func (m *Manager) UpdateTunnelPort(
 		return nil, fmt.Errorf("cluster ids do not match")
 	}
 	path := fmt.Sprintf("%s/%d", portsApiSubPath, port.PortNumber)
-	url, err := m.buildTunnelSpecificUri(tunnel, path, options, "", false)
+	url, err := m.buildTunnelSpecificUri(tunnel, path, options, "forceUpdate=true", false)
 	if err != nil {
 		return nil, fmt.Errorf("error creating tunnel url: %w", err)
 	}

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.1.1"
+const PackageVersion = "0.1.2"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -378,7 +378,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
     if (generatedId) {
       tunnel.tunnelId = IdGeneration.generateTunnelId();
     }
-    var uri = buildUri(tunnel, options, true);
+    var uri = buildUri(tunnel, options,null, "forceCreate=true", true);
     final Type responseType = new TypeToken<Tunnel>() {
     }.getType();
     for (int i = 0; i <= 3; i++){
@@ -444,7 +444,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
 
   @Override
   public CompletableFuture<Tunnel> updateTunnelAsync(Tunnel tunnel, TunnelRequestOptions options) {
-    var uri = buildUri(tunnel, options, true);
+    var uri = buildUri(tunnel, options,null, "forceUpdate=true", true);
     final Type responseType = new TypeToken<Tunnel>() {
     }.getType();
     return requestAsync(
@@ -607,7 +607,9 @@ public class TunnelManagementClient implements ITunnelManagementClient {
     var uri = buildUri(
         tunnel,
         options,
-        path);
+        path,
+        "forceCreate=true",
+        false);
     final Type responseType = new TypeToken<TunnelPort>() {
     }.getType();
     CompletableFuture<TunnelPort> result = requestAsync(
@@ -689,7 +691,9 @@ public class TunnelManagementClient implements ITunnelManagementClient {
     var uri = buildUri(
         tunnel,
         options,
-        path);
+        path,
+        "forceUpdate=true",
+        false);
 
     final Type responseType = new TypeToken<TunnelPort>() {
     }.getType();

--- a/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
+++ b/java/src/main/java/com/microsoft/tunnels/management/TunnelManagementClient.java
@@ -378,7 +378,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
     if (generatedId) {
       tunnel.tunnelId = IdGeneration.generateTunnelId();
     }
-    var uri = buildUri(tunnel, options,null, "forceCreate=true", true);
+    var uri = buildUri(tunnel, options, null, "forceCreate=true", true);
     final Type responseType = new TypeToken<Tunnel>() {
     }.getType();
     for (int i = 0; i <= 3; i++){
@@ -444,7 +444,7 @@ public class TunnelManagementClient implements ITunnelManagementClient {
 
   @Override
   public CompletableFuture<Tunnel> updateTunnelAsync(Tunnel tunnel, TunnelRequestOptions options) {
-    var uri = buildUri(tunnel, options,null, "forceUpdate=true", true);
+    var uri = buildUri(tunnel, options, null, "forceUpdate=true", true);
     final Type responseType = new TypeToken<Tunnel>() {
     }.getType();
     return requestAsync(

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -258,7 +258,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
                     tunnel,
                     manageAccessTokenScope,
                     undefined,
-                    undefined,
+                    "forceCreate=true",
                     options,
                     this.convertTunnelForRequest(tunnel),
                     undefined,
@@ -298,7 +298,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             tunnel,
             manageAccessTokenScope,
             undefined,
-            undefined,
+            "forceUpdate=true",
             options,
             this.convertTunnelForRequest(tunnel),
         ))!;
@@ -439,7 +439,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             tunnel,
             managePortsAccessTokenScopes,
             path,
-            undefined,
+            "forceCreate=true",
             options,
             tunnelPort,
         ))!;
@@ -473,7 +473,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             tunnel,
             managePortsAccessTokenScopes,
             path,
-            undefined,
+            "forceUpdate=true",
             options,
             tunnelPort,
         ))!;

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -283,7 +283,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             tunnel,
             manageAccessTokenScope,
             undefined,
-            undefined,
+            "forceCreate=true",
             options,
             this.convertTunnelForRequest(tunnel),
         ))!;

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -286,6 +286,8 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             "forceCreate=true",
             options,
             this.convertTunnelForRequest(tunnel),
+            undefined,
+            true,
         ))!;
         preserveAccessTokens(tunnel, result2);
         parseTunnelDates(result2);


### PR DESCRIPTION
Fixes #

### Changes proposed: 
- Adds query params to force a tunnel update or tunnel create that will be added to the service in a different PR
- Fixes issue in typescript where last retry message would get a clusterId missing error
-

### Other Tasks:
- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
