### PR TITLE
Fix flaky ConnectRelayClientToHostAndReconnectHost test

### DIFF
--- a/cs/test/TunnelsSDK.Test/Extensions/TunnelConnectionExtensions.cs
+++ b/cs/test/TunnelsSDK.Test/Extensions/TunnelConnectionExtensions.cs
@@ -16,8 +16,11 @@ public static class TunnelConnectionExtensions
             var tcs = new TaskCompletionSource();
             void OnConnectionStatusChanged(object sender, ConnectionStatusChangedEventArgs e)
             {
-                assert?.Invoke(tunnelConnection);
-                tcs.TrySetResult();
+                if (e.Status == status)
+                {
+                    assert?.Invoke(tunnelConnection);
+                    tcs.TrySetResult();
+                }
             }
 
             tunnelConnection.ConnectionStatusChanged += OnConnectionStatusChanged;
@@ -25,6 +28,7 @@ public static class TunnelConnectionExtensions
             {
                 if (tunnelConnection.ConnectionStatus == status)
                 {
+                    assert?.Invoke(tunnelConnection);
                     break;
                 }
 

--- a/cs/test/TunnelsSDK.Test/Extensions/TunnelConnectionExtensions.cs
+++ b/cs/test/TunnelsSDK.Test/Extensions/TunnelConnectionExtensions.cs
@@ -4,16 +4,21 @@ namespace Microsoft.DevTunnels.Test;
 
 public static class TunnelConnectionExtensions
 {
-    public async static Task WaitForConnectionStatusAsync(
-        this TunnelConnection tunnelConnection,
+    public async static Task WaitForConnectionStatusAsync<T>(
+        this T tunnelConnection,
         ConnectionStatus status,
+        Action<T> assert = null,
         CancellationToken cancellationToken = default)
+        where T : TunnelConnection
     {
         while (tunnelConnection.ConnectionStatus != status)
         {
             var tcs = new TaskCompletionSource();
-            void OnConnectionStatusChanged(object sender, ConnectionStatusChangedEventArgs e) =>
+            void OnConnectionStatusChanged(object sender, ConnectionStatusChangedEventArgs e)
+            {
+                assert?.Invoke(tunnelConnection);
                 tcs.TrySetResult();
+            }
 
             tunnelConnection.ConnectionStatusChanged += OnConnectionStatusChanged;
             try


### PR DESCRIPTION
The issue was that the test was asynchronously waiting for `Connecting` connection status and then asserted disconnect exception while reconnection run in parallel and might have cleared up the disconnect exception.

The fix is to assert the disconnect exception in `ConnectionStatusChanged` event handler.
