### PR TITLE
rs: remove unused mut

### DIFF
--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -549,7 +549,7 @@ fn create_full_user_agent(user_agent: &str) -> String {
     let pkg_version = PKG_VERSION.unwrap_or("unknown");
     let os = os_info::get();
     let os_info = format!("{}: {} {}", "OS", os.os_type(), os.version());
-    let mut windows_partner_id: Option<String> = None;
+    let windows_partner_id: Option<String> = None;
     #[cfg(windows)]
     {
         use winreg::enums::*;


### PR DESCRIPTION
This just fixes an error I noticed when building:

```
➜  rs git:(main) cargo build
warning: variable does not need to be mutable
   --> src/management/http_client.rs:552:9
    |
552 |     let mut windows_partner_id: Option<String> = None;
    |         ----^^^^^^^^^^^^^^^^^^
    |         |
    |         help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: `tunnels` (lib) generated 1 warning (run `cargo fix --lib -p tunnels` to apply 1 suggestion)
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
```