### PR TITLE
Add policies property to tunnelservice request header on C#

### DIFF
--- a/cs/src/Management/DevTunnels.Management.csproj
+++ b/cs/src/Management/DevTunnels.Management.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Microsoft.DevTunnels.Management</AssemblyName>
@@ -10,6 +10,10 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Contracts\DevTunnels.Contracts.csproj" />

--- a/cs/src/Management/PolicyProvider.cs
+++ b/cs/src/Management/PolicyProvider.cs
@@ -1,4 +1,4 @@
-// <copyright file="RegistryTools.cs" company="Microsoft">
+// <copyright file="PolicyProvider.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>

--- a/cs/src/Management/RegistryTools.cs
+++ b/cs/src/Management/RegistryTools.cs
@@ -1,0 +1,79 @@
+// <copyright file="TunnelExtensions.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.DevTunnels.Contracts;
+using Microsoft.Win32;
+
+namespace Microsoft.DevTunnels.Management
+{
+    internal class RegistryTools
+    {
+        /// <summary>
+        /// Get registry key value from the HKLM root Registry.
+        /// </summary>
+        /// <param name="regKeyPath"></param>
+        /// <param name="defaultOnError"></param>
+        /// <returns></returns>
+        public object GetRegistryValueFromLocalMachineRoot(string regKeyPath, object? defaultOnError = null)
+        {
+            object regValue = "";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                RegistryKey rootKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
+                regValue = this.GetRegistryValue(rootKey, regKeyPath, defaultOnError);
+            }
+            return regValue;
+        }
+
+        /// <summary>
+        /// Get registry key settings int value.
+        /// </summary>
+        /// <param name="rootKey">Root key entry</param>
+        /// <param name="regKeyPath">Path to Key</param>
+        /// <param name="defaultOnError"></param>
+        /// <returns></returns>
+        private object GetRegistryValue(RegistryKey rootKey, string regKeyPath, object? defaultOnError = null)
+        {
+            StringBuilder headerBuilder = new StringBuilder();
+
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    if (rootKey != null)
+                    {
+                        using (RegistryKey? subKey = rootKey.OpenSubKey(regKeyPath, RegistryKeyPermissionCheck.ReadSubTree, System.Security.AccessControl.RegistryRights.QueryValues))
+                        {
+                            if (subKey != null)
+                            {
+                                foreach (string valueName in subKey.GetValueNames())
+                                {
+                                    object? value = subKey.GetValue(valueName);
+                                    string headerValue = value != null ? value.ToString()! : "Not Set";
+
+                                    headerBuilder.AppendFormat("{0}={1}; ", Uri.EscapeDataString(valueName), Uri.EscapeDataString(headerValue!));
+                                }
+                            }
+                        }
+
+                        if (headerBuilder.Length > 0)
+                        {
+                            headerBuilder.Length -= 2;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return headerBuilder.ToString();
+        }
+    }
+}

--- a/cs/src/Management/RegistryTools.cs
+++ b/cs/src/Management/RegistryTools.cs
@@ -76,11 +76,10 @@ namespace Microsoft.DevTunnels.Management
             {
                 foreach (string valueName in subKey.GetValueNames())
                 {
-                    var value = subKey.GetValue(valueName);
-                    if (value != null)
+                    var value = subKey.GetValue(valueName, "");
+                    if (value != null && !string.IsNullOrEmpty(value.ToString()))
                     {
                         string headerValue = value.ToString()!;
-
                         headerBuilder.AppendFormat("{0}={1}; ", Uri.EscapeDataString(valueName), Uri.EscapeDataString(headerValue!));
                     }
                 }

--- a/cs/src/Management/RegistryTools.cs
+++ b/cs/src/Management/RegistryTools.cs
@@ -1,4 +1,4 @@
-// <copyright file="TunnelExtensions.cs" company="Microsoft">
+// <copyright file="RegistryTools.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 // </copyright>
@@ -55,9 +55,12 @@ namespace Microsoft.DevTunnels.Management
                                 foreach (string valueName in subKey.GetValueNames())
                                 {
                                     object? value = subKey.GetValue(valueName);
-                                    string headerValue = value != null ? value.ToString()! : "Not Set";
+                                    if (value != null)
+                                    {
+                                        string headerValue = value.ToString()!;
 
-                                    headerBuilder.AppendFormat("{0}={1}; ", Uri.EscapeDataString(valueName), Uri.EscapeDataString(headerValue!));
+                                        headerBuilder.AppendFormat("{0}={1}; ", Uri.EscapeDataString(valueName), Uri.EscapeDataString(headerValue!));
+                                    }
                                 }
                             }
                         }

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -519,6 +519,15 @@ namespace Microsoft.DevTunnels.Management
 
             request.Headers.UserAgent.Add(TunnelSdkUserAgent);
 
+            const string regKeyPath = @"Software\Policies\Microsoft\Tunnels";
+            var defaultOnError = true;
+            RegistryTools policies = new RegistryTools();
+            var keyValue = (string)policies.GetRegistryValueFromLocalMachineRoot(regKeyPath, defaultOnError);
+            if (keyValue != null)
+            {
+                request.Headers.Add("Policies", keyValue);
+            }
+
             if (body != null)
             {
                 request.Content = JsonContent.Create(body, null, JsonOptions);

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -520,12 +520,12 @@ namespace Microsoft.DevTunnels.Management
             request.Headers.UserAgent.Add(TunnelSdkUserAgent);
 
             // Add Group Policies
-            const string policyRegKeyPath = @"Software\Policies\Microsoft\Tunnels";
+            const string policyRegKeyPath = @"Software\Policies\Microsoft\DevTunnels";
             var policyProvider = new PolicyProvider(policyRegKeyPath);
             var policyHeaderValue = policyProvider.GetHeaderValue();
             if (!string.IsNullOrEmpty(policyHeaderValue))
             {
-                request.Headers.Add("Policies", policyHeaderValue);
+                request.Headers.Add("User-Agent-Policies", policyHeaderValue);
             }
 
             if (body != null)

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -519,13 +519,13 @@ namespace Microsoft.DevTunnels.Management
 
             request.Headers.UserAgent.Add(TunnelSdkUserAgent);
 
-            const string regKeyPath = @"Software\Policies\Microsoft\Tunnels";
-            var defaultOnError = true;
-            RegistryTools policies = new RegistryTools();
-            var keyValue = (string)policies.GetRegistryValueFromLocalMachineRoot(regKeyPath, defaultOnError);
-            if (keyValue != null)
+            // Add Group Policies
+            const string policyRegKeyPath = @"Software\Policies\Microsoft\Tunnels";
+            var policyProvider = new PolicyProvider(policyRegKeyPath);
+            var policyHeaderValue = policyProvider.GetHeaderValue();
+            if (!string.IsNullOrEmpty(policyHeaderValue))
             {
-                request.Headers.Add("Policies", keyValue);
+                request.Headers.Add("Policies", policyHeaderValue);
             }
 
             if (body != null)


### PR DESCRIPTION
Fixes # https://github.com/orgs/microsoft/projects/115/views/18?pane=issue&itemId=43806545 

### Changes proposed: 
- Read policies from windows registry and add them to the request header. 
- Updated header:
![image](https://github.com/microsoft/dev-tunnels/assets/17537419/27129952-088c-4a78-a566-e1722ce208cd)

