### PR TITLE
Fix CG alert in gopkg.in/yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064
 )
 
-require golang.org/x/sys v0.1.0 // indirect
+require (
+	golang.org/x/sys v0.1.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -24,5 +24,6 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e h1:3i3ny04XV6HbZ2N1oIBw1UBYATHAOpo4tfTF83JM3Z0=
+gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.1.4"
+const PackageVersion = "0.1.5"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{


### PR DESCRIPTION
Fix for https://devdiv.visualstudio.com/OnlineServices/_componentGovernance/tunnels/alert/8884434?typeId=14289336&pipelinesTrackingFilter=0

An issue in the Unmarshal function in Go-Yaml v3 can cause a program to panic when attempting to deserialize invalid input.

The fix is to upgrade gopkg.in/yaml.v3 from v3.0.0-20200313102051-9f266ea9e77c to 3.0.0-20220521103104-8f96da9f5d5e to fix the vulnerability.
