### PR TITLE
Manually Specify C# and TS package version

### DIFF
--- a/cs/Directory.Build.props
+++ b/cs/Directory.Build.props
@@ -20,6 +20,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/microsoft/dev-tunnels</RepositoryUrl>
     <PackageProjectUrl>https://github.com/microsoft/dev-tunnels</PackageProjectUrl>
+    <Versions>1.0.7500</Versions>
   </PropertyGroup>
 
   <!-- Product Properties -->

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -46,7 +46,8 @@
 				"typescript": "^4.9.5",
 				"websocket": "^1.0.28",
 				"yargs": "^17.2.1"
-			}
+			},
+			"version": "1.0.7500"
 		},
 		"node_modules/@es-joy/jsdoccomment": {
 			"version": "0.37.0",
@@ -4872,5 +4873,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
-	}
+	},
+	"version": "1.0.7500"
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -109,5 +109,6 @@
 		"trailingComma": "all",
 		"arrowParens": "always",
 		"parser": "typescript"
-	}
+	},
+	"version": "1.0.7500"
 }


### PR DESCRIPTION
Fixes #

### Changes proposed: 
- Add manual entry of TS and CS package version

### Other Tasks:
- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
