### PR TITLE
Allow client app to cancel fwd of specific ports

### DIFF
--- a/cs/src/Connections/ITunnelClient.cs
+++ b/cs/src/Connections/ITunnelClient.cs
@@ -27,6 +27,20 @@ public interface ITunnelClient : IAsyncDisposable
     IReadOnlyCollection<TunnelConnectionMode> ConnectionModes { get; }
 
     /// <summary>
+    /// Event raised when a port is about to be forwarded to the client.
+    /// </summary>
+    /// <remarks>
+    /// The application may cancel this event to prevent specific port(s) from being
+    /// forwarded to the client. Cancelling prevents the tunnel client from listening on a
+    /// local socket for the port, AND prevents use of <see cref="ConnectToForwardedPortAsync"/>
+    /// to open a direct stream connection to the port.
+    /// 
+    /// This event is still fired when <see cref="AcceptLocalConnectionsForForwardedPorts" />
+    /// is false.
+    /// </remarks>
+    event EventHandler<PortForwardingEventArgs>? PortForwarding;
+
+    /// <summary>
     /// Gets list of ports forwarded to client, this collection
     /// contains events to notify when ports are forwarded
     /// </summary>

--- a/cs/src/Connections/MultiModeTunnelClient.cs
+++ b/cs/src/Connections/MultiModeTunnelClient.cs
@@ -46,6 +46,12 @@ public class MultiModeTunnelClient : TunnelConnection, ITunnelClient
     public IReadOnlyCollection<TunnelConnectionMode> ConnectionModes
         => Clients.SelectMany((c) => c.ConnectionModes).Distinct().ToArray();
 
+#pragma warning disable CS0067 // Not used
+    /// <inheritdoc />
+    public event EventHandler<PortForwardingEventArgs>? PortForwarding;
+#pragma warning restore CS0067
+
+
     /// <inheritdoc />
     public ForwardedPortsCollection? ForwardedPorts => throw new NotImplementedException();
 

--- a/cs/src/Connections/PortForwardingEventArgs.cs
+++ b/cs/src/Connections/PortForwardingEventArgs.cs
@@ -1,0 +1,39 @@
+// <copyright file="PortForwardingEventArgs.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+
+namespace Microsoft.DevTunnels.Connections;
+
+/// <summary>
+/// Event raised when a port is about to be forwarded to the tunnel client.
+/// </summary>
+public class PortForwardingEventArgs : EventArgs
+{
+    /// <summary>
+    /// Create a new instance of <see cref="PortForwardingEventArgs"/>.
+    /// </summary>
+    public PortForwardingEventArgs(int portNumber)
+    {
+        PortNumber = portNumber;
+    }
+
+    /// <summary>
+    /// Gets the port number that is being forwarded.
+    /// </summary>
+    public int PortNumber { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the current forward request will be cancelled
+    /// (ignored by this client).
+    /// </summary>
+    /// <remarks>
+    /// Cancelling the event prevents the current port from being forwarded to the client. It
+    /// prevents the tunnel client from listening on a local socket for the port, AND prevents
+    /// use of <see cref="ITunnelClient.ConnectToForwardedPortAsync"/> to open a direct stream
+    /// connection to the port.
+    /// </remarks>
+    public bool Cancel { get; set; }
+}

--- a/ts/src/connections/index.ts
+++ b/ts/src/connections/index.ts
@@ -23,4 +23,5 @@ export { maxReconnectDelayMs } from './relayTunnelConnector';
 export * from './refreshingTunnelAccessTokenEventArgs';
 export * from './refreshingTunnelEventArgs';
 export * from './retryingTunnelConnectionEventArgs';
+export * from './portForwardingEventArgs';
 export * from './tunnelConnector';

--- a/ts/src/connections/multiModeTunnelClient.ts
+++ b/ts/src/connections/multiModeTunnelClient.ts
@@ -4,9 +4,11 @@
 import { TunnelConnectionMode, Tunnel, TunnelAccessScopes } from '@microsoft/dev-tunnels-contracts';
 import { CancellationToken, SshStream } from '@microsoft/dev-tunnels-ssh';
 import { ForwardedPortsCollection } from '@microsoft/dev-tunnels-ssh-tcp';
-import { TunnelClient } from '.';
+import { TunnelClient } from './tunnelClient'
+import { PortForwardingEventArgs } from './portForwardingEventArgs';
 import { TunnelConnectionBase } from './tunnelConnectionBase';
 import { TunnelConnectionOptions } from './tunnelConnectionOptions';
+import { Event } from 'vscode-jsonrpc';
 
 /**
  * Tunnel client implementation that selects one of multiple available connection modes.
@@ -53,6 +55,10 @@ export class MultiModeTunnelClient extends TunnelConnectionBase implements Tunne
         }
 
         return new Promise<void>((resolve) => {});
+    }
+
+    public get portForwarding() : Event<PortForwardingEventArgs> {
+        throw new Error('Not supported.');
     }
 
     public connectToForwardedPort(

--- a/ts/src/connections/portForwardingEventArgs.ts
+++ b/ts/src/connections/portForwardingEventArgs.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Event raised when a port is about to be forwarded to the tunnel client.
+ */
+export class PortForwardingEventArgs {
+    /**
+     * Creates a new instance of PortForwardingEventArgs.
+     */
+    public constructor(
+        /**
+         * Gets the port number that is being forwarded.
+         */
+        public readonly portNumber: number,
+    ) {}
+
+    public cancel: boolean = false;
+}

--- a/ts/src/connections/tunnelClient.ts
+++ b/ts/src/connections/tunnelClient.ts
@@ -2,11 +2,13 @@
 // Licensed under the MIT license.
 
 import { Duplex } from 'stream';
+import { Event } from 'vscode-jsonrpc';
 import { TunnelConnectionMode, Tunnel } from '@microsoft/dev-tunnels-contracts';
 import { CancellationToken } from '@microsoft/dev-tunnels-ssh';
 import { ForwardedPortsCollection } from '@microsoft/dev-tunnels-ssh-tcp';
 import { TunnelConnection } from './tunnelConnection';
 import { TunnelConnectionOptions } from './tunnelConnectionOptions';
+import { PortForwardingEventArgs } from './portForwardingEventArgs';
 
 /**
  * Interface for a client capable of making a connection
@@ -17,6 +19,17 @@ export interface TunnelClient extends TunnelConnection {
      * Gets the list of connection modes that this client supports.
      */
     readonly connectionModes: TunnelConnectionMode[];
+
+    /**
+     * Event raised when a port is about to be forwarded to the client.
+     *
+     * The application may cancel this event to prevent specific port(s) from being
+     * forwarded to the client. Cancelling prevents the tunnel client from listening on
+     * a local socket for the port, AND prevents use of {@link connectToForwardedPort}
+     * to open a direct stream connection to the port. This event is still fired when
+     * {@link acceptLocalConnectionsForForwardedPorts} is false.
+     */
+    readonly portForwarding: Event<PortForwardingEventArgs>;
 
     /**
      * Gets list of ports forwarded to client, this collection

--- a/ts/test/tunnels-test/connectTests.ts
+++ b/ts/test/tunnels-test/connectTests.ts
@@ -13,6 +13,8 @@ import { TunnelManagementClient } from '@microsoft/dev-tunnels-management';
 import { TunnelClient, TunnelConnectionBase, TunnelHost } from '@microsoft/dev-tunnels-connections';
 import { CancellationToken, SshStream } from '@microsoft/dev-tunnels-ssh';
 import { TunnelConnectionOptions } from 'src/connections/tunnelConnectionOptions';
+import { Event } from 'vscode-jsonrpc';
+import { PortForwardingEventArgs } from 'src/connections/portForwardingEventArgs';
 
 @suite
 @slow(3000)
@@ -93,6 +95,9 @@ class MockTunnelClient extends TunnelConnectionBase implements TunnelClient {
     public onConnected?: Function;
     public onForwarding?: Function;
 
+    public get portForwarding() : Event<PortForwardingEventArgs> {
+        throw new Error('Method not implemented.');
+    }
     connectToForwardedPort(
         fowardedPort: number,
         cancellation?: CancellationToken,


### PR DESCRIPTION
Normally a tunnel client will forward all ports requested by the host. However in some scenarios it's useful for a client to be able to selectively decline to forward some port numbers. This change adds a `TunnelClient.PortForwarding` event with a `Cancel` property. The event notifies the client application when a port is about to be forwarded as requested by the host and allow cancellation of that request.