### PR TITLE
Add enum for Api Version in C# and TS

### DIFF
--- a/cs/src/Management/ManagementApiVersions.cs
+++ b/cs/src/Management/ManagementApiVersions.cs
@@ -1,0 +1,38 @@
+// <copyright file="ManagementApiVersions.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+namespace Microsoft.DevTunnels.Management;
+
+/// <summary>
+/// Allowed Api Versions for Management API.
+/// </summary>
+public enum ManagementApiVersions
+{
+    /// <summary>
+    /// Value for api version 2023-09-27-preview.
+    /// </summary>
+    Version20230927Preview,
+}
+
+
+/// <summary>
+/// Version extensions for ManagementApiVersions enum.
+/// </summary>
+public static class VersionExtensions
+{
+    /// <summary>
+    /// Get string version from enum
+    /// </summary>
+    /// <param name="version">Enum value</param>
+    /// <returns>String representaion of version</returns>
+    public static string ToVersionString(this ManagementApiVersions version)
+    {
+        switch (version)
+        {
+            case ManagementApiVersions.Version20230927Preview:   return "2023-09-27-preview";
+            default:                                             return "2023-09-27-preview";
+        }
+    }
+}

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DevTunnels.Management
         /// <summary>
         /// ApiVersion that will be used if one is not specified
         /// </summary>
-        public const string DefaultApiVersion = "2023-09-27-preview";
+        public const ManagementApiVersions DefaultApiVersion = ManagementApiVersions.Version20230927Preview;
 
         private static readonly ProductInfoHeaderValue TunnelSdkUserAgent =
             TunnelUserAgent.GetUserAgent(typeof(TunnelManagementClient).Assembly, "Dev-Tunnels-Service-CSharp-SDK")!;
@@ -95,7 +95,7 @@ namespace Microsoft.DevTunnels.Management
         public TunnelManagementClient(
             ProductInfoHeaderValue userAgent,
             Func<Task<AuthenticationHeaderValue?>>? userTokenCallback = null,
-            string apiVersion = DefaultApiVersion)
+            ManagementApiVersions apiVersion = DefaultApiVersion)
             : this(new[] { userAgent }, userTokenCallback, tunnelServiceUri: null, httpHandler: null, apiVersion)
         {
         }
@@ -116,7 +116,7 @@ namespace Microsoft.DevTunnels.Management
         public TunnelManagementClient(
             ProductInfoHeaderValue[] userAgents,
             Func<Task<AuthenticationHeaderValue?>>? userTokenCallback = null,
-            string apiVersion = DefaultApiVersion)
+            ManagementApiVersions apiVersion = DefaultApiVersion)
             : this(userAgents, userTokenCallback, tunnelServiceUri: null, httpHandler: null, apiVersion)
         {
         }
@@ -144,7 +144,7 @@ namespace Microsoft.DevTunnels.Management
             Func<Task<AuthenticationHeaderValue?>>? userTokenCallback = null,
             Uri? tunnelServiceUri = null,
             HttpMessageHandler? httpHandler = null,
-            string apiVersion = DefaultApiVersion)
+            ManagementApiVersions apiVersion = DefaultApiVersion)
             : this(new[] { userAgent }, userTokenCallback, tunnelServiceUri, httpHandler, apiVersion)
         {
         }
@@ -167,17 +167,18 @@ namespace Microsoft.DevTunnels.Management
         /// <see cref="HttpClientHandler"/> specified (or at the end of the chain) must have
         /// automatic redirection disabled. The provided HTTP handler will not be disposed
         /// by <see cref="Dispose"/>.</param>
-        /// <param name="apiVersion"> Api version to use for tunnels requests, accepted
+        /// <param name="apiVersionEnum"> Api version to use for tunnels requests, accepted
         /// values are <see cref="TunnelsApiVersions"/></param>
         public TunnelManagementClient(
             ProductInfoHeaderValue[] userAgents,
             Func<Task<AuthenticationHeaderValue?>>? userTokenCallback = null,
             Uri? tunnelServiceUri = null,
             HttpMessageHandler? httpHandler = null,
-            string apiVersion = DefaultApiVersion)
+            ManagementApiVersions apiVersionEnum = DefaultApiVersion)
         {
             Requires.NotNullEmptyOrNullElements(userAgents, nameof(userAgents));
             UserAgents = Requires.NotNull(userAgents, nameof(userAgents));
+            var apiVersion = apiVersionEnum.ToVersionString();
             if (!string.IsNullOrEmpty(apiVersion) && !TunnelsApiVersions.Contains(apiVersion))
             {
                 throw new ArgumentException(
@@ -672,7 +673,7 @@ namespace Microsoft.DevTunnels.Management
 
                     case HttpStatusCode.Unauthorized:
                     case HttpStatusCode.Forbidden:
-                        // Enterprise Policies 
+                        // Enterprise Policies
                         if (response.Headers.Contains("X-Enterprise-Policy-Failure"))
                         {
                             var message = response.Content != null ? await response.Content.ReadAsStringAsync() : string.Empty;

--- a/ts/src/management/managementApiVersions.ts
+++ b/ts/src/management/managementApiVersions.ts
@@ -1,3 +1,0 @@
-enum ManagementApiVersions {
-    Version20230927preview = '2023-09-27-preview',
-}

--- a/ts/src/management/managementApiVersions.ts
+++ b/ts/src/management/managementApiVersions.ts
@@ -1,0 +1,3 @@
+enum ManagementApiVersions {
+    Version20230927preview = '2023-09-27-preview',
+}

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -38,7 +38,7 @@ const clustersApiPath = '/clusters';
 const tunnelAuthentication = 'Authorization';
 const checkAvailablePath = ':checkNameAvailability';
 const createNameRetries = 3;
-enum ManagementApiVersions {
+export enum ManagementApiVersions {
     Version20230927preview = '2023-09-27-preview',
 }
 

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -124,6 +124,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
      * with a client authentication callback, service URI, and HTTP handler.
      *
      * @param userAgent { name, version } object or a comment string to use as the User-Agent header.
+     * @param apiVersion ApiVersion to be used for requests, value should be one of ManagementApiVersions enum.
      * @param userTokenCallback Optional async callback for retrieving a client authentication
      * header value with access token, for AAD or GitHub user authentication. This may be omitted
      * for anonymous tunnel clients, or if tunnel access tokens will be specified via

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -38,6 +38,9 @@ const clustersApiPath = '/clusters';
 const tunnelAuthentication = 'Authorization';
 const checkAvailablePath = ':checkNameAvailability';
 const createNameRetries = 3;
+enum ManagementApiVersions {
+    Version20230927preview = '2023-09-27-preview',
+}
 
 function comparePorts(a: TunnelPort, b: TunnelPort) {
     return (a.portNumber ?? Number.MAX_SAFE_INTEGER) - (b.portNumber ?? Number.MAX_SAFE_INTEGER);

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -133,7 +133,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
      */
     public constructor(
         userAgents: (ProductHeaderValue | string)[] | ProductHeaderValue | string,
-        apiVersion: string,
+        apiVersion: ManagementApiVersions,
         userTokenCallback?: () => Promise<string | null>,
         tunnelServiceUri?: string,
         public readonly httpsAgent?: https.Agent,

--- a/ts/test/tunnels-test/connection.ts
+++ b/ts/test/tunnels-test/connection.ts
@@ -3,7 +3,7 @@
 
 import { TunnelRelayTunnelClient } from '@microsoft/dev-tunnels-connections';
 import { Tunnel, TunnelConnectionMode } from '@microsoft/dev-tunnels-contracts';
-import { TunnelManagementHttpClient, TunnelRequestOptions } from '@microsoft/dev-tunnels-management';
+import { ManagementApiVersions, TunnelManagementHttpClient, TunnelRequestOptions } from '@microsoft/dev-tunnels-management';
 import * as yargs from 'yargs';
 
 const userAgent = 'test-connection/1.0';
@@ -58,7 +58,7 @@ async function connect(port: number, options: { [name: string]: string }) {
 async function startTunnelRelayConnection() {
     let tunnelManagementClient = new TunnelManagementHttpClient(
         userAgent,
-        "2023-09-27-preview",
+        ManagementApiVersions.Version20230927preview,
         () => Promise.resolve('Bearer'),
         'http://localhost:9900/');
     const tunnel: Tunnel = {

--- a/ts/test/tunnels-test/host.ts
+++ b/ts/test/tunnels-test/host.ts
@@ -8,7 +8,7 @@ import {
     TunnelAccessControlEntryType,
     TunnelConnectionMode,
 } from '@microsoft/dev-tunnels-contracts';
-import { TunnelManagementHttpClient, TunnelRequestOptions } from '@microsoft/dev-tunnels-management';
+import { ManagementApiVersions, TunnelManagementHttpClient, TunnelRequestOptions } from '@microsoft/dev-tunnels-management';
 import * as yargs from 'yargs';
 import * as https from 'https';
 
@@ -43,7 +43,7 @@ async function main() {
 async function startTunnelRelayHost() {
     let tunnelManagementClient = new TunnelManagementHttpClient(
         userAgent,
-        "2023-09-27-preview",
+        ManagementApiVersions.Version20230927preview,
         () => Promise.resolve('Bearer'),
         'http://localhost:9900/', //'https://ci.dev.tunnels.vsengsaas.visualstudio.com/',
         new https.Agent({

--- a/ts/test/tunnels-test/tunnelManagementTests.ts
+++ b/ts/test/tunnels-test/tunnelManagementTests.ts
@@ -5,7 +5,7 @@ import * as assert from 'assert';
 import axios, { AxiosPromise, AxiosRequestConfig, Method } from 'axios';
 import * as https from 'https';
 import { suite, test, slow, timeout } from '@testdeck/mocha';
-import { TunnelManagementHttpClient } from '@microsoft/dev-tunnels-management';
+import { ManagementApiVersions, TunnelManagementHttpClient } from '@microsoft/dev-tunnels-management';
 import { Tunnel } from '@microsoft/dev-tunnels-contracts';
 
 @suite
@@ -17,7 +17,7 @@ export class TunnelManagementTests {
 
     public constructor() {
         this.managementClient = new TunnelManagementHttpClient(
-            'test/0.0.0', "2023-09-27-preview", undefined, 'http://global.tunnels.test.api.visualstudio.com');
+            'test/0.0.0', ManagementApiVersions.Version20230927preview, undefined, 'http://global.tunnels.test.api.visualstudio.com');
         (<any>this.managementClient).request = this.mockRequest.bind(this);
     }
 
@@ -110,7 +110,7 @@ export class TunnelManagementTests {
 
         // Create a management client with a mock https agent and adapter
         const managementClient = new TunnelManagementHttpClient(
-            'test/0.0.0',"2023-09-27-preview", undefined, 'http://global.tunnels.test.api.visualstudio.com', httpsAgent, axiosAdapter);
+            'test/0.0.0', ManagementApiVersions.Version20230927preview, undefined, 'http://global.tunnels.test.api.visualstudio.com', httpsAgent, axiosAdapter);
         (<any>managementClient).request = this.mockRequest.bind(this);
 
         this.nextResponse = [];


### PR DESCRIPTION
Fixes #

### Changes proposed: 
- Adds an enum for api versions in C# and TS SDKs
-
-

### Other Tasks:
- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
