### PR TITLE
Clear axios timeout after request is done

### DIFF
--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -1090,13 +1090,14 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
 
         let disposable: Disposable | undefined;
         const abortController = new AbortController();
+        let timeOutId: number | undefined;
         const newAbortSignal = () => {
             if (cancellation?.isCancellationRequested) {
                 abortController.abort();
             } else if (cancellation) {
                 disposable = cancellation.onCancellationRequested(() => abortController.abort());
             } else {
-                setTimeout(() => abortController.abort(), defaultRequestTimeoutMS);
+                timeOutId = setTimeout(() => abortController.abort(), defaultRequestTimeoutMS);
             }
             return abortController.signal;
         }
@@ -1136,6 +1137,8 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
 
             throw requestError;
         } finally {
+            // clear abort timeout
+            clearTimeout(timeOutId);
             disposable?.dispose();
         }
     }


### PR DESCRIPTION

### Changes proposed: 

Clearing the timeout that handles the abort signal for the axios request.

This way we make sure that future requests do not get aborted by mistake.


### Other Tasks:

- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [ ] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
