### PR TITLE
rs: fix error logs and compilation warning on non-windows

### DIFF
--- a/rs/src/management/policy_provider.rs
+++ b/rs/src/management/policy_provider.rs
@@ -1,15 +1,20 @@
 use std::io;
 
-pub const REGISTRY_KEY_PATH: &str = r"Software\Policies\Microsoft\Tunnels";
-
 #[cfg(target_os = "windows")]
 pub fn get_policy_header_value() -> io::Result<Option<String>> {
     use urlencoding::encode;
     use winreg::enums::*;
     use winreg::RegKey;
 
+    pub const REGISTRY_KEY_PATH: &str = r"Software\Policies\Microsoft\Tunnels";
+
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-    let sub_key = hklm.open_subkey(REGISTRY_KEY_PATH)?;
+    let sub_key = match hklm.open_subkey(REGISTRY_KEY_PATH) {
+        Ok(sub_key) => sub_key,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+
     let mut header_values = vec![];
 
     for (name, value) in sub_key.enum_values().filter_map(Result::ok) {


### PR DESCRIPTION
Fixes #388

### Changes proposed: 
- Avoids noisy error logging if no access policies are configured
- Fixes a compilation warning, and generate the user agent string in a slightly DRY-er way

### Other Tasks:

- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [x] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
