### PR TITLE
Add endpoint connection mode query param

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build --verbose --manifest-path=rs/Cargo.toml
+      run: cargo build --features connections --verbose --manifest-path=rs/Cargo.toml
     - name: Run tests
-      run: cargo test --verbose --manifest-path=rs/Cargo.toml
-   
+      run: cargo test --features connections --verbose --manifest-path=rs/Cargo.toml
+

--- a/rs/src/connections/relay_tunnel_host.rs
+++ b/rs/src/connections/relay_tunnel_host.rs
@@ -325,7 +325,7 @@ impl RelayTunnelHost {
             connection_timeout: None,
             auth_rejection_time: std::time::Duration::from_secs(5),
             keys: vec![keypair],
-            window_size: 1024 * 1024 * 1,
+            window_size: 1024 * 1024,
             preferred: russh::Preferred::COMPRESSED,
             limits: russh::Limits {
                 rekey_read_limit: usize::MAX,
@@ -389,7 +389,7 @@ impl RelayTunnelHost {
                 &self.locator,
                 &TunnelRelayTunnelEndpoint {
                     base: TunnelEndpoint {
-                        id: format!("{}-relay",self.host_id.to_string()),
+                        id: format!("{}-relay", self.host_id),
                         connection_mode: TunnelConnectionMode::TunnelRelay,
                         host_id: self.host_id.to_string(),
                         host_public_keys: vec![],

--- a/rs/src/connections/relay_tunnel_host.rs
+++ b/rs/src/connections/relay_tunnel_host.rs
@@ -239,7 +239,7 @@ impl RelayTunnelHost {
         self.mgmt
             .delete_tunnel_endpoints(
                 &self.locator,
-                Some(format!("{}-{}", &self.host_id.to_string(), "relay")),
+                Some(format!("{}-relay", &self.host_id.to_string())),
                 NO_REQUEST_OPTIONS,
             )
             .await
@@ -389,7 +389,7 @@ impl RelayTunnelHost {
                 &self.locator,
                 &TunnelRelayTunnelEndpoint {
                     base: TunnelEndpoint {
-                        id: format!("{}-{}",self.host_id.to_string(), relay),
+                        id: format!("{}-relay",self.host_id.to_string()),
                         connection_mode: TunnelConnectionMode::TunnelRelay,
                         host_id: self.host_id.to_string(),
                         host_public_keys: vec![],

--- a/rs/src/connections/relay_tunnel_host.rs
+++ b/rs/src/connections/relay_tunnel_host.rs
@@ -240,7 +240,6 @@ impl RelayTunnelHost {
             .delete_tunnel_endpoints(
                 &self.locator,
                 Some(format!("{}-{}", &self.host_id.to_string(), "relay")),
-                None,
                 NO_REQUEST_OPTIONS,
             )
             .await

--- a/rs/src/connections/relay_tunnel_host.rs
+++ b/rs/src/connections/relay_tunnel_host.rs
@@ -239,7 +239,7 @@ impl RelayTunnelHost {
         self.mgmt
             .delete_tunnel_endpoints(
                 &self.locator,
-                &self.host_id.to_string(),
+                Some(format!("{}-{}", &self.host_id.to_string(), "relay")),
                 None,
                 NO_REQUEST_OPTIONS,
             )
@@ -390,7 +390,7 @@ impl RelayTunnelHost {
                 &self.locator,
                 &TunnelRelayTunnelEndpoint {
                     base: TunnelEndpoint {
-                        id: Some(uuid::Uuid::new_v4().to_string()),
+                        id: format!("{}-{}",self.host_id.to_string(), relay),
                         connection_mode: TunnelConnectionMode::TunnelRelay,
                         host_id: self.host_id.to_string(),
                         host_public_keys: vec![],

--- a/rs/src/connections/relay_tunnel_host.rs
+++ b/rs/src/connections/relay_tunnel_host.rs
@@ -239,7 +239,7 @@ impl RelayTunnelHost {
         self.mgmt
             .delete_tunnel_endpoints(
                 &self.locator,
-                Some(format!("{}-relay", &self.host_id.to_string())),
+                &format!("{}-relay", &self.host_id.to_string()),
                 NO_REQUEST_OPTIONS,
             )
             .await

--- a/rs/src/connections/ws.rs
+++ b/rs/src/connections/ws.rs
@@ -368,8 +368,7 @@ mod test {
             }
         });
 
-        let mut output = Vec::new();
-        output.resize(input_len, 0);
+        let mut output = vec![0; input_len];
         read.read_exact(&mut output)
             .await
             .expect("expected to read");

--- a/rs/src/contracts/tunnel.rs
+++ b/rs/src/contracts/tunnel.rs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/Tunnel.cs
 
-use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControl;
 use crate::contracts::TunnelEndpoint;
 use crate::contracts::TunnelOptions;
 use crate::contracts::TunnelPort;
 use crate::contracts::TunnelStatus;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/rs/src/contracts/tunnel_access_control_entry.rs
+++ b/rs/src/contracts/tunnel_access_control_entry.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/TunnelAccessControlEntry.cs
 
-use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControlEntryType;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 // Data contract for an access control entry on a `Tunnel` or `TunnelPort`.

--- a/rs/src/contracts/tunnel_constraints.rs
+++ b/rs/src/contracts/tunnel_constraints.rs
@@ -110,7 +110,7 @@ pub const TUNNEL_ALIAS_PATTERN: &str = r#"[0123456789bcdfghjklmnpqrstvwxz]{3,60}
 pub const TUNNEL_NAME_PATTERN: &str = r#"([a-z0-9][a-z0-9-]{1,58}[a-z0-9])|(^$)"#;
 
 // Regular expression that can match or validate tunnel or port labels.
-pub const LABEL_PATTERN: &str = r#"[\w-=]{1,50}"#;
+pub const LABEL_PATTERN: &str = r"[\w-=]{1,50}";
 
 // Regular expression that can match or validate tunnel domains.
 //

--- a/rs/src/contracts/tunnel_port.rs
+++ b/rs/src/contracts/tunnel_port.rs
@@ -43,7 +43,7 @@ pub struct TunnelPort {
     // A client that connects to a tunnel (by ID or name) without specifying a port number
     // will connect to the default port for the tunnel, if a default is configured. Or if
     // the tunnel has only one port then the single port is the implicit default.
-    // 
+    //
     // Selection of a default port for a connection also depends on matching the
     // connection to the port `TunnelPort.Protocol`, so it is possible to configure
     // separate defaults for distinct protocols like `TunnelProtocol.Http` and

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -249,7 +249,7 @@ impl TunnelManagementClient {
     ) -> HttpResult<TunnelPort> {
         let url = self.build_tunnel_uri(
             locator,
-            Some(&format!("{}/{}", PORTS_API_SUB_PATH, port_number)),
+            Some(&format!("{}/{}", PORTS_API_SUB_PATH, port.port_number)),
         );
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, port);

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -187,7 +187,6 @@ impl TunnelManagementClient {
                 ENDPOINTS_API_SUB_PATH, endpoint.base.id
             )),
         );
-        options.connection_mode = endpoint.base.connection_mode;
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, endpoint);
         self.execute_json("update_tunnel_relay_endpoints", request)
@@ -651,10 +650,6 @@ fn add_query(url: &mut Url, tunnel_opts: &TunnelRequestOptions, api_version: &st
         if tunnel_opts.require_all_labels {
             url.query_pairs_mut().append_pair("allLabels", "true");
         }
-    }
-    if tunnel_opts.connection_mode.is_empty() {
-        url.query_pairs_mut()
-            .append_pair("connectionMode", &tunnel_opts.connection_mode);
     }
     url.query_pairs_mut()
         .append_pair("api-version", api_version);

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -165,10 +165,10 @@ impl TunnelManagementClient {
             locator,
             Some(&format!(
                 "{}/{}",
-                ENDPOINTS_API_SUB_PATH, endpoint.base.id
+                ENDPOINTS_API_SUB_PATH, endpoint.id
             )),
         );
-        url.query_pairs_mut().append_pair("connectionMode", &endpoint.base.connection_mode.to_string());
+        url.query_pairs_mut().append_pair("connectionMode", &endpoint.connection_mode.to_string());
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, endpoint);
         self.execute_json("update_tunnel_endpoints", request).await
@@ -200,7 +200,6 @@ impl TunnelManagementClient {
         &self,
         locator: &TunnelLocator,
         id: &str,
-        connection_mode: Option<TunnelConnectionMode>,
         options: &TunnelRequestOptions,
     ) -> HttpResult<bool> {
         let path = format!("{}/{}", ENDPOINTS_API_SUB_PATH, id);

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -247,7 +247,10 @@ impl TunnelManagementClient {
         port: &TunnelPort,
         options: &TunnelRequestOptions,
     ) -> HttpResult<TunnelPort> {
-        let url = self.build_tunnel_uri(locator, Some(PORTS_API_SUB_PATH));
+        let url = self.build_tunnel_uri(
+            locator,
+            Some(&format!("{}/{}", PORTS_API_SUB_PATH, port_number)),
+        );
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, port);
         self.execute_json("create_tunnel_port", request).await

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -187,6 +187,7 @@ impl TunnelManagementClient {
                 ENDPOINTS_API_SUB_PATH, endpoint.base.id
             )),
         );
+        options.connection_mode = endpoint.base.connection_mode;
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, endpoint);
         self.execute_json("update_tunnel_relay_endpoints", request)
@@ -650,6 +651,10 @@ fn add_query(url: &mut Url, tunnel_opts: &TunnelRequestOptions, api_version: &st
         if tunnel_opts.require_all_labels {
             url.query_pairs_mut().append_pair("allLabels", "true");
         }
+    }
+    if tunnel_opts.connection_mode.is_empty() {
+        url.query_pairs_mut()
+            .append_pair("connectionMode", &tunnel_opts.connection_mode);
     }
     url.query_pairs_mut()
         .append_pair("api-version", api_version);

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -14,7 +14,7 @@ use url::Url;
 use rand::Rng;
 
 use crate::contracts::{
-    env_production, NamedRateStatus, Tunnel, TunnelConnectionMode, TunnelEndpoint,
+    env_production, NamedRateStatus, Tunnel, TunnelEndpoint,
     TunnelListByRegionResponse, TunnelPort, TunnelPortListResponse, TunnelRelayTunnelEndpoint,
     TunnelServiceProperties,
 };
@@ -161,7 +161,7 @@ impl TunnelManagementClient {
         endpoint: &TunnelEndpoint,
         options: &TunnelRequestOptions,
     ) -> HttpResult<TunnelEndpoint> {
-        let url = self.build_tunnel_uri(
+        let mut url = self.build_tunnel_uri(
             locator,
             Some(&format!(
                 "{}/{}",

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -180,7 +180,7 @@ impl TunnelManagementClient {
         endpoint: &TunnelRelayTunnelEndpoint,
         options: &TunnelRequestOptions,
     ) -> HttpResult<TunnelRelayTunnelEndpoint> {
-        let url = self.build_tunnel_uri(
+        let mut url = self.build_tunnel_uri(
             locator,
             Some(&format!(
                 "{}/{}",

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -187,6 +187,7 @@ impl TunnelManagementClient {
                 ENDPOINTS_API_SUB_PATH, endpoint.base.id
             )),
         );
+        url.query_pairs_mut().append_pair("connectionMode", &endpoint.base.connection_mode.to_string());
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, endpoint);
         self.execute_json("update_tunnel_relay_endpoints", request)

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -14,9 +14,8 @@ use url::Url;
 use rand::Rng;
 
 use crate::contracts::{
-    env_production, NamedRateStatus, Tunnel, TunnelEndpoint,
-    TunnelListByRegionResponse, TunnelPort, TunnelPortListResponse, TunnelRelayTunnelEndpoint,
-    TunnelServiceProperties,
+    env_production, NamedRateStatus, Tunnel, TunnelEndpoint, TunnelListByRegionResponse,
+    TunnelPort, TunnelPortListResponse, TunnelRelayTunnelEndpoint, TunnelServiceProperties,
 };
 
 use super::{
@@ -163,12 +162,10 @@ impl TunnelManagementClient {
     ) -> HttpResult<TunnelEndpoint> {
         let mut url = self.build_tunnel_uri(
             locator,
-            Some(&format!(
-                "{}/{}",
-                ENDPOINTS_API_SUB_PATH, endpoint.id
-            )),
+            Some(&format!("{}/{}", ENDPOINTS_API_SUB_PATH, endpoint.id)),
         );
-        url.query_pairs_mut().append_pair("connectionMode", &endpoint.connection_mode.to_string());
+        url.query_pairs_mut()
+            .append_pair("connectionMode", &endpoint.connection_mode.to_string());
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, endpoint);
         self.execute_json("update_tunnel_endpoints", request).await
@@ -183,12 +180,10 @@ impl TunnelManagementClient {
     ) -> HttpResult<TunnelRelayTunnelEndpoint> {
         let mut url = self.build_tunnel_uri(
             locator,
-            Some(&format!(
-                "{}/{}",
-                ENDPOINTS_API_SUB_PATH, endpoint.base.id
-            )),
+            Some(&format!("{}/{}", ENDPOINTS_API_SUB_PATH, endpoint.base.id)),
         );
-        url.query_pairs_mut().append_pair("connectionMode", &endpoint.base.connection_mode.to_string());
+        url.query_pairs_mut()
+            .append_pair("connectionMode", &endpoint.base.connection_mode.to_string());
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, endpoint);
         self.execute_json("update_tunnel_relay_endpoints", request)

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -164,10 +164,11 @@ impl TunnelManagementClient {
         let url = self.build_tunnel_uri(
             locator,
             Some(&format!(
-                "{}/{}/{}",
-                ENDPOINTS_API_SUB_PATH, endpoint.host_id, endpoint.connection_mode
+                "{}/{}",
+                ENDPOINTS_API_SUB_PATH, endpoint.base.id
             )),
         );
+        url.query_pairs_mut().append_pair("connectionMode", &endpoint.base.connection_mode.to_string());
         let mut request = self.make_tunnel_request(Method::PUT, url, options).await?;
         json_body(&mut request, endpoint);
         self.execute_json("update_tunnel_endpoints", request).await
@@ -198,15 +199,11 @@ impl TunnelManagementClient {
     pub async fn delete_tunnel_endpoints(
         &self,
         locator: &TunnelLocator,
-        host_id: &str,
+        id: &str,
         connection_mode: Option<TunnelConnectionMode>,
         options: &TunnelRequestOptions,
     ) -> HttpResult<bool> {
-        let path = if let Some(cm) = connection_mode {
-            format!("{}/{}/{}", ENDPOINTS_API_SUB_PATH, host_id, cm)
-        } else {
-            format!("{}/{}", ENDPOINTS_API_SUB_PATH, host_id)
-        };
+        let path = format!("{}/{}", ENDPOINTS_API_SUB_PATH, id);
 
         let url = self.build_tunnel_uri(locator, Some(&path));
         let request = self

--- a/rs/src/management/tunnel_request_options.rs
+++ b/rs/src/management/tunnel_request_options.rs
@@ -1,5 +1,7 @@
 use reqwest::header::{HeaderName, HeaderValue};
 
+use crate::contracts::TunnelConnectionMode;
+
 use super::Authorization;
 
 #[derive(Default, Clone)]
@@ -50,6 +52,9 @@ pub struct TunnelRequestOptions {
 
     /// Limits the number of tunnels returned when searching or listing tunnels.
     pub limit: u32,
+
+    /// Gets or sets the connection mode of the endpoint.
+    pub connection_mode: TunnelConnectionMode,
 }
 
 pub const NO_REQUEST_OPTIONS: &TunnelRequestOptions = &TunnelRequestOptions {

--- a/rs/src/management/tunnel_request_options.rs
+++ b/rs/src/management/tunnel_request_options.rs
@@ -1,7 +1,5 @@
 use reqwest::header::{HeaderName, HeaderValue};
 
-use crate::contracts::TunnelConnectionMode;
-
 use super::Authorization;
 
 #[derive(Default, Clone)]
@@ -52,9 +50,6 @@ pub struct TunnelRequestOptions {
 
     /// Limits the number of tunnels returned when searching or listing tunnels.
     pub limit: u32,
-
-    /// Gets or sets the connection mode of the endpoint.
-    pub connection_mode: TunnelConnectionMode,
 }
 
 pub const NO_REQUEST_OPTIONS: &TunnelRequestOptions = &TunnelRequestOptions {


### PR DESCRIPTION
Fixes #

### Changes proposed: 
- Adds endpoint connection mode query  param to fix issue where endpoint is always returned as local network
-
-

### Other Tasks:

- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [ ] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
