### PR TITLE
rs: allow parsing proxies given as full URIs

### DIFF
--- a/rs/src/connections/errors.rs
+++ b/rs/src/connections/errors.rs
@@ -30,6 +30,9 @@ pub enum TunnelError {
     #[error("proxy connection failed: {0}")]
     ProxyConnectionFailed(std::io::Error),
 
+    #[error("proxy address invalid: {0}")]
+    ProxyAddressInvalid(url::ParseError),
+
     #[error("proxy handshake failed: {0}")]
     ProxyHandshakeFailed(hyper::Error),
 


### PR DESCRIPTION
Rather than only host:port

For microsoft/vscode#201417


### Changes proposed: 
- HTTPS_PROXY may be given as a URI rather than just host:port. Doing so is rather extraneous since only the host and port are used, but handle parsing it anyway.

### Other Tasks:

- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [ ] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
