### PR TITLE
Bump `es5-ext` to version 0.10.64 to resolve CVE-2024-27088

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1542,14 +1542,15 @@
 			"dev": true
 		},
 		"node_modules/es5-ext": {
-			"version": "0.10.62",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-			"integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+			"version": "0.10.64",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"es6-iterator": "^2.0.3",
 				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
 				"next-tick": "^1.1.0"
 			},
 			"engines": {
@@ -1972,6 +1973,27 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/esniff": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+			"integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+			"dev": true,
+			"dependencies": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.62",
+				"event-emitter": "^0.3.5",
+				"type": "^2.7.2"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/esniff/node_modules/type": {
+			"version": "2.7.2",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+			"integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+			"dev": true
 		},
 		"node_modules/espree": {
 			"version": "9.5.0",

--- a/ts/src/connections/package.json
+++ b/ts/src/connections/package.json
@@ -25,6 +25,6 @@
 		"uuid": "^3.3.3",
 		"await-semaphore": "^0.1.3",
 		"websocket": "^1.0.28",
-		"es5-ext": "0.10.53"
+		"es5-ext": "^0.10.64"
 	}
 }


### PR DESCRIPTION
### Changes proposed: 
Upgrade the `es5-ext` package to 0.10.64 to resolve [CVE-2024-27088](https://github.com/advisories/GHSA-4gmj-3p3h-gm8h).

I am aware of this [previous PR](https://github.com/microsoft/dev-tunnels/pull/45) pinning the version, but it doesn't seem like it was working as version `0.10.62` was installed which still includes the war messaging.

### Other Tasks:

- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [X] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
