### PR TITLE
rs: fix policy registry key name

### DIFF
--- a/rs/src/management/policy_provider.rs
+++ b/rs/src/management/policy_provider.rs
@@ -6,7 +6,7 @@ pub fn get_policy_header_value() -> io::Result<Option<String>> {
     use winreg::enums::*;
     use winreg::RegKey;
 
-    pub const REGISTRY_KEY_PATH: &str = r"Software\Policies\Microsoft\Tunnels";
+    pub const REGISTRY_KEY_PATH: &str = r"Software\Policies\Microsoft\DevTunnels";
 
     let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
     let sub_key = match hklm.open_subkey(REGISTRY_KEY_PATH) {


### PR DESCRIPTION
Fixes #

### Changes proposed: 
-
-
-

### Other Tasks:

- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [ ] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
