### PR TITLE
Detect 4xx error response from firewall

### DIFF
--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -718,7 +718,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const config = await this.getAxiosRequestConfig(tunnel, options, accessTokenScopes);
         this.raiseReportProgress(TunnelProgress.StartingSendTunnelRequest);
         try {
-            const result = await this.request<TResult>(method, uri, body, config, allowNotFound);
+            const result = await this.request<TResult>(method, uri, body, config, allowNotFound, cancellation);
             this.raiseReportProgress(TunnelProgress.CompletedSendTunnelRequest);
             return result;
         } catch (error) {
@@ -760,7 +760,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         const uri = await this.buildUri(clusterId, path, query, options);
         const config = await this.getAxiosRequestConfig(undefined, options);
         try {
-            const result = await this.request<TResult>(method, uri, body, config, allowNotFound);
+            const result = await this.request<TResult>(method, uri, body, config, allowNotFound, cancellation);
             this.raiseReportProgress(TunnelProgress.CompletedSendTunnelRequest);
             return result;
         } catch (error) {
@@ -817,8 +817,27 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
             }
         }
 
+        if (!errorMessage && error.response && error.response.status &&
+            error.response.status >= 400 && error.response.status < 500 &&
+            error.response.headers
+        ) {
+            const headers = error.response.headers;
+            const servedBy = headers['X-Served-By'] || headers['x-served-by'];
+            if (!/tunnel-/.test(servedBy)) {
+                // The response did not include either a ProblemDetails body object or a header
+                // confirming it was served by the tunnel service. This check excludes 5xx status
+                // responses which may include non-firwall network infrastructure issues.
+                const requestDomain = new URL(error.config?.url ??
+                    TunnelServiceProperties.production.serviceUri).host;
+                errorMessage = 'The tunnel request resulted in ' +
+                    `${error.response.status} status, but the request ` +
+                    'did not reach the tunnel service. This may indicate the domain ' +
+                    `'${requestDomain}' is blocked by a firewall.`;
+            }
+        }
+
         if (!errorMessage) {
-            if (error?.response) {
+            if (error.response) {
                 errorMessage =
                     'Tunnel service returned status code: ' +
                     `${error.response.status} ${error.response.statusText}`;

--- a/ts/src/management/tunnelManagementHttpClient.ts
+++ b/ts/src/management/tunnelManagementHttpClient.ts
@@ -823,7 +823,7 @@ export class TunnelManagementHttpClient implements TunnelManagementClient {
         ) {
             const headers = error.response.headers;
             const servedBy = headers['X-Served-By'] || headers['x-served-by'];
-            if (!/tunnel-/.test(servedBy)) {
+            if (!/tunnels-/.test(servedBy)) {
                 // The response did not include either a ProblemDetails body object or a header
                 // confirming it was served by the tunnel service. This check excludes 5xx status
                 // responses which may include non-firwall network infrastructure issues.


### PR DESCRIPTION
When handling a 4xx error response from a tunnel management API request, check for the absence `X-Served-By` response header to detect when the error was likely caused by a firewall intercepting the request.