### PR TITLE
Add failed policy requirement names to UnauthorizedAccessException

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -731,9 +731,9 @@ namespace Microsoft.DevTunnels.Management
 
                         // Propagate failed policy requirement names.
                         if (response.Headers.TryGetValues(
-                            EnterprisePolicyFailureHeaderName, out var policyFaiulreValues))
+                            EnterprisePolicyFailureHeaderName, out var policyFailureValues))
                         {
-                            ex.SetEnterprisePolicyRequirements(policyFaiulreValues);
+                            ex.SetEnterprisePolicyRequirements(policyFailureValues);
                         }
 
                         throw ex;

--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -44,6 +44,7 @@ namespace Microsoft.DevTunnels.Management
         private const string TunnelAuthenticationScheme = "Tunnel";
         private const string RequestIdHeaderName = "VsSaaS-Request-Id";
         private const string CheckAvailableSubPath = ":checkNameAvailability";
+        private const string EnterprisePolicyFailureHeaderName = "X-Enterprise-Policy-Failure";
         private const int CreateNameRetries = 3;
 
         private static readonly string[] ManageAccessTokenScope =
@@ -640,7 +641,7 @@ namespace Microsoft.DevTunnels.Management
                             }
 
                             // Enterprise Policies
-                            if (response.Headers.Contains("X-Enterprise-Policy-Failure"))
+                            if (response.Headers.Contains(EnterprisePolicyFailureHeaderName))
                             {
                                 errorMessage = problemDetails!.Title + ": " + problemDetails.Detail;
                             }
@@ -726,6 +727,13 @@ namespace Microsoft.DevTunnels.Management
                             "WWW-Authenticate", out var authHeaderValues))
                         {
                             ex.SetAuthenticationSchemes(authHeaderValues);
+                        }
+
+                        // Propagate failed policy requirement names.
+                        if (response.Headers.TryGetValues(
+                            EnterprisePolicyFailureHeaderName, out var policyFaiulreValues))
+                        {
+                            ex.SetEnterprisePolicyRequirements(policyFaiulreValues);
                         }
 
                         throw ex;


### PR DESCRIPTION
This change enables applications to programmatically detect when an `UnauthorizedAccessException` was thrown due to a specific policy violation.
