### PR TITLE
Re-encode tenant unicode characters in rust SDK

### DIFF
--- a/rs/src/contracts/tunnel.rs
+++ b/rs/src/contracts/tunnel.rs
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/Tunnel.cs
 
-use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControl;
 use crate::contracts::TunnelEndpoint;
 use crate::contracts::TunnelOptions;
 use crate::contracts::TunnelPort;
 use crate::contracts::TunnelStatus;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/rs/src/contracts/tunnel_access_control_entry.rs
+++ b/rs/src/contracts/tunnel_access_control_entry.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 // Generated from ../../../cs/src/Contracts/TunnelAccessControlEntry.cs
 
-use chrono::{DateTime, Utc};
 use crate::contracts::TunnelAccessControlEntryType;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 // Data contract for an access control entry on a `Tunnel` or `TunnelPort`.

--- a/rs/src/contracts/tunnel_port.rs
+++ b/rs/src/contracts/tunnel_port.rs
@@ -43,7 +43,7 @@ pub struct TunnelPort {
     // A client that connects to a tunnel (by ID or name) without specifying a port number
     // will connect to the default port for the tunnel, if a default is configured. Or if
     // the tunnel has only one port then the single port is the implicit default.
-    // 
+    //
     // Selection of a default port for a connection also depends on matching the
     // connection to the port `TunnelPort.Protocol`, so it is possible to configure
     // separate defaults for distinct protocols like `TunnelProtocol.Http` and

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -162,7 +162,11 @@ impl TunnelManagementClient {
     ) -> HttpResult<TunnelEndpoint> {
         let mut url = self.build_tunnel_uri(
             locator,
-            Some(&format!("{}/{}", ENDPOINTS_API_SUB_PATH, endpoint.id.as_deref().unwrap())),
+            Some(&format!(
+                "{}/{}",
+                ENDPOINTS_API_SUB_PATH,
+                endpoint.id.as_deref().unwrap()
+            )),
         );
         url.query_pairs_mut()
             .append_pair("connectionMode", &endpoint.connection_mode.to_string());
@@ -180,7 +184,11 @@ impl TunnelManagementClient {
     ) -> HttpResult<TunnelRelayTunnelEndpoint> {
         let mut url = self.build_tunnel_uri(
             locator,
-            Some(&format!("{}/{}", ENDPOINTS_API_SUB_PATH, endpoint.base.id.as_deref().unwrap())),
+            Some(&format!(
+                "{}/{}",
+                ENDPOINTS_API_SUB_PATH,
+                endpoint.base.id.as_deref().unwrap()
+            )),
         );
         url.query_pairs_mut()
             .append_pair("connectionMode", &endpoint.base.connection_mode.to_string());
@@ -458,8 +466,15 @@ impl TunnelManagementClient {
         match get_policy_header_value() {
             Ok(Some(policy_header_value)) => {
                 if let Ok(header_value) = HeaderValue::from_maybe_shared(policy_header_value) {
-                    let header_value_str = header_value.to_str().unwrap().replace("%22", "").replace("%3B", ";");
-                    headers.insert("User-Agent-Policies", HeaderValue::from_str(&header_value_str).unwrap());
+                    let header_value_str = header_value
+                        .to_str()
+                        .unwrap()
+                        .replace("%22", "")
+                        .replace("%3B", ";");
+                    headers.insert(
+                        "User-Agent-Policies",
+                        HeaderValue::from_str(&header_value_str).unwrap(),
+                    );
                     log::info!("Headers: {:?}", headers);
                 } else {
                     log::error!("Invalid header value");

--- a/rs/src/management/http_client.rs
+++ b/rs/src/management/http_client.rs
@@ -458,7 +458,9 @@ impl TunnelManagementClient {
         match get_policy_header_value() {
             Ok(Some(policy_header_value)) => {
                 if let Ok(header_value) = HeaderValue::from_maybe_shared(policy_header_value) {
-                    headers.insert("User-Agent-Policies", header_value);
+                    let header_value_str = header_value.to_str().unwrap().replace("%22", "").replace("%3B", ";");
+                    headers.insert("User-Agent-Policies", HeaderValue::from_str(&header_value_str).unwrap());
+                    log::info!("Headers: {:?}", headers);
                 } else {
                     log::error!("Invalid header value");
                 }


### PR DESCRIPTION
Fixes https://github.com/devdiv-microsoft/basis-planning/issues/1658

### Changes proposed: 
- Before sending the User-Agent-Policies header, we need to re-encode the header value to ensure that it is correctly formatted. This manually reencodes the " and ; as they are the only accepted characters in this field. Old value looked like %22tenantId%3DtenantId%22
- Adds formatting changes
