### PR TITLE
Implement ssh keep-alive for Tunnels C# SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dev tunnels allows developers to securely expose local web services to the Inter
 | Reconnection | ✅ | ✅ | ❌ | ❌ | ❌ |
 | SSH-level Reconnection | ✅ | ✅ | ❌ | ❌ | ❌ |
 | Automatic tunnel access token refresh | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Ssh Keep-alive | ✅ | 🗓️ | ❌ | ❌ | ❌ |
 
 ✅ - Supported  
 🚧 - In Progress  

--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -41,7 +41,7 @@
     <ReportGeneratorVersion>5.3.9</ReportGeneratorVersion>
     <SystemTextEncodingsWebPackageVersion>4.7.2</SystemTextEncodingsWebPackageVersion>
     <VisualStudioValidationVersion>15.5.31</VisualStudioValidationVersion>
-    <DevTunnelsSshPackageVersion>3.12.5</DevTunnelsSshPackageVersion>
+    <DevTunnelsSshPackageVersion>3.12.8</DevTunnelsSshPackageVersion>
     <XunitRunnerVisualStudioVersion>2.4.0</XunitRunnerVisualStudioVersion>
     <XunitVersion>2.4.0</XunitVersion>
   </PropertyGroup>

--- a/cs/src/Connections/IRelayClient.cs
+++ b/cs/src/Connections/IRelayClient.cs
@@ -51,7 +51,7 @@ internal interface IRelayClient
 
     /// <summary>
     /// Create stream to the tunnel.
-    /// If this method succeeds, <see cref="ConfigureSessionAsync(Stream, bool, CancellationToken)"/> will be called.
+    /// If this method succeeds, <see cref="ConfigureSessionAsync(Stream, bool, TunnelConnectionOptions?, CancellationToken)"/> will be called.
     /// If this method fails, depending on <see cref="TunnelConnectionOptions.EnableRetry"/> and failure, tunnel client may try reconnecting.
     /// </summary>
     Task<Stream> CreateSessionStreamAsync(CancellationToken cancellation);
@@ -66,7 +66,7 @@ internal interface IRelayClient
     /// If this method succeeds, the SSH session must be connected and ready.
     /// If this method fails, depending on <see cref="TunnelConnectionOptions.EnableRetry"/> and failure, tunnel client may try reconnecting.
     /// </summary>
-    Task ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation);
+    Task ConfigureSessionAsync(Stream stream, bool isReconnect, TunnelConnectionOptions? options, CancellationToken cancellation);
 
     /// <summary>
     /// Closes tunnel SSH session due to an error or exception happened during connection.

--- a/cs/src/Connections/ITunnelClient.cs
+++ b/cs/src/Connections/ITunnelClient.cs
@@ -193,5 +193,15 @@ public interface ITunnelClient : IAsyncDisposable
     /// Connection status changed event.
     /// </summary>
     event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
+
+    /// <summary>
+    /// Event raised when a keep-alive message respose is not received.
+    /// </summary>
+    /// <remarks>
+    /// The event args provide the count of keep-alive messages that did not get a response within the
+    /// configured <see cref="TunnelConnectionOptions.KeepAliveIntervalInSeconds"/>. This callback is only invoked
+    /// if the keep-alive interval is greater than 0.
+    /// </remarks>
+    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveRequestFailed;
 }
 

--- a/cs/src/Connections/ITunnelClient.cs
+++ b/cs/src/Connections/ITunnelClient.cs
@@ -195,13 +195,13 @@ public interface ITunnelClient : IAsyncDisposable
     event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
 
     /// <summary>
-    /// Event raised when a keep-alive message respose is not received.
+    /// Event raised when a keep-alive message response is not received.
     /// </summary>
     /// <remarks>
     /// The event args provide the count of keep-alive messages that did not get a response within the
     /// configured <see cref="TunnelConnectionOptions.KeepAliveIntervalInSeconds"/>. This callback is only invoked
     /// if the keep-alive interval is greater than 0.
     /// </remarks>
-    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveRequestFailed;
+    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveFailed;
 }
 

--- a/cs/src/Connections/ITunnelHost.cs
+++ b/cs/src/Connections/ITunnelHost.cs
@@ -129,12 +129,12 @@ public interface ITunnelHost : IAsyncDisposable
     event EventHandler<ForwardedPortConnectingEventArgs>? ForwardedPortConnecting;
     
     /// <summary>
-    /// Event raised when a keep-alive message respose is not received.
+    /// Event raised when a keep-alive message response is not received.
     /// </summary>
     /// <remarks>
     /// The event args provide the count of keep-alive messages that did not get a response within the
     /// configured <see cref="TunnelConnectionOptions.KeepAliveIntervalInSeconds"/>. This callback is only invoked
     /// if the keep-alive interval is greater than 0.
     /// </remarks>
-    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveRequestFailed;
+    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveFailed;
 }

--- a/cs/src/Connections/ITunnelHost.cs
+++ b/cs/src/Connections/ITunnelHost.cs
@@ -127,4 +127,14 @@ public interface ITunnelHost : IAsyncDisposable
     /// ForwardedPortConnecting event will be raised.
     /// </remarks>
     event EventHandler<ForwardedPortConnectingEventArgs>? ForwardedPortConnecting;
+    
+    /// <summary>
+    /// Event raised when a keep-alive message respose is not received.
+    /// </summary>
+    /// <remarks>
+    /// The event args provide the count of keep-alive messages that did not get a response within the
+    /// configured <see cref="TunnelConnectionOptions.KeepAliveIntervalInSeconds"/>. This callback is only invoked
+    /// if the keep-alive interval is greater than 0.
+    /// </remarks>
+    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveRequestFailed;
 }

--- a/cs/src/Connections/RelayTunnelConnector.cs
+++ b/cs/src/Connections/RelayTunnelConnector.cs
@@ -70,7 +70,7 @@ internal sealed class RelayTunnelConnector : ITunnelConnector
 
                     // TODO: check tunnel access token expiration and try refresh it if it's expired.
                     stream = await this.relayClient.CreateSessionStreamAsync(cts.Token);
-                    await this.relayClient.ConfigureSessionAsync(stream, isReconnect, cts.Token);
+                    await this.relayClient.ConfigureSessionAsync(stream, isReconnect, options, cts.Token);
 
                     stream = null;
                     disconnectReason = SshDisconnectReason.None;

--- a/cs/src/Connections/SshKeepAliveFailureEventArgs.cs
+++ b/cs/src/Connections/SshKeepAliveFailureEventArgs.cs
@@ -1,0 +1,27 @@
+// <copyright file="SshKeepAliveFailureEventArgs.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+// </copyright>
+
+using System;
+
+namespace Microsoft.DevTunnels.Connections;
+
+/// <summary>
+/// Event raised when a keep-alive message respose is not received.
+/// </summary>
+public class SshKeepAliveFailureEventArgs : EventArgs
+{
+    /// <summary>
+    /// Create a new instance of <see cref="SshKeepAliveFailureEventArgs"/>.
+    /// </summary>
+	public SshKeepAliveFailureEventArgs(int count)
+	{
+		Count = count;
+	}
+
+	/// <summary>
+	/// The number of keep-alive messages that have been sent without a response.
+	/// </summary>
+	public int Count { get; }
+}

--- a/cs/src/Connections/TunnelClient.cs
+++ b/cs/src/Connections/TunnelClient.cs
@@ -169,7 +169,7 @@ public abstract class TunnelClient : TunnelRelayConnection, ITunnelClient
     /// Overwrites <see cref="SshSession"/> property.
     /// SSH session reconnect is enabled only if <see cref="TunnelConnection.connector"/> is not null.
     /// </remarks>
-    protected async Task StartSshSessionAsync(Stream stream, CancellationToken cancellation)
+    protected async Task StartSshSessionAsync(Stream stream, TunnelConnectionOptions? options, CancellationToken cancellation)
     {
         var session = this.SshSession;
         if (session != null)
@@ -196,11 +196,20 @@ public abstract class TunnelClient : TunnelRelayConnection, ITunnelClient
             clientConfig.KeyExchangeAlgorithms.Add(SshAlgorithms.KeyExchange.DHGroup14Sha256);
         }
 
+        if (options?.KeepAliveIntervalInSeconds > 0)
+        {
+            clientConfig.KeepAliveTimeoutInSeconds = options.KeepAliveIntervalInSeconds;
+        }
+
         // Enable port-forwarding via the SSH protocol.
         clientConfig.AddService(typeof(PortForwardingService));
 
         session = new SshClientSession(clientConfig, Trace.WithName("SSH"));
         SshSession = session;
+        session.KeepAliveRequestFailed += (_, e) =>
+        {
+            OnKeepAliveRequestFailed(e.Count);
+        };
         SshPortForwardingService = session.ActivateService<PortForwardingService>();
         ConfigurePortForwardingService();
         SubscribeSessionEvents(session);

--- a/cs/src/Connections/TunnelClient.cs
+++ b/cs/src/Connections/TunnelClient.cs
@@ -208,7 +208,7 @@ public abstract class TunnelClient : TunnelRelayConnection, ITunnelClient
         SshSession = session;
         session.KeepAliveRequestFailed += (_, e) =>
         {
-            OnKeepAliveRequestFailed(e.Count);
+            OnKeepAliveFailed(e.Count);
         };
         SshPortForwardingService = session.ActivateService<PortForwardingService>();
         ConfigurePortForwardingService();

--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -258,14 +258,14 @@ public abstract class TunnelConnection : IAsyncDisposable
     public event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
 
     /// <summary>
-    /// Event raised when a keep-alive message respose is not received.
+    /// Event raised when a keep-alive message response is not received.
     /// </summary>
     /// <remarks>
     /// The event args provide the count of keep-alive messages that did not get a response within the
     /// configured <see cref="TunnelConnectionOptions.KeepAliveIntervalInSeconds"/>. This callback is only invoked
     /// if the keep-alive interval is greater than 0.
     /// </remarks>
-    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveRequestFailed;
+    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveFailed;
 
     /// <summary>
     /// Fetch the tunnel from the service if <see cref="ManagementClient"/> and <see cref="Tunnel"/> are not null.
@@ -358,10 +358,9 @@ public abstract class TunnelConnection : IAsyncDisposable
     /// <summary>
     /// Event raised when a keep-alive message response is not received.
     /// </summary>
-    protected virtual void OnKeepAliveRequestFailed(int count)
+    protected virtual void OnKeepAliveFailed(int count)
     {
-        var e = new SshKeepAliveFailureEventArgs(count);
-        KeepAliveRequestFailed?.Invoke(this, e);
+        KeepAliveFailed?.Invoke(this, new SshKeepAliveFailureEventArgs(count));
     }
 
     /// <inheritdoc />

--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -258,6 +258,16 @@ public abstract class TunnelConnection : IAsyncDisposable
     public event EventHandler<ConnectionStatusChangedEventArgs>? ConnectionStatusChanged;
 
     /// <summary>
+    /// Event raised when a keep-alive message respose is not received.
+    /// </summary>
+    /// <remarks>
+    /// The event args provide the count of keep-alive messages that did not get a response within the
+    /// configured <see cref="TunnelConnectionOptions.KeepAliveIntervalInSeconds"/>. This callback is only invoked
+    /// if the keep-alive interval is greater than 0.
+    /// </remarks>
+    public event EventHandler<SshKeepAliveFailureEventArgs>? KeepAliveRequestFailed;
+
+    /// <summary>
     /// Fetch the tunnel from the service if <see cref="ManagementClient"/> and <see cref="Tunnel"/> are not null.
     /// </summary>
     /// <returns><c>true</c> if <see cref="Tunnel"/> was refreshed; otherwise, <c>false</c>.</returns>
@@ -343,6 +353,15 @@ public abstract class TunnelConnection : IAsyncDisposable
 
         this.accessToken = await eventArgs.TunnelAccessTokenTask.ConfigureAwait(false);
         return true;
+    }
+
+    /// <summary>
+    /// Event raised when a keep-alive message response is not received.
+    /// </summary>
+    protected virtual void OnKeepAliveRequestFailed(int count)
+    {
+        var e = new SshKeepAliveFailureEventArgs(count);
+        KeepAliveRequestFailed?.Invoke(this, e);
     }
 
     /// <inheritdoc />

--- a/cs/src/Connections/TunnelConnectionOptions.cs
+++ b/cs/src/Connections/TunnelConnectionOptions.cs
@@ -65,12 +65,12 @@ public class TunnelConnectionOptions
     /// <summary>
     /// Gets or sets the ssh keep-alive interval in seconds. The default value is 0, which means no keep-alive.
     /// When set to a positive value, the client will send keep-alive messages to the server
-    /// and calls the <see cref="TunnelConnection.KeepAliveRequestFailed"/> callback with the number of times
+    /// and calls the <see cref="TunnelConnection.KeepAliveFailed"/> callback with the number of times
     /// the keep-alive is sent without a response.
     /// 
-    /// The KeepAliveRequestFailed event is raised at the time of sending the next keep-alive request,
+    /// The KeepAliveFailed event is raised at the time of sending the next keep-alive request,
     /// for example if the interval is set to 10 seconds the first request is sent after 10 seconds of inactivity
-    /// and waits for 10 more seconds to call the KeepAliveRequestFailed callback before sending another
+    /// and waits for 10 more seconds to call the KeepAliveFailed callback before sending another
     /// keep-alive request.
     /// </summary>
     public int KeepAliveIntervalInSeconds { get; set; } = 0;

--- a/cs/src/Connections/TunnelConnectionOptions.cs
+++ b/cs/src/Connections/TunnelConnectionOptions.cs
@@ -61,4 +61,17 @@ public class TunnelConnectionOptions
     /// (most common). This option applies only to client connections.
     /// </summary>
     public string? HostId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ssh keep-alive interval in seconds. The default value is 0, which means no keep-alive.
+    /// When set to a positive value, the client will send keep-alive messages to the server
+    /// and calls the <see cref="TunnelConnection.KeepAliveRequestFailed"/> callback with the number of times
+    /// the keep-alive is sent without a response.
+    /// 
+    /// The KeepAliveRequestFailed event is raised at the time of sending the next keep-alive request,
+    /// for example if the interval is set to 10 seconds the first request is sent after 10 seconds of inactivity
+    /// and waits for 10 more seconds to call the KeepAliveRequestFailed callback before sending another
+    /// keep-alive request.
+    /// </summary>
+    public int KeepAliveIntervalInSeconds { get; set; } = 0;
 }

--- a/cs/src/Connections/TunnelRelayConnection.cs
+++ b/cs/src/Connections/TunnelRelayConnection.cs
@@ -265,6 +265,7 @@ public abstract class TunnelRelayConnection : TunnelConnection, IRelayClient, IP
     protected abstract Task ConfigureSessionAsync(
         Stream stream,
         bool isReconnect,
+        TunnelConnectionOptions? options,
         CancellationToken cancellation);
 
     /// <summary>
@@ -481,8 +482,9 @@ public abstract class TunnelRelayConnection : TunnelConnection, IRelayClient, IP
     Task IRelayClient.ConfigureSessionAsync(
         Stream stream,
         bool isReconnect,
+        TunnelConnectionOptions? options,
         CancellationToken cancellation) =>
-        ConfigureSessionAsync(stream, isReconnect, cancellation);
+        ConfigureSessionAsync(stream, isReconnect, options, cancellation);
 
     /// <inheritdoc />
     Task IRelayClient.CloseSessionAsync(SshDisconnectReason disconnectReason, Exception? exception) =>

--- a/cs/src/Connections/TunnelRelayTunnelClient.cs
+++ b/cs/src/Connections/TunnelRelayTunnelClient.cs
@@ -128,7 +128,11 @@ public class TunnelRelayTunnelClient : TunnelClient
     /// <summary>
     /// Configures tunnel SSH session with the given stream.
     /// </summary>
-    protected override async Task ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
+    protected override async Task ConfigureSessionAsync(
+        Stream stream,
+        bool isReconnect,
+        TunnelConnectionOptions? options,
+        CancellationToken cancellation)
     {
         var session = SshSession;
         if (isReconnect && session != null && !session.IsClosed)
@@ -137,7 +141,7 @@ public class TunnelRelayTunnelClient : TunnelClient
         }
         else
         {
-            await StartSshSessionAsync(stream, cancellation);
+            await StartSshSessionAsync(stream, options, cancellation);
         }
     }
 }

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -209,7 +209,7 @@ public class TunnelRelayTunnelHost : TunnelHost
         
         session.KeepAliveRequestFailed += (_, e) =>
         {
-            OnKeepAliveRequestFailed(e.Count);
+            OnKeepAliveFailed(e.Count);
         };
 
         SshSession = session;

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -172,15 +172,15 @@ public class TunnelRelayTunnelHost : TunnelHost
     }
 
     /// <inheritdoc />
-    protected override async Task ConfigureSessionAsync(Stream stream, bool isReconnect, CancellationToken cancellation)
+    protected override async Task ConfigureSessionAsync(Stream stream, bool isReconnect, TunnelConnectionOptions? options, CancellationToken cancellation)
     {
         SshClientSession session;
         if (ConnectionProtocol == WebSocketSubProtocol)
         {
             // The V1 protocol always configures no security, equivalent to SSH MultiChannelStream.
             // The websocket transport is still encrypted and authenticated.
-            session = new SshClientSession(
-                SshSessionConfiguration.NoSecurity, Trace.WithName("HostSSH"));
+            var sessionConfig = new SshSessionConfiguration(useSecurity: false) { KeepAliveTimeoutInSeconds = options?.KeepAliveIntervalInSeconds ?? 0 };
+            session = new SshClientSession(sessionConfig, Trace.WithName("HostSSH"));
         }
         else
         {
@@ -196,11 +196,21 @@ public class TunnelRelayTunnelHost : TunnelHost
             config.KeyExchangeAlgorithms.Add(SshAlgorithms.KeyExchange.DHGroup14Sha256);
 
             config.AddService(typeof(PortForwardingService));
+            if (options?.KeepAliveIntervalInSeconds > 0)
+            {
+                config.KeepAliveTimeoutInSeconds = options.KeepAliveIntervalInSeconds;
+            }
+            
             session = new SshClientSession(config, Trace.WithName("HostSSH"));
 
             var hostPfs = session.ActivateService<PortForwardingService>();
             hostPfs.MessageFactory = this;
         }
+        
+        session.KeepAliveRequestFailed += (_, e) =>
+        {
+            OnKeepAliveRequestFailed(e.Count);
+        };
 
         SshSession = session;
         SubscribeSessionEvents(session);


### PR DESCRIPTION
Implement support for keep alive messages in SSH layer. Providing `KeepAliveIntervalInSeconds` to the SDK will send keep-alive messages to the server at the specified interval. And calls the `KeepAliveRequestFailed` event if the server does not respond to the keep-alive message.