### PR TITLE
Fix nullability for tunnel CORS options

### DIFF
--- a/cs/src/Contracts/TunnelOptions.cs
+++ b/cs/src/Contracts/TunnelOptions.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DevTunnels.Contracts
         /// This only applies to tunnels that require authentication.
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public bool IsCrossSiteAuthenticationEnabled { get; set; }
+        public bool? IsCrossSiteAuthenticationEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the tunnel web-forwarding authentication cookie is set as
@@ -93,6 +93,6 @@ namespace Microsoft.DevTunnels.Contracts
         /// A partitioned cookie always also has SameSite=None for compatbility with browsers that do not support partitioning.
         /// </remarks>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public bool IsPartitionedSiteAuthenticationEnabled { get; set; }
+        public bool? IsPartitionedSiteAuthenticationEnabled { get; set; }
     }
 }

--- a/rs/src/contracts/tunnel_options.rs
+++ b/rs/src/contracts/tunnel_options.rs
@@ -59,7 +59,7 @@ pub struct TunnelOptions {
     // SameSite=None. The default is false, which means the cookie is marked as
     // SameSite=Lax. This only applies to tunnels that require authentication.
     #[serde(default)]
-    pub is_cross_site_authentication_enabled: bool,
+    pub is_cross_site_authentication_enabled: Option<bool>,
 
     // Gets or sets a value indicating whether the tunnel web-forwarding authentication
     // cookie is set as Partitioned (CHIPS). The default is false. This only applies to
@@ -68,5 +68,5 @@ pub struct TunnelOptions {
     // A partitioned cookie always also has SameSite=None for compatbility with browsers
     // that do not support partitioning.
     #[serde(default)]
-    pub is_partitioned_site_authentication_enabled: bool,
+    pub is_partitioned_site_authentication_enabled: Option<bool>,
 }


### PR DESCRIPTION
The two new CORS-related options `IsCrossSiteAuthenticationEnabled` and `IsPartitionedSiteAuthenticationEnabled` can be applied to tunnel and/or to specific port(s) of a tunnel. The properties should be nullable so that a null value for a port means it will inherit the setting from the tunnel (if non-null) while a non-null true or false for a port would override any tunnel-level setting.

The properties were already nullable in the auto-generated TypeScript contract, so there are no changes there.