### PR TITLE
Fix `ListTunnelPorts` in Go

### DIFF
--- a/go/tunnels/manager.go
+++ b/go/tunnels/manager.go
@@ -410,8 +410,8 @@ func (m *Manager) ListTunnelPorts(
 		return nil, fmt.Errorf("error parsing response json to tunnel ports: %w", err)
 	}
 
-	for _, port := range tunnelPortsResponse.Value {
-		tp = append(tp, &port)
+	for i := range tunnelPortsResponse.Value {
+		tp = append(tp, &tunnelPortsResponse.Value[i])
 	}
 
 	return tp, nil

--- a/go/tunnels/manager_test.go
+++ b/go/tunnels/manager_test.go
@@ -653,6 +653,15 @@ func TestTunnelListPorts(t *testing.T) {
 	if len(ports) != 2 {
 		t.Errorf("ports not successfully listed")
 	}
+
+	if ports[0].PortNumber != 3000 {
+		t.Errorf("port 3000 not successfully listed")
+	}
+
+	if ports[1].PortNumber != 3001 {
+		t.Errorf("port 3001 not successfully listed")
+	}
+
 	for _, port := range ports {
 		logger.Printf("Port: %d", port.PortNumber)
 		port.Table().Print()

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.1.18"
+const PackageVersion = "0.1.19"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{


### PR DESCRIPTION
## Description

Hey folks, while debugging `gh cs ssh` I noticed that `ListTunnelPorts` was returning the same port in every element of the slice. In a for loop, a new address is created for the loopvar. Appending the pointer of the loopvar to a slice means that every element in the slice will point to the last element ranged over.

`TestTunnelListPorts` in `manager_test.go` only checks that 2 ports were returning and doesn't interrogate the actual values, which is why this didn't fail. I would have updated the test but I didn't really want to figure out how to run them since they require a token.

I have no idea whether the tasks below are required for this change.

### Other Tasks:

- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [ ] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
