### PR TITLE
Add session ID properties to connection events reporting

### DIFF
--- a/cs/src/Connections/SshSessionExtensions.cs
+++ b/cs/src/Connections/SshSessionExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.DevTunnels.Ssh;
+
+namespace Microsoft.DevTunnels.Connections;
+
+internal static class SshSessionExtensions
+{
+    public static string GetShortSessionId(this SshSession session)
+    {
+        if (session.SessionId == null || session.SessionId.Length < 16)
+        {
+            return string.Empty;
+        }
+
+        return new Guid(session.SessionId.AsSpan(0, 16)).ToString();
+    }
+}

--- a/cs/src/Connections/TunnelClient.cs
+++ b/cs/src/Connections/TunnelClient.cs
@@ -140,7 +140,7 @@ public abstract class TunnelClient : TunnelRelayConnection, ITunnelClient
         Requires.NotNull(tunnel, nameof(tunnel));
         Requires.NotNull(tunnel.Endpoints!, nameof(Tunnel.Endpoints));
 
-        if (this.SshSession != null)
+        if (this.SshSession?.IsConnected == true)
         {
             throw new InvalidOperationException(
                 "Already connected. Use separate instances to connect to multiple tunnels.");
@@ -240,6 +240,7 @@ public abstract class TunnelClient : TunnelRelayConnection, ITunnelClient
 
     private void OnSshSessionDisconnected(object? sender, EventArgs e) =>
         MaybeStartReconnecting(
+            (SshSession)sender!,
             SshDisconnectReason.ConnectionLost,
             exception: new SshConnectionException("Connection lost.", SshDisconnectReason.ConnectionLost));
 

--- a/cs/src/Connections/TunnelConnection.cs
+++ b/cs/src/Connections/TunnelConnection.cs
@@ -22,7 +22,6 @@ public abstract class TunnelConnection : IAsyncDisposable
 {
     private readonly CancellationTokenSource disposeCts = new();
     private ConnectionStatus connectionStatus;
-    private Stopwatch connectionTimer = new();
     private Tunnel? tunnel;
 
     /// <summary>
@@ -423,25 +422,6 @@ public abstract class TunnelConnection : IAsyncDisposable
         ConnectionStatus previousConnectionStatus,
         ConnectionStatus connectionStatus)
     {
-        TimeSpan duration = this.connectionTimer.Elapsed;
-        this.connectionTimer.Restart();
-
-        if (Tunnel != null)
-        {
-            var statusEvent = new TunnelEvent($"{ConnectionRole}_connection_status");
-            statusEvent.Properties = new Dictionary<string, string>
-            {
-                [nameof(ConnectionStatus)] = connectionStatus.ToString(),
-                [$"Previous{nameof(ConnectionStatus)}"] = previousConnectionStatus.ToString(),
-            };
-            if (previousConnectionStatus != ConnectionStatus.None)
-            {
-                statusEvent.Properties[$"{previousConnectionStatus}Duration"] = duration.ToString();
-            }
-
-            ManagementClient?.ReportEvent(Tunnel, statusEvent);
-        }
-
         var handler = ConnectionStatusChanged;
         if (handler != null)
         {

--- a/cs/src/Connections/TunnelRelayTunnelHost.cs
+++ b/cs/src/Connections/TunnelRelayTunnelHost.cs
@@ -59,6 +59,9 @@ public class TunnelRelayTunnelHost : TunnelHost
         this.hostId = MultiModeTunnelHost.HostId;
     }
 
+    /// <inheritdoc/>
+    protected override string ConnectionId => this.hostId;
+
     /// <summary>
     /// Get or set synthetic endpoint signature for the endpoint created for the host
     /// when connecting.
@@ -426,6 +429,8 @@ public class TunnelRelayTunnelHost : TunnelHost
                     connectedEvent.Properties = new Dictionary<string, string>
                     {
                         ["ClientChannelId"] = channelId.ToString(),
+                        ["ClientSessionId"] = session.GetShortSessionId(),
+                        ["HostSessionId"] = ConnectionId,
                     };
                     ManagementClient?.ReportEvent(Tunnel, connectedEvent);
                 }
@@ -456,12 +461,15 @@ public class TunnelRelayTunnelHost : TunnelHost
 
         async void OnSshClientReconnected(object? sender, EventArgs e)
         {
+            var session = (SshSession)sender!;
             if (Tunnel != null)
             {
                 var reconnectedEvent = new TunnelEvent($"host_client_reconnect");
                 reconnectedEvent.Properties = new Dictionary<string, string>
                 {
                     ["ClientChannelId"] = channelId.ToString(),
+                    ["ClientSessionId"] = session.GetShortSessionId(),
+                    ["HostSessionId"] = ConnectionId,
                 };
                 ManagementClient?.ReportEvent(Tunnel, reconnectedEvent);
             }
@@ -473,7 +481,8 @@ public class TunnelRelayTunnelHost : TunnelHost
 
         void OnClientSessionClosed(object? sender, SshSessionClosedEventArgs e)
         {
-            TraceSource trace = ((SshSession)sender!).Trace;
+            var session = (SshSession)sender!;
+            var trace = session.Trace;
             string? details = null;
             string? severity = null;
 
@@ -510,6 +519,8 @@ public class TunnelRelayTunnelHost : TunnelHost
                 disconnectedEvent.Properties = new Dictionary<string, string>
                 {
                     ["ClientChannelId"] = channelId.ToString(),
+                    ["ClientSessionId"] = session.GetShortSessionId(),
+                    ["HostSessionId"] = ConnectionId,
                 };
                 ManagementClient?.ReportEvent(Tunnel, disconnectedEvent);
             }


### PR DESCRIPTION
Add host and client session IDs to connection events reporting. This allows for correlation of connection events during a session lifetime and correlation of host and client sessions. Also report the websocket HTTP request ID for the connection (in C# only; the header is not available in JS).