### PR TITLE
Use EnableEventsReporting flag in C# client

### DIFF
--- a/cs/src/Management/TunnelManagementClient.cs
+++ b/cs/src/Management/TunnelManagementClient.cs
@@ -1692,6 +1692,11 @@ namespace Microsoft.DevTunnels.Management
                 return;
             }
 
+            if (!EnableEventsReporting)
+            {
+                return;
+            }
+
             lock (this.eventsQueue)
             {
                 if (this.isDisposed)


### PR DESCRIPTION
Apply the `EnableEventsReporting` flag in the C# management client, the same as [in TS](https://github.com/microsoft/dev-tunnels/blob/fab4fe74d6de5e28c7a65f33483233ba6d3cf8fc/ts/src/management/tunnelManagementHttpClient.ts#L824).