### PR TITLE
Allow colon in ACE subject name to support repo URIs

### DIFF
--- a/cs/src/Contracts/TunnelConstraints.cs
+++ b/cs/src/Contracts/TunnelConstraints.cs
@@ -369,7 +369,7 @@ public static class TunnelConstraints
     /// formatted name with email. The service will block any other use of angle-brackets,
     /// to avoid any XSS risks.
     /// </remarks>
-    public const string AccessControlSubjectNamePattern = "[ \\w\\d-.,/'\"_@()<>]{0,200}";
+    public const string AccessControlSubjectNamePattern = "[ \\w\\d-.,/:'\"_@()<>]{0,200}";
 
     /// <summary>
     /// Regular expression that can match or validate an access control subject name, when resolving

--- a/go/tunnels/tunnel_constraints.go
+++ b/go/tunnels/tunnel_constraints.go
@@ -156,7 +156,7 @@ const (
 	// Note angle-brackets are only allowed when they wrap an email address as part of a
 	// formatted name with email. The service will block any other use of angle-brackets, to
 	// avoid any XSS risks.
-	TunnelConstraintsAccessControlSubjectNamePattern = "[ \\w\\d-.,/'\"_@()<>]{0,200}"
+	TunnelConstraintsAccessControlSubjectNamePattern = "[ \\w\\d-.,/:'\"_@()<>]{0,200}"
 )
 var (
 	// Regular expression that can match or validate tunnel cluster ID strings.

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelConstraints.java
@@ -298,7 +298,7 @@ public class TunnelConstraints {
      * formatted name with email. The service will block any other use of angle-brackets,
      * to avoid any XSS risks.
      */
-    public static final String accessControlSubjectNamePattern = "[ \\w\\d-.,/'\"_@()<>]{0,200}";
+    public static final String accessControlSubjectNamePattern = "[ \\w\\d-.,/:'\"_@()<>]{0,200}";
 
     /**
      * Regular expression that can match or validate an access control subject name, when

--- a/rs/src/contracts/tunnel_constraints.rs
+++ b/rs/src/contracts/tunnel_constraints.rs
@@ -150,4 +150,4 @@ pub const ACCESS_CONTROL_SUBJECT_PATTERN: &str = r#"[0-9a-zA-Z-._:/@]{0,200}"#;
 // Note angle-brackets are only allowed when they wrap an email address as part of a
 // formatted name with email. The service will block any other use of angle-brackets, to
 // avoid any XSS risks.
-pub const ACCESS_CONTROL_SUBJECT_NAME_PATTERN: &str = r#"[ \w\d-.,/'"_@()<>]{0,200}"#;
+pub const ACCESS_CONTROL_SUBJECT_NAME_PATTERN: &str = r#"[ \w\d-.,/:'"_@()<>]{0,200}"#;

--- a/ts/src/contracts/tunnelConstraints.ts
+++ b/ts/src/contracts/tunnelConstraints.ts
@@ -295,7 +295,7 @@ export namespace TunnelConstraints {
      * formatted name with email. The service will block any other use of angle-brackets,
      * to avoid any XSS risks.
      */
-    export const accessControlSubjectNamePattern: string = '[ \\w\\d-.,/\'"_@()<>]{0,200}';
+    export const accessControlSubjectNamePattern: string = '[ \\w\\d-.,/:\'"_@()<>]{0,200}';
 
     /**
      * Regular expression that can match or validate an access control subject name, when


### PR DESCRIPTION
We're considering support for tunnel access control entries of type `Repositories` (which was previously declared but not implemented). To support repo URIs, the ACE subject name regex should allow the `:` character. 