### PR TITLE
Adding test pipeline for Symbols publishing AAD auth

### DIFF
--- a/.pipelines/symbols-aad-test.yaml
+++ b/.pipelines/symbols-aad-test.yaml
@@ -1,0 +1,27 @@
+# symbols-aadtest.yml
+# Minimal test for Entra (AAD) auth for PublishSymbols@2
+
+pool:
+  name: VSEngSS-MicroBuild2022-1ES
+
+trigger: none
+pr: none
+
+steps:
+# Create a tiny dummy "PDB" file so the task has something to upload.
+# (We only care that auth succeeds and the task can create/upload a request.)
+- powershell: |
+    $out = "$(Build.SourcesDirectory)\_symtest"
+    New-Item -ItemType Directory -Force -Path $out | Out-Null
+    # dummy file; PublishSymbols will match *.pdb
+    Set-Content -Path (Join-Path $out "dummy.pdb") -Value "not-a-real-pdb"
+    Write-Host "Created test symbols folder: $out"
+  displayName: "Create dummy symbol file"
+
+- task: PublishSymbols@2
+  displayName: "PublishSymbols@2 (AAD smoke test)"
+  inputs:
+    SymbolsFolder: '$(Build.SourcesDirectory)\_symtest'
+    SearchPattern: '**\*.pdb'
+    SymbolServerType: 'TeamServices'
+    SymbolExpirationInDays: '2'


### PR DESCRIPTION
Fixes #

### Changes proposed: 

Dummy/temporary pipeline to test Symbols publishing with AAD auth. Unfortunately, it needs to be in main as Azure DevOps does not supporting creating pipelines from branches.

