### PR TITLE
Build pipeline: disabling an expected warning

### DIFF
--- a/.pipelines/cs-ci-build.yaml
+++ b/.pipelines/cs-ci-build.yaml
@@ -91,6 +91,7 @@ steps:
     SymbolsAgentPath: '$(Pipeline.Workspace)\Symbols'
     SubmitToInternet: false
     ExpirationInDays: 1095
+    SuppressSymwebOnlyWarning: true
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)  # required by task per WIF migration guidance [1](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/49030)
 


### PR DESCRIPTION
Fixes #

### Changes proposed: 

Disabled the following warning in the CI pipeline, as the behavior is intended and by design:
##[warning]DevTunnels-Dev-Tunnels-SDK-CSharp-CI-Build-1.3.15-13463989-260305183406 will be published to Symweb only. Is that your intention? Surpress this message by setting SuppressSymwebOnlyWarning to true.


