### PR TITLE
Fix TLS certificate validation in Java SDK WebSocket relay connections

### DIFF
--- a/java/src/main/java/com/microsoft/tunnels/websocket/WebSocketConnector.java
+++ b/java/src/main/java/com/microsoft/tunnels/websocket/WebSocketConnector.java
@@ -19,6 +19,9 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.net.SocketAddress;
 import java.net.URI;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
 import org.apache.sshd.common.AttributeRepository;
 import org.apache.sshd.common.io.IoConnectFuture;
 import org.apache.sshd.common.io.IoHandler;
@@ -69,9 +72,27 @@ public class WebSocketConnector extends NettyIoConnector {
 
           ChannelPipeline p = ch.pipeline();
           if (factory.webSocketUri.getScheme().equals("wss")) {
-            SslContext sslContext = SslContextBuilder.forClient()
-                .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
-            p.addLast("ssl", new SslHandler(sslContext.newEngine(ch.alloc())));
+            String host = factory.webSocketUri.getHost();
+            boolean isLocalDev = "localhost".equals(host)
+                || "tunnels.local.api.visualstudio.com".equals(host);
+
+            SslContextBuilder builder = SslContextBuilder.forClient();
+            if (isLocalDev) {
+              builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
+            }
+            SslContext sslContext = builder.build();
+
+            var relayPort = factory.webSocketUri.getPort();
+            if (relayPort == -1) {
+              relayPort = 443;
+            }
+            SSLEngine engine = sslContext.newEngine(ch.alloc(), host, relayPort);
+            if (!isLocalDev) {
+              SSLParameters params = engine.getSSLParameters();
+              params.setEndpointIdentificationAlgorithm("HTTPS");
+              engine.setSSLParameters(params);
+            }
+            p.addLast("ssl", new SslHandler(engine));
           }
           p.addLast(new HttpClientCodec());
           p.addLast(new HttpObjectAggregator(8192));


### PR DESCRIPTION
The Java SDK’s WebSocketConnector did not fully enforce TLS certificate verification for secure relay connections. This reduced the overall security of the connection and could have allowed unauthorized interaction under certain network conditions.

### Changes proposed: 
 - WebSocketConnector.java: The SSL context now uses the JDK's default trust manager for production relay connections, which properly validates server certificates against the system's trusted CA store.
 - Localhost exceptions are preserved for local development (localhost and tunnels.local.api.visualstudio.com), matching the pattern used by the Go SDK.

### Other Tasks:

- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [ ] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
