### PR TITLE
Update DEV environment 3PA app IDs for new Tunnels 3PA DEV app in Test Tenant

### DIFF
--- a/cs/src/Contracts/TunnelServiceProperties.cs
+++ b/cs/src/Contracts/TunnelServiceProperties.cs
@@ -51,14 +51,14 @@ public class TunnelServiceProperties
     internal const string PpeFirstPartyAppId = "54c45752-bacd-424a-b928-652f3eca2b18";
 
     /// <summary>
-    /// Third-party app ID: `DEV-VSTunnelService-3P`
+    /// Third-party app ID for the DEV service environment.
     /// </summary>
     /// <remarks>
-    /// Used for authenticating AAD/MSA users, and service principals outside the AME tenant,
-    /// in the DEV service environment.
-    /// This is a 3P app registration in the Microsoft corp tenant, replacing the former 1P FPA.
+    /// A 3PA registered in the test tenant, used for authenticating AAD/MSA users
+    /// and service principals outside the AME tenant. Replaces the former 1P FPA
+    /// (9c63851a) which was disabled.
     /// </remarks>
-    internal const string DevFirstPartyAppId = "906ce216-6f2e-40be-875d-7fe1a9bc288a";
+    internal const string DevServiceAppId = "686ab1c6-3cd9-4a62-b228-4f71eaaaf53e";
 
     /// <summary>
     /// Third-party app ID: `tunnels-prod-app-sp`
@@ -158,7 +158,7 @@ public class TunnelServiceProperties
     /// </summary>
     public static TunnelServiceProperties Development { get; } = new TunnelServiceProperties(
         $"https://{DevDnsName}/",
-        DevFirstPartyAppId,
+        DevServiceAppId,
         DevThirdPartyAppId,
         DevGitHubAppClientId);
 
@@ -171,7 +171,7 @@ public class TunnelServiceProperties
     /// </remarks>
     public static TunnelServiceProperties Local { get; } = new TunnelServiceProperties(
         $"https://{LocalDnsName}/",
-        DevFirstPartyAppId,
+        DevServiceAppId,
         DevThirdPartyAppId,
         LocalGitHubAppClientId);
 

--- a/go/tunnels/manager.go
+++ b/go/tunnels/manager.go
@@ -33,7 +33,7 @@ var PpeServiceProperties = TunnelServiceProperties{
 
 var DevServiceProperties = TunnelServiceProperties{
 	ServiceURI:           fmt.Sprintf("https://%s/", devDnsName),
-	ServiceAppID:         devFirstPartyAppID,
+	ServiceAppID:         devServiceAppID,
 	ServiceInternalAppID: devThirdPartyAppID,
 	GitHubAppClientID:    devGitHubAppClientID,
 }
@@ -42,7 +42,7 @@ var DevServiceProperties = TunnelServiceProperties{
 // but a different GitHub app with localhost callback URLs.
 var LocalServiceProperties = TunnelServiceProperties{
 	ServiceURI:           fmt.Sprintf("https://%s/", localDnsName),
-	ServiceAppID:         devFirstPartyAppID,
+	ServiceAppID:         devServiceAppID,
 	ServiceInternalAppID: devThirdPartyAppID,
 	GitHubAppClientID:    localGitHubAppClientID,
 }

--- a/go/tunnels/tunnel_service_properties.go
+++ b/go/tunnels/tunnel_service_properties.go
@@ -53,12 +53,12 @@ var prodFirstPartyAppID = "46da2f7e-b5ef-422a-88d4-2a7f9de6a0b2"
 // in the PPE service environments.
 var ppeFirstPartyAppID = "54c45752-bacd-424a-b928-652f3eca2b18"
 
-// Third-party app ID: `DEV-VSTunnelService-3P`
+// Third-party app ID for the DEV service environment.
 //
-// Used for authenticating AAD/MSA users, and service principals outside the AME tenant,
-// in the DEV service environment. This is a 3P app registration in the Microsoft corp
-// tenant, replacing the former 1P FPA.
-var devFirstPartyAppID = "906ce216-6f2e-40be-875d-7fe1a9bc288a"
+// A 3PA registered in the test tenant, used for authenticating AAD/MSA users and service
+// principals outside the AME tenant. Replaces the former 1P FPA (9c63851a) which was
+// disabled.
+var devServiceAppID = "686ab1c6-3cd9-4a62-b228-4f71eaaaf53e"
 
 // Third-party app ID: `tunnels-prod-app-sp`
 //

--- a/go/tunnels/tunnels.go
+++ b/go/tunnels/tunnels.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rodaine/table"
 )
 
-const PackageVersion = "0.1.24"
+const PackageVersion = "0.1.25"
 
 func (tunnel *Tunnel) requestObject() (*Tunnel, error) {
 	convertedTunnel := &Tunnel{

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelServiceProperties.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelServiceProperties.java
@@ -54,13 +54,13 @@ public class TunnelServiceProperties {
     static final String ppeFirstPartyAppId = "54c45752-bacd-424a-b928-652f3eca2b18";
 
     /**
-     * Third-party app ID: `DEV-VSTunnelService-3P`
+     * Third-party app ID for the DEV service environment.
      *
-     * Used for authenticating AAD/MSA users, and service principals outside the AME
-     * tenant, in the DEV service environment. This is a 3P app registration in the
-     * Microsoft corp tenant, replacing the former 1P FPA.
+     * A 3PA registered in the test tenant, used for authenticating AAD/MSA users and
+     * service principals outside the AME tenant. Replaces the former 1P FPA (9c63851a)
+     * which was disabled.
      */
-    static final String devFirstPartyAppId = "906ce216-6f2e-40be-875d-7fe1a9bc288a";
+    static final String devServiceAppId = "686ab1c6-3cd9-4a62-b228-4f71eaaaf53e";
 
     /**
      * Third-party app ID: `tunnels-prod-app-sp`

--- a/java/src/main/java/com/microsoft/tunnels/contracts/TunnelServicePropertiesStatics.java
+++ b/java/src/main/java/com/microsoft/tunnels/contracts/TunnelServicePropertiesStatics.java
@@ -31,7 +31,7 @@ class TunnelServicePropertiesStatics {
    */
   static final TunnelServiceProperties development = new TunnelServiceProperties(
       "https://" + TunnelServiceProperties.devDnsName + "/",
-      TunnelServiceProperties.devFirstPartyAppId,
+      TunnelServiceProperties.devServiceAppId,
       TunnelServiceProperties.devThirdPartyAppId,
       TunnelServiceProperties.devGitHubAppClientId);
 
@@ -43,7 +43,7 @@ class TunnelServicePropertiesStatics {
    */
   static final TunnelServiceProperties local = new TunnelServiceProperties(
       "https://" + TunnelServiceProperties.localDnsName + "/",
-      TunnelServiceProperties.devFirstPartyAppId,
+      TunnelServiceProperties.devServiceAppId,
       TunnelServiceProperties.devThirdPartyAppId,
       TunnelServiceProperties.localGitHubAppClientId);
 

--- a/rs/src/contracts/tunnel_environments.rs
+++ b/rs/src/contracts/tunnel_environments.rs
@@ -33,7 +33,7 @@ pub fn env_development() -> TunnelServiceProperties {
 pub fn env_local() -> TunnelServiceProperties {
     TunnelServiceProperties {
         service_uri: format!("https://{}", LOCAL_DNS_NAME),
-        service_app_id: DEV_FIRST_PARTY_APP_ID.to_owned(),
+        service_app_id: DEV_SERVICE_APP_ID.to_owned(),
         service_internal_app_id: DEV_THIRD_PARTY_APP_ID.to_owned(),
         github_app_client_id: LOCAL_GITHUB_APP_CLIENT_ID.to_owned(),
     }

--- a/rs/src/contracts/tunnel_environments.rs
+++ b/rs/src/contracts/tunnel_environments.rs
@@ -24,7 +24,7 @@ pub fn env_staging() -> TunnelServiceProperties {
 pub fn env_development() -> TunnelServiceProperties {
     TunnelServiceProperties {
         service_uri: format!("https://{}", DEV_DNS_NAME),
-        service_app_id: DEV_FIRST_PARTY_APP_ID.to_owned(),
+        service_app_id: DEV_SERVICE_APP_ID.to_owned(),
         service_internal_app_id: DEV_THIRD_PARTY_APP_ID.to_owned(),
         github_app_client_id: DEV_GITHUB_APP_CLIENT_ID.to_owned(),
     }

--- a/rs/src/contracts/tunnel_service_properties.rs
+++ b/rs/src/contracts/tunnel_service_properties.rs
@@ -55,12 +55,12 @@ pub const PROD_FIRST_PARTY_APP_ID: &str = "46da2f7e-b5ef-422a-88d4-2a7f9de6a0b2"
 // in the PPE service environments.
 pub const PPE_FIRST_PARTY_APP_ID: &str = "54c45752-bacd-424a-b928-652f3eca2b18";
 
-// Third-party app ID: `DEV-VSTunnelService-3P`
+// Third-party app ID for the DEV service environment.
 //
-// Used for authenticating AAD/MSA users, and service principals outside the AME tenant,
-// in the DEV service environment. This is a 3P app registration in the Microsoft corp
-// tenant, replacing the former 1P FPA.
-pub const DEV_FIRST_PARTY_APP_ID: &str = "906ce216-6f2e-40be-875d-7fe1a9bc288a";
+// A 3PA registered in the test tenant, used for authenticating AAD/MSA users and service
+// principals outside the AME tenant. Replaces the former 1P FPA (9c63851a) which was
+// disabled.
+pub const DEV_SERVICE_APP_ID: &str = "686ab1c6-3cd9-4a62-b228-4f71eaaaf53e";
 
 // Third-party app ID: `tunnels-prod-app-sp`
 //

--- a/ts/src/connections/package.json
+++ b/ts/src/connections/package.json
@@ -18,7 +18,7 @@
 		"buffer": "^5.2.1",
 		"debug": "^4.1.1",
 		"vscode-jsonrpc": "^4.0.0",
-		"@microsoft/dev-tunnels-contracts": "^1.3.38",
+		"@microsoft/dev-tunnels-contracts": ">1.3.43",
 		"@microsoft/dev-tunnels-management": "^1.3.38",
 		"uuid": "^3.3.3",
 		"await-semaphore": "^0.1.3",

--- a/ts/src/contracts/tunnelServiceProperties.ts
+++ b/ts/src/contracts/tunnelServiceProperties.ts
@@ -75,13 +75,13 @@ export const prodFirstPartyAppId = '46da2f7e-b5ef-422a-88d4-2a7f9de6a0b2';
 export const ppeFirstPartyAppId = '54c45752-bacd-424a-b928-652f3eca2b18';
 
 /**
- * Third-party app ID: `DEV-VSTunnelService-3P`
+ * Third-party app ID for the DEV service environment.
  *
- * Used for authenticating AAD/MSA users, and service principals outside the AME tenant,
- * in the DEV service environment. This is a 3P app registration in the Microsoft corp
- * tenant, replacing the former 1P FPA.
+ * A 3PA registered in the test tenant, used for authenticating AAD/MSA users and service
+ * principals outside the AME tenant. Replaces the former 1P FPA (9c63851a) which was
+ * disabled.
  */
-export const devFirstPartyAppId = '906ce216-6f2e-40be-875d-7fe1a9bc288a';
+export const devServiceAppId = '686ab1c6-3cd9-4a62-b228-4f71eaaaf53e';
 
 /**
  * Third-party app ID: `tunnels-prod-app-sp`

--- a/ts/src/contracts/tunnelServicePropertiesStatics.ts
+++ b/ts/src/contracts/tunnelServicePropertiesStatics.ts
@@ -5,7 +5,7 @@ import {
     TunnelServiceProperties as ITunnelServiceProperties,
     prodFirstPartyAppId,
     ppeFirstPartyAppId,
-    devFirstPartyAppId,
+    devServiceAppId,
     prodThirdPartyAppId,
     ppeThirdPartyAppId,
     devThirdPartyAppId,
@@ -44,7 +44,7 @@ export const staging = <ITunnelServiceProperties>{
  */
 export const development = <ITunnelServiceProperties>{
     serviceUri: `https://${devDnsName}/`,
-    serviceAppId: devFirstPartyAppId,
+    serviceAppId: devServiceAppId,
     serviceInternalAppId: devThirdPartyAppId,
     gitHubAppClientId: devGitHubAppClientId,
 };
@@ -57,7 +57,7 @@ export const development = <ITunnelServiceProperties>{
  */
 export const local = <ITunnelServiceProperties>{
     serviceUri: `https://${localDnsName}/`,
-    serviceAppId: devFirstPartyAppId,
+    serviceAppId: devServiceAppId,
     serviceInternalAppId: devThirdPartyAppId,
     gitHubAppClientId: localGitHubAppClientId,
 };

--- a/ts/src/management/package.json
+++ b/ts/src/management/package.json
@@ -18,7 +18,7 @@
 		"buffer": "^5.2.1",
 		"debug": "^4.1.1",
 		"vscode-jsonrpc": "^4.0.0",
-		"@microsoft/dev-tunnels-contracts": "^1.3.38",
+		"@microsoft/dev-tunnels-contracts": ">1.3.43",
 		"axios": "^1.8.4"
 	}
 }


### PR DESCRIPTION
### Changes proposed: 
The Tunnels1st party app previously used for the DEV environment was disabled, as we're no longer allowed to have 1PA in the Microsoft tenant. The previously created 3PA in the Microsoft tenant is not allowed to become multitenant to allow the E2E tests to use it. Therefore, I've created a new 3PA in our test tenant, which can be multitenant, to allow the previously reenabled DEV usage, and the E2E tests to use it.

This PR pdates the DEV service 3rd-party app (3PA) application IDs to the new values across all five SDK languages (C#, Go, Java, Rust, TypeScript). Changes are limited to TunnelServiceProperties-related files — both manually maintained and auto-generated — and are purely value replacements to use the new 3PA in DEV.

### Other Tasks:

- [x] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [x] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
