### PR TITLE
Update dev-tunnels-ssh package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+*.lscache

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -8,8 +8,8 @@
 			"name": "@microsoft/dev-tunnels",
 			"license": "MIT",
 			"dependencies": {
-				"@microsoft/dev-tunnels-ssh": "^3.12.22",
-				"@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
+				"@microsoft/dev-tunnels-ssh": "^3.12.29",
+				"@microsoft/dev-tunnels-ssh-tcp": "^3.12.29",
 				"await-semaphore": "^0.1.3",
 				"axios": "^1.13.5",
 				"buffer": "^5.2.1",
@@ -257,9 +257,9 @@
 			}
 		},
 		"node_modules/@microsoft/dev-tunnels-ssh": {
-			"version": "3.12.22",
-			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.12.22.tgz",
-			"integrity": "sha512-BiYjRiBAbvo306zeZmRaLgY5f3JuN8x0F108ZcssVwL11CUP5zvYwjyOUysMOSH42qfQG/zCG+1b56muLGW+5A==",
+			"version": "3.12.29",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh/-/dev-tunnels-ssh-3.12.29.tgz",
+			"integrity": "sha512-k70Lolv2qkZgcuT2zIUkBDCUbf61/aJLc6fMv2ieJG+aVgdwIj6e2+ANgd0q8AqanqXGEO+/uwYmwWBdqaZnug==",
 			"license": "MIT",
 			"dependencies": {
 				"buffer": "^5.2.1",
@@ -269,9 +269,9 @@
 			}
 		},
 		"node_modules/@microsoft/dev-tunnels-ssh-tcp": {
-			"version": "3.12.22",
-			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.12.22.tgz",
-			"integrity": "sha512-oZs7CLRv5V6Lo0+oFGsW2EwKFAzAdQ+sa+06yc9O4CyV0HAywP/E6o52vhjVJD4RpsZzCTsUf0ApoYYr05hDpw==",
+			"version": "3.12.29",
+			"resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-ssh-tcp/-/dev-tunnels-ssh-tcp-3.12.29.tgz",
+			"integrity": "sha512-v0B6/K1ymZ7IgcPViQouaRZUOZxHfLZnYcxU/f25oHSGpp0BkPam4nHkSSZdcy2jGWXZbVrx2nnfw68Xi42pTA==",
 			"license": "MIT",
 			"dependencies": {
 				"@microsoft/dev-tunnels-ssh": "~3.12"

--- a/ts/package.json
+++ b/ts/package.json
@@ -21,8 +21,8 @@
 		"build-pack-publish": "npm run build && npm run pack && npm run publish"
 	},
 	"dependencies": {
-		"@microsoft/dev-tunnels-ssh": "^3.12.22",
-		"@microsoft/dev-tunnels-ssh-tcp": "^3.12.22",
+		"@microsoft/dev-tunnels-ssh": "^3.12.29",
+		"@microsoft/dev-tunnels-ssh-tcp": "^3.12.29",
 		"await-semaphore": "^0.1.3",
 		"axios": "^1.13.5",
 		"buffer": "^5.2.1",

--- a/ts/src/connections/package.json
+++ b/ts/src/connections/package.json
@@ -18,15 +18,15 @@
 		"buffer": "^5.2.1",
 		"debug": "^4.1.1",
 		"vscode-jsonrpc": "^4.0.0",
-		"@microsoft/dev-tunnels-contracts": ">1.3.43",
-		"@microsoft/dev-tunnels-management": "^1.3.38",
+		"@microsoft/dev-tunnels-contracts": ">1.3.50",
+		"@microsoft/dev-tunnels-management": ">1.3.50",
 		"uuid": "^3.3.3",
 		"await-semaphore": "^0.1.3",
 		"websocket": "^1.0.28",
 		"es5-ext": "0.10.64"
 	},
 	"peerDependencies": {
-		"@microsoft/dev-tunnels-ssh": "^3.12.22",
-		"@microsoft/dev-tunnels-ssh-tcp": "^3.12.22"
+		"@microsoft/dev-tunnels-ssh": "^3.12.29",
+		"@microsoft/dev-tunnels-ssh-tcp": "^3.12.29"
 	}
 }

--- a/ts/src/management/package.json
+++ b/ts/src/management/package.json
@@ -18,7 +18,7 @@
 		"buffer": "^5.2.1",
 		"debug": "^4.1.1",
 		"vscode-jsonrpc": "^4.0.0",
-		"@microsoft/dev-tunnels-contracts": ">1.3.43",
+		"@microsoft/dev-tunnels-contracts": ">1.3.50",
 		"axios": "^1.8.4"
 	}
 }


### PR DESCRIPTION
Updates the dev-tunnel-ssh package with a stability fix.

### Other Tasks:

- [ ] If you updated the Go SDK did you update the PackageVersion in tunnels.go
- [x] If you updated the TS SDK did you update the dependencies in package.json for connections and management to require a dependency that is > the current published version(Found using `npm view @microsoft/dev-tunnels-contracts`). This will fix issues where yarn will pull the old version of packages and will cause mismatched dependencies. See [example PR](https://github.com/microsoft/dev-tunnels/pull/358)
