### PR TITLE
Remove quarantined es5-ext dependency

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1507,6 +1507,23 @@
 				"type": "^1.0.1"
 			}
 		},
+		"node_modules/d/node_modules/es5-ext": {
+			"name": "@unes/es5-ext",
+			"version": "0.10.64-1",
+			"resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+			"integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/dash-ast": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-2.0.1.tgz",
@@ -1797,23 +1814,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/es5-ext": {
-			"version": "0.10.64",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "ISC",
-			"dependencies": {
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.3",
-				"esniff": "^2.0.1",
-				"next-tick": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/es6-iterator": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
@@ -1823,6 +1823,23 @@
 				"d": "1",
 				"es5-ext": "^0.10.35",
 				"es6-symbol": "^3.1.1"
+			}
+		},
+		"node_modules/es6-iterator/node_modules/es5-ext": {
+			"name": "@unes/es5-ext",
+			"version": "0.10.64-1",
+			"resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+			"integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/es6-map": {
@@ -1837,6 +1854,23 @@
 				"es6-set": "~0.1.5",
 				"es6-symbol": "~3.1.1",
 				"event-emitter": "~0.3.5"
+			}
+		},
+		"node_modules/es6-map/node_modules/es5-ext": {
+			"name": "@unes/es5-ext",
+			"version": "0.10.64-1",
+			"resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+			"integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/es6-set": {
@@ -1854,6 +1888,23 @@
 			},
 			"engines": {
 				"node": ">=0.12"
+			}
+		},
+		"node_modules/es6-set/node_modules/es5-ext": {
+			"name": "@unes/es5-ext",
+			"version": "0.10.64-1",
+			"resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+			"integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/es6-set/node_modules/type": {
@@ -2283,6 +2334,23 @@
 				"node": ">=0.10"
 			}
 		},
+		"node_modules/esniff/node_modules/es5-ext": {
+			"name": "@unes/es5-ext",
+			"version": "0.10.64-1",
+			"resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+			"integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/esniff/node_modules/type": {
 			"version": "2.7.3",
 			"resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
@@ -2395,6 +2463,23 @@
 			"dependencies": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
+			}
+		},
+		"node_modules/event-emitter/node_modules/es5-ext": {
+			"name": "@unes/es5-ext",
+			"version": "0.10.64-1",
+			"resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+			"integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/events": {
@@ -5262,6 +5347,23 @@
 			"dev": true,
 			"dependencies": {
 				"ms": "2.0.0"
+			}
+		},
+		"node_modules/websocket/node_modules/es5-ext": {
+			"name": "@unes/es5-ext",
+			"version": "0.10.64-1",
+			"resolved": "https://registry.npmjs.org/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz",
+			"integrity": "sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/websocket/node_modules/ms": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -109,5 +109,8 @@
 		"trailingComma": "all",
 		"arrowParens": "always",
 		"parser": "typescript"
+	},
+	"overrides": {
+		"es5-ext": "npm:@unes/es5-ext@0.10.64-1"
 	}
 }

--- a/ts/src/connections/package.json
+++ b/ts/src/connections/package.json
@@ -22,8 +22,7 @@
 		"@microsoft/dev-tunnels-management": ">1.3.50",
 		"uuid": "^3.3.3",
 		"await-semaphore": "^0.1.3",
-		"websocket": "^1.0.28",
-		"es5-ext": "0.10.64"
+		"websocket": "^1.0.28"
 	},
 	"peerDependencies": {
 		"@microsoft/dev-tunnels-ssh": "^3.12.29",


### PR DESCRIPTION
## Summary

- Remove the direct `es5-ext@0.10.64` dependency from `ts/src/connections/package.json` — it is an ES5 polyfill unnecessary for modern Node.js targets (connor4312 noted this in #420).
- Add npm override to alias the remaining transitive `es5-ext` (from `websocket@^1.0.28`) to `@unes/es5-ext@0.10.64-1`, a community fork without the postinstall script.
- `es5-ext` is quarantined by Nexus Firewall (sonatype-2022-2248) due to undisclosed postinstall code execution, blocking hardened supply chain builds.

Ref: #420

## References

- [medikoo/es5-ext#186](https://github.com/medikoo/es5-ext/issues/186) — upstream protestware discussion
- [microsoft/vscode#310541](https://github.com/microsoft/vscode/issues/310541) — downstream impact on VS Code
- [theturtle32/WebSocket-Node#473](https://github.com/theturtle32/WebSocket-Node/pull/473) — upstream `websocket` package dropping es5-ext

Made with [Cursor](https://cursor.com)