### PR TITLE
Replace websocket with ws to eliminate es5-ext dependency

### DIFF
--- a/ts/src/connections/package.json
+++ b/ts/src/connections/package.json
@@ -22,8 +22,7 @@
 		"@microsoft/dev-tunnels-management": ">1.3.50",
 		"uuid": "^3.3.3",
 		"await-semaphore": "^0.1.3",
-		"websocket": "^1.0.28",
-		"es5-ext": "0.10.64"
+		"ws": "^8.18.0"
 	},
 	"peerDependencies": {
 		"@microsoft/dev-tunnels-ssh": "^3.12.29",


### PR DESCRIPTION
## Summary

The `websocket` package (`theturtle32/WebSocket-Node`) depends on `es5-ext`, which is quarantined by Nexus Firewall (sonatype-2022-2248). The `websocket` package has an [open PR to drop es5-ext](https://github.com/theturtle32/WebSocket-Node/pull/473) but it has been unreviewed for 9 months.

This PR proposes replacing `websocket@^1.0.28` with [`ws@^8.18.0`](https://www.npmjs.com/package/ws), the modern, actively maintained WebSocket implementation for Node.js (86M weekly downloads, zero `es5-ext` dependency).

**Note:** This is a draft to start the conversation. The `ws` package has a different API surface from `websocket`, so source code changes in the connections module would be needed. The immediate fix is in the companion PR that removes the direct `es5-ext` dep and adds an npm override.

Ref: #420

## References

- [theturtle32/WebSocket-Node#473](https://github.com/theturtle32/WebSocket-Node/pull/473) — upstream es5-ext removal PR (unreviewed since Aug 2025)
- [`ws` on npm](https://www.npmjs.com/package/ws) — 86M weekly downloads, MIT license

Made with [Cursor](https://cursor.com)