### PR TITLE
Bump SSH package to 3.12.40 (channel cancellation deadlock fix)

### DIFF
--- a/cs/build/build.props
+++ b/cs/build/build.props
@@ -41,7 +41,7 @@
     <NerdbankStreamsVersion>2.13.16</NerdbankStreamsVersion>
     <ReportGeneratorVersion>5.5.4</ReportGeneratorVersion>
     <VisualStudioValidationVersion>17.13.22</VisualStudioValidationVersion>
-    <DevTunnelsSshPackageVersion>3.12.36</DevTunnelsSshPackageVersion>
+    <DevTunnelsSshPackageVersion>3.12.40</DevTunnelsSshPackageVersion>
     <XunitRunnerVisualStudioVersion>3.1.5</XunitRunnerVisualStudioVersion>
     <XunitV3Version>3.2.2</XunitV3Version>
     <XunitV3ExtensibilityCoreVersion>3.2.2</XunitV3ExtensibilityCoreVersion>


### PR DESCRIPTION
Updates Microsoft.DevTunnels.Ssh from 3.12.36 to 3.12.40, which includes a fix for a deadlock in ConnectionService where disposing a CancellationTokenRegistration inside a lock could block indefinitely when the cancellation callback needed the same lock.